### PR TITLE
Fix GitHub PR link in get-github-info

### DIFF
--- a/.changeset/orange-years-guess/changes.json
+++ b/.changeset/orange-years-guess/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@changesets/get-github-info", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/orange-years-guess/changes.md
+++ b/.changeset/orange-years-guess/changes.md
@@ -1,0 +1,1 @@
+Fix GitHub PR link

--- a/packages/get-github-info/src/index.js
+++ b/packages/get-github-info/src/index.js
@@ -100,7 +100,7 @@ export async function getInfo(request) {
       pull:
         data === null
           ? null
-          : `[#${data.number}](https://github.com/${request.repo}/pulls/${
+          : `[#${data.number}](https://github.com/${request.repo}/pull/${
               data.number
             })`,
       user:


### PR DESCRIPTION
I got the links wrong before, linking to a PR is done with `pull` whereas `pulls` links to the PR list.