### PR TITLE
Add import/no-extraneous-dependencies lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,12 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "argsIgnorePattern": "^_", "ignoreRestSiblings": true }
+    ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": ["**/__tests__/**/*.{ts,js}", "**/*.test.{ts,js}"]
+      }
     ]
   },
   "overrides": [


### PR DESCRIPTION
I've been experimenting with preconstruct TS declaration generation performance and I used the code in #55 to test stuff and I got errors from preconstruct because a bunch of deps weren't specified in the package.json of `bolt-check` so I thought it might be a good idea to add this rule.