### PR TITLE
fix access to not use wrong names

### DIFF
--- a/.changeset/proud-rings-appear.md
+++ b/.changeset/proud-rings-appear.md
@@ -1,0 +1,17 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/cli": patch
+"@changesets/config": patch
+"get-workspaces": patch
+"@changesets/types": patch
+---
+
+Correctly handle the 'access' flag for packages
+
+This is a patch, but it's a pretty big one, and I'm pretty 😳 about it. Previously, we had access as "public" or "private", access "private" isn't valid. This was a confusino because there are three states for publishing a package:
+
+- `private: true` - the package will not be published to npm (worked)
+- `access: public` - the package will be publicly published to npm (even if it uses a scope) (worked)
+- `access: restricted` - the package will be published to npm, but only visible/accessible by those who are part of the scope. This technically worked, but we were passing the wrong bit of information in.
+
+Now, we pass the correct access options `public` or `restricted`.

--- a/.changeset/slow-queens-remember.md
+++ b/.changeset/slow-queens-remember.md
@@ -1,0 +1,9 @@
+---
+"@changesets/cli": minor
+---
+
+Respect `access: public` in workspace package.jsons`
+
+Previously, every package in your repository had one 'public' or 'restricted' setting.
+
+Now, if a workspace lists `access` in its package.json, we will defer to the workspace configuration over the global changesets config.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -40,7 +40,7 @@ class FakeReleasePlan {
       changelog: false,
       commit: false,
       linked: [],
-      access: "private"
+      access: "restricted"
     };
 
     this.changesets = [this.baseChangeset, ...changesets];
@@ -66,7 +66,7 @@ async function testSetup(
       changelog: false,
       commit: false,
       linked: [],
-      access: "private"
+      access: "restricted"
     };
 
   let tempDir = await copyFixtureIntoTempDir(__dirname, fixtureName);

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -12,7 +12,7 @@ export default async function publishPackages({
   otp
 }: {
   cwd: string;
-  access: "public" | "private";
+  access: "public" | "restricted";
   otp?: string;
 }) {
   const packages = await getWorkspaces({ cwd });
@@ -46,10 +46,10 @@ export default async function publishPackages({
 
 async function publishAPackage(
   pkg: Workspace,
-  access: "public" | "private",
+  access: "public" | "restricted",
   twoFactorState: TwoFactorState
 ) {
-  const { name, version } = pkg.config;
+  const { name, version, access: localAccess } = pkg.config;
   info(
     `Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`
   );
@@ -60,7 +60,7 @@ async function publishAPackage(
     name,
     {
       cwd: publishDir,
-      access
+      access: localAccess || access
     },
     twoFactorState
   );

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,7 +1,7 @@
 export type CliOptions = {
   commit?: boolean;
   changelog?: string;
-  access?: "public" | "private";
+  access?: "public" | "restricted";
   sinceMaster?: boolean;
   verbose?: boolean;
   output?: string;

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -44,10 +44,10 @@
       "default": false
     },
     "access": {
-      "enum": ["private", "public"],
+      "enum": ["restricted", "public"],
       "type": "string",
-      "description": "Determines whether changesets should publish packages to the registry publicly or privately",
-      "default": "private"
+      "description": "Determines whether changesets should publish packages to the registry publicly or to a restricted scope",
+      "default": "restricted"
     }
   }
 }

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -11,7 +11,7 @@ test("read reads the config", async () => {
     linked: [],
     changelog: false,
     commit: true,
-    access: "private"
+    access: "restricted"
   });
 });
 
@@ -19,7 +19,7 @@ let defaults = {
   linked: [],
   changelog: ["@changesets/cli/changelog", null],
   commit: false,
-  access: "private"
+  access: "restricted"
 } as const;
 
 let correctCases = {
@@ -72,13 +72,13 @@ let correctCases = {
       commit: true
     }
   },
-  "access private": {
+  "access restricted": {
     input: {
-      access: "private"
+      access: "restricted"
     },
     output: {
       ...defaults,
-      access: "private"
+      access: "restricted"
     }
   },
   "access public": {
@@ -153,7 +153,7 @@ The \`changelog\` option is set as [
       unsafeParse({ access: "something" });
     }).toThrowErrorMatchingInlineSnapshot(`
 "Some errors occurred when validating the changesets config:
-The \`access\` option is set as \\"something\\" when the only valid values are undefined, \\"public\\" or \\"private\\""
+The \`access\` option is set as \\"something\\" when the only valid values are undefined, \\"public\\" or \\"restricted\\""
 `);
   });
   test("commit non-boolean", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,7 +11,7 @@ export let defaultWrittenConfig = {
   changelog: "@changesets/cli/changelog",
   commit: false,
   linked: [] as ReadonlyArray<ReadonlyArray<string>>,
-  access: "private"
+  access: "restricted"
 } as const;
 
 function getNormalisedChangelogOption(
@@ -57,7 +57,7 @@ export let parse = (
 
   if (
     json.access !== undefined &&
-    json.access !== "private" &&
+    json.access !== "restricted" &&
     json.access !== "public"
   ) {
     messages.push(
@@ -65,7 +65,7 @@ export let parse = (
         json.access,
         null,
         2
-      )} when the only valid values are undefined, "public" or "private"`
+      )} when the only valid values are undefined, "public" or "restricted"`
     );
   }
 

--- a/packages/get-workspaces/src/index.ts
+++ b/packages/get-workspaces/src/index.ts
@@ -19,6 +19,7 @@ export type PackageJSON = {
   devDependencies?: { [key: string]: string };
   optionalDependencies?: { [key: string]: string };
   private?: boolean;
+  access?: "restricted" | "public";
 };
 
 export type Workspace = { config: PackageJSON; name: string; dir: string };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -41,6 +41,7 @@ export type PackageJSON = {
   peerDependencies?: { [key: string]: string };
   devDependencies?: { [key: string]: string };
   optionalDependencies?: { [key: string]: string };
+  access?: "restricted" | "public";
 };
 
 export type Linked = ReadonlyArray<ReadonlyArray<string>>;
@@ -49,14 +50,14 @@ export type Config = {
   changelog: false | readonly [string, any];
   commit: boolean;
   linked: Linked;
-  access: "public" | "private";
+  access: "public" | "restricted";
 };
 
 export type WrittenConfig = {
   changelog?: false | readonly [string, any] | string;
   commit?: boolean;
   linked?: Linked;
-  access?: "public" | "private";
+  access?: "public" | "restricted";
 };
 
 export type Workspace = { config: PackageJSON; name: string; dir: string };


### PR DESCRIPTION
Coupla things on this PR:

- this might be a breaking change to `config` and `types` - I just don't wanna. My argument on it not being is that the previous state was genuinely in error (a patch). I think this is pragmatically fine.
- Nothing actually failed to work as intended previously. If you passed `--access="private"` to npm, it ignored the flag and did the default option, which was restricted. :badpokerface:
- I added an option to make individual packages have their own `access` field. Note that npm's regular publish does not respect this field. I was unsure whether to a) just not implement this feature and only allow the global access (@Andarist I believe you had a use-case for this though), b) nest this so it's `changesets: { access: "restricted" }`.