### PR TITLE
Fix tables in status command from flowing over to the next line

### DIFF
--- a/.changeset/three-trainers-vanish/changes.json
+++ b/.changeset/three-trainers-vanish/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@changesets/cli", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/three-trainers-vanish/changes.md
+++ b/.changeset/three-trainers-vanish/changes.md
@@ -1,1 +1,3 @@
 Fix tables in status command from flowing over to the next line
+
+![changeset status --verbose output](https://user-images.githubusercontent.com/11481355/59011589-875d4300-8878-11e9-9e69-cada41f83261.png)

--- a/.changeset/three-trainers-vanish/changes.md
+++ b/.changeset/three-trainers-vanish/changes.md
@@ -1,0 +1,1 @@
+Fix tables in status command from flowing over to the next line

--- a/packages/cli/src/commands/status/index.js
+++ b/packages/cli/src/commands/status/index.js
@@ -71,7 +71,7 @@ function SimplePrint(type, releases) {
 function verbosePrint(type, releases) {
   const packages = releases.filter(r => r.type === type);
   if (packages.length) {
-    logger.info(chalk`Packages to be bumped at {green ${type}}:\n`);
+    logger.info(chalk`Packages to be bumped at {green ${type}}`);
 
     const columns = packages.map(({ name, version, changesets }) => [
       chalk.green(name),
@@ -81,14 +81,14 @@ function verbosePrint(type, releases) {
 
     const t1 = table(
       [
-        { value: "Package Name" },
+        { value: "Package Name", width: 20 },
         { value: "New Version", width: 20 },
-        { value: "Related Changeset Summaries" }
+        { value: "Related Changeset Summaries", width: 70 }
       ],
       columns,
       { paddingLeft: 1, paddingRight: 0, headerAlign: "center", align: "left" }
     );
-    logger.log(t1.render());
+    logger.log(t1.render() + "\n");
   } else {
     logger.info(
       chalk`Running release would release {red NO} packages as a {green ${type}}`


### PR DESCRIPTION
<img width="893" alt="changeset status --verbose output" src="https://user-images.githubusercontent.com/11481355/59011589-875d4300-8878-11e9-9e69-cada41f83261.png">
