### PR TITLE
Only bump peer dependents when the peer dependency is out of range

### DIFF
--- a/.changeset/green-flies-ring.md
+++ b/.changeset/green-flies-ring.md
@@ -1,0 +1,8 @@
+---
+"@changesets/cli": major
+"@changesets/assemble-release-plan": minor
+---
+
+Only bump dependents which depend on the given dependency as a peerDependency
+
+If you want to restore the old behaviour, you should change your peerDependencies from using a caret(`^`) to a tilde(`~`)

--- a/.changeset/green-flies-ring.md
+++ b/.changeset/green-flies-ring.md
@@ -3,6 +3,6 @@
 "@changesets/assemble-release-plan": minor
 ---
 
-Only bump dependents which depend on the given dependency as a peerDependency
+Only bump peer dependents when the peer dependency is out of range.
 
 If you want to restore the old behaviour, you should change your peerDependencies from using a caret(`^`) to a tilde(`~`)

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -65,6 +65,10 @@ export default function getDependents(
         if (
           depTypes.includes("peerDependencies") &&
           nextRelease.type !== "patch" &&
+          !semver.satisfies(
+            semver.inc(nextRelease.oldVersion, nextRelease.type)!,
+            versionRange
+          ) &&
           (!releases.some(dep => dep.name === dependent) ||
             releases.some(
               dep => dep.name === dependent && dep.type !== "major"
@@ -83,6 +87,7 @@ export default function getDependents(
             type = "patch";
           }
         }
+
         return { name: dependent, type, pkgJSON: dependentPkgJSON };
       })
       .filter(({ type }) => type)

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -430,8 +430,8 @@ describe("bumping peerDeps", () => {
     expect(releases[0].name).toEqual("pkg-a");
     expect(releases[0].newVersion).toEqual("1.0.1");
   });
-  it("should major bump dependent when bumping caret peerDep by minor", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+  it("should major bump dependent when leaving range", () => {
+    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "minor" }]
@@ -471,7 +471,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("2.0.0");
   });
   it("should patch bump transitive dep that is only affected by peerDep bump", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
     setup.addWorkspace("pkg-c", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
     setup.addChangeset({


### PR DESCRIPTION
Part of the motivation behind this is I want to be able to minor version Emotion. I think doing this is a good thing because people can get back nearly the exact same behavior by changing from a caret to a tilde but people also have more control over when peer dependents are bumped.

This probably isn't something we should do soon since we should probably batch other breaking changes.