### PR TITLE
When in pre mode publish packages with "never" and "pre-only" published states under both latest and configured tags

### DIFF
--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -172,3 +172,14 @@ export function publish(
     return internalPublish(pkgName, opts, twoFactorState);
   });
 }
+
+export function distTag(
+  pkgName: string,
+  opts: { cwd: string; version: string; tag: string },
+  twoFactorState: TwoFactorState
+): Promise<{ published: boolean }> {
+  return npmRequestLimit(() => {
+    /* TODO: actually implement this */
+    return { published: true };
+  });
+}


### PR DESCRIPTION
It's just a draft so far, but I'm opening it to get initial validation from changesets maintainers.

This is supposed to fix 2 problems:
- packages with `never` published state being published also with non-latest tag. Without this the package was first published with a tag but when doing subsequent releases it was released with the latest tag (because it has transitioned to `only-pre` published state) - this was caused by not including `"never"` [here](https://github.com/atlassian/changesets/blob/2d6698332cf019a2c47ffebd653d2659d40b8c23/packages/cli/src/commands/publish/publishPackages.ts#L81-L82)
- `only-pre` packages being published only with the latest tag - this is confusing when introducing a new package in a set of closely related packages such as in case of Emotion, where people expect to install multiple packages at once and specify the same tag (`next` in this case) for all of them