### PR TITLE
Limit the number of rows the package selection question takes up

### DIFF
--- a/.changeset/shaggy-timers-grab/changes.json
+++ b/.changeset/shaggy-timers-grab/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@changesets/cli", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/shaggy-timers-grab/changes.md
+++ b/.changeset/shaggy-timers-grab/changes.md
@@ -1,0 +1,1 @@
+Limit the number of rows the package selection question takes up so that the question is still visible in repos with a very large number of packages

--- a/.changeset/shaggy-timers-grab/changes.md
+++ b/.changeset/shaggy-timers-grab/changes.md
@@ -1,1 +1,3 @@
 Limit the number of rows the package selection question takes up so that the question is still visible in repos with a very large number of packages
+
+![changeset package question in atlaskit](https://user-images.githubusercontent.com/11481355/59012109-ff783880-8879-11e9-9b68-77ab672921fa.png)

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "tty-table": "^2.7.0",
     "typescript": "^3.4.5",
     "uuid": "^3.3.2",
-    "strip-ansi": "^5.2.0"
+    "strip-ansi": "^5.2.0",
+    "term-size": "^2.1.0"
   },
   "preconstruct": {
     "packages": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "prettier": "^1.14.3",
     "projector-spawn": "^1.0.1",
     "semver": "^5.4.1",
+    "term-size": "^2.1.0",
     "tty-table": "^2.7.0",
     "uuid": "^3.3.2"
   },

--- a/packages/cli/src/utils/cli.ts
+++ b/packages/cli/src/utils/cli.ts
@@ -1,4 +1,6 @@
 import uuid from "uuid/v1";
+// @ts-ignore it's not worth writing a TS declaration file in this repo for a tiny module we use once like this
+import termSize from "term-size";
 import { prefix } from "./logger";
 // @ts-ignore
 import { prompt } from "enquirer";
@@ -8,6 +10,8 @@ import { prompt } from "enquirer";
  * At each call, the entire responses object is returned, so we need a unique
  * identifier for the name every time. This is why we are using UUIDs.
  */
+
+const limit = Math.max(termSize().rows - 5, 10);
 
 async function askCheckboxPlus(
   message: string,
@@ -24,7 +28,8 @@ async function askCheckboxPlus(
     prefix,
     multiple: true,
     choices,
-    format
+    format,
+    limit
   }).then((responses: any) => responses[name]);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5160,6 +5160,11 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+term-size@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.0.tgz#3aec444c07a7cf936e157c1dc224b590c3c7eef2"
+  integrity sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==
+
 terser@^3.14.1:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"


### PR DESCRIPTION


<img width="1392" alt="changeset package question in atlaskit" src="https://user-images.githubusercontent.com/11481355/59012109-ff783880-8879-11e9-9b68-77ab672921fa.png">
I've also checked the small number of packages case and it only uses the rows necessary.