### PR TITLE
add validate command

### DIFF
--- a/packages/cli/src/commands/validate/index.js
+++ b/packages/cli/src/commands/validate/index.js
@@ -1,0 +1,37 @@
+import getWorkspaces from "get-workspaces";
+import semver from "semver";
+import chalk from "chalk";
+
+import { getDependencyVersionRange } from "../../utils/bolt-replacements/getDependencyInfo";
+import logger from "../../utils/logger";
+import versionRangeToRangeType from "../../utils/bolt-replacements/versionRangeToRangeType";
+
+export default async function bumpReleasedPackages(config) {
+  let allPackages = await getWorkspaces(config);
+
+  let errors = [];
+
+  for (let pkg of allPackages) {
+    for (let pkg2 of allPackages) {
+      let depRange = getDependencyVersionRange(pkg2.name, pkg.config);
+      if (!depRange) continue;
+
+      let cannotSymlink = !semver.satisfies(pkg2.config.version, depRange);
+      if (cannotSymlink) {
+        errors.push(
+          chalk`- Update {green ${pkg.name}} to depend on {yellow "${
+            pkg2.name
+          }": "${versionRangeToRangeType(depRange)}${pkg2.config.version}"}`
+        );
+      }
+    }
+  }
+  if (errors.length) {
+    logger.error(
+      "Oh no! Not everything can ge linked! Here's what you should do:"
+    );
+    errors.forEach(a => logger.error(a));
+  } else {
+    logger.success("Everything should link together nicely!");
+  }
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -7,6 +7,7 @@ import add from "./commands/add";
 import bump from "./commands/bump";
 import release from "./commands/release";
 import status from "./commands/status";
+import validate from "./commands/validate";
 
 const { input, flags } = meow(
   `
@@ -70,6 +71,10 @@ const cwd = process.cwd();
     } = flags;
 
     switch (input[0]) {
+      case "validate": {
+        await validate({ cwd });
+        return;
+      }
       case "init": {
         await init({ cwd });
         return;

--- a/packages/get-workspaces/src/index.js
+++ b/packages/get-workspaces/src/index.js
@@ -1,19 +1,14 @@
-// This is a modified version of the package-getting in bolt
-// It supports yarn workspaces as well, and can fall back through
-// several options
-
 import fs from "fs-extra";
 import path from "path";
 import globby from "globby";
 
-export default async function getWorkspaces(opts) {
+async function getWorkspaces(opts = {}) {
   const cwd = opts.cwd || process.cwd();
   const tools = opts.tools || ["yarn", "bolt"]; // We also support root, but don't do it by default
 
   const pkg = await fs
     .readFile(path.join(cwd, "package.json"), "utf-8")
     .then(JSON.parse);
-
   let workspaces;
 
   if (tools.includes("yarn") && pkg.workspaces) {
@@ -28,8 +23,15 @@ export default async function getWorkspaces(opts) {
 
   if (!workspaces) {
     if (tools.includes("root")) {
-      return [{ config: pkg, dir: cwd, name: pkg.name }];
+      return [
+        {
+          config: pkg,
+          dir: cwd,
+          name: pkg.name
+        }
+      ];
     }
+
     return null;
   }
 
@@ -39,16 +41,21 @@ export default async function getWorkspaces(opts) {
     absolute: true,
     expandDirectories: false
   });
-
   const results = await Promise.all(
     folders
       .filter(dir => fs.existsSync(path.join(dir, "package.json")))
       .map(async dir =>
         fs.readFile(path.join(dir, "package.json")).then(contents => {
           const config = JSON.parse(contents);
-          return { config, name: config.name, dir };
+          return {
+            config,
+            name: config.name,
+            dir
+          };
         })
       )
   );
   return results;
 }
+
+export default getWorkspaces;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,8 +1271,8 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
 
 caniuse-lite@^1.0.30000963:
-  version "1.0.30000966"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz#f3c6fefacfbfbfb981df6dfa68f2aae7bff41b64"
+  version "1.0.30000967"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz#a5039577806fccee80a04aaafb2c0890b1ee2f73"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1722,8 +1722,8 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.127:
-  version "1.3.131"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz#205a0b7a276b3f56bc056f19178909243054252a"
+  version "1.3.133"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz#c47639c19b91feee3e22fad69f5556142007008c"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -2264,7 +2264,18 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.3, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -3638,8 +3649,8 @@ node-pre-gyp@^0.12.0:
     tar "^4"
 
 node-releases@^1.1.17:
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.17.tgz#71ea4631f0a97d5cd4f65f7d04ecf9072eac711a"
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.18.tgz#cc98fd75598a324a77188ebddf6650e9cbd8b1d5"
   dependencies:
     semver "^5.3.0"
 
@@ -4806,8 +4817,8 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 table@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.3.0.tgz#8a2c3354dc87312328c68732039b38b6a41c86c9"
   dependencies:
     ajv "^6.9.1"
     lodash "^4.17.11"
@@ -4994,8 +5005,8 @@ typewise@^1.0.3:
     typewise-core "^1.2.0"
 
 uglify-js@^3.1.4:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.10.tgz#652bef39f86d9dbfd6674407ee05a5e2d372cf2d"
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.11.tgz#833442c0aa29b3a7d34344c7c63adaa3f3504f6a"
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
<img width="565" alt="image" src="https://user-images.githubusercontent.com/15622106/57458856-73dcad80-72b5-11e9-9c26-554e7e92d86e.png">

So, uh, I wrote this thing, that validates projects for linking like bolt does, but for yarn workspaces, because I couldn't find an easy way to do this in yarn workspaces (the info command tells you mis-aligned things, but not how and how to fix)

The more I did this, the less this feels like changesets. @mitchellhamilton would preconstruct be interested in doing something like this? I feel like preconstruct fix would be nice here. But also, maybe it can't be in preconstruct because it cares about all workspaces?