### PR TITLE
Fix internal update deps

### DIFF
--- a/.changeset/old-lions-end.md
+++ b/.changeset/old-lions-end.md
@@ -1,0 +1,7 @@
+---
+"@changesets/assemble-release-plan": minor
+"@changesets/types": minor
+---
+
+Add optional `dependenciesLeavingRange` field to release object that contains a list dependencies of the released package have been updated to maintain semver compatibility.
+This is useful for identifying dependencies that _must_ be updated regardless of what internal dependency range bumping strategy used when applying the release plan.

--- a/.changeset/perfect-meals-matter.md
+++ b/.changeset/perfect-meals-matter.md
@@ -1,0 +1,6 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/cli": patch
+---
+
+Fix dependencies that were patch bumped not being updated in dependents package.json if they would leave semver range with `updateInternalDependencies` set to minor

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -2,7 +2,7 @@ import { ChangelogFunctions, NewChangesetWithCommit } from "@changesets/types";
 
 import { ModCompWithPackage } from "@changesets/types";
 import startCase from "lodash.startcase";
-import { shouldUpdateInternalDependencies } from "./utils";
+import { shouldUpdateInternalDependency } from "./utils";
 
 type ChangelogLines = {
   major: Array<Promise<string>>;
@@ -60,7 +60,11 @@ export default async function generateMarkdown(
       release.packageJson.peerDependencies[rel.name];
     return (
       (isDependency || isPeerDependency) &&
-      shouldUpdateInternalDependencies(updateInternalDependencies, rel.type)
+      shouldUpdateInternalDependency(
+        updateInternalDependencies,
+        rel,
+        release.dependenciesLeavingRange
+      )
     );
   });
 

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -14,10 +14,15 @@ function getBumpLevel(type: VersionType) {
   return level;
 }
 
-export function shouldUpdateInternalDependencies(
+export function shouldUpdateInternalDependency(
   minReleaseType: "patch" | "minor",
-  releaseType: VersionType
+  dependency: { name: string; type: VersionType },
+  dependenciesLeavingRange: string[] = []
 ) {
+  if (dependenciesLeavingRange.includes(dependency.name)) {
+    // Dependencies leaving semver range should always be updated regardless of bump type
+    return true;
+  }
   const minLevel = getBumpLevel(minReleaseType);
-  return getBumpLevel(releaseType) >= minLevel;
+  return getBumpLevel(dependency.type) >= minLevel;
 }

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -5,7 +5,7 @@ import {
 } from "@changesets/types";
 import getVersionRangeType from "@changesets/get-version-range-type";
 import { Range } from "semver";
-import { shouldUpdateInternalDependencies } from "./utils";
+import { shouldUpdateInternalDependency } from "./utils";
 
 const DEPENDENCY_TYPES = [
   "dependencies",
@@ -36,7 +36,11 @@ export default function versionPackage(
           !depCurrentVersion ||
           depCurrentVersion.startsWith("file:") ||
           depCurrentVersion.startsWith("link:") ||
-          !shouldUpdateInternalDependencies(updateInternalDependencies, type)
+          !shouldUpdateInternalDependency(
+            updateInternalDependencies,
+            { name, type },
+            release.dependenciesLeavingRange
+          )
         )
           continue;
         const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -160,7 +160,7 @@ function assembleReleasePlan(
       preInfo
     );
 
-    // The map passed in to determineDependents will be mutated
+    // The map passed in to applyLinks will be mutated
     let linksUpdated = applyLinks(releases, packagesByName, config.linked);
 
     releaseObjectValidated = !linksUpdated && !dependentAdded;

--- a/packages/assemble-release-plan/src/test-utils.ts
+++ b/packages/assemble-release-plan/src/test-utils.ts
@@ -79,29 +79,29 @@ class FakeFullState {
     this.changesets.push(changeset);
   }
 
-  updateDependency(pkgA: string, pkgB: string, version: string) {
-    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
+  updateDependency(pkgName: string, dependency: string, version: string) {
+    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgName);
     if (!pkg) throw new Error("no pkg");
     if (!pkg.packageJson.dependencies) {
       pkg.packageJson.dependencies = {};
     }
-    pkg.packageJson.dependencies[pkgB] = version;
+    pkg.packageJson.dependencies[dependency] = version;
   }
-  updateDevDependency(pkgA: string, pkgB: string, version: string) {
-    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
+  updateDevDependency(pkgName: string, dependency: string, version: string) {
+    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgName);
     if (!pkg) throw new Error("no pkg");
     if (!pkg.packageJson.devDependencies) {
       pkg.packageJson.devDependencies = {};
     }
-    pkg.packageJson.devDependencies[pkgB] = version;
+    pkg.packageJson.devDependencies[dependency] = version;
   }
-  updatePeerDep(pkgA: string, pkgB: string, version: string) {
-    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
+  updatePeerDep(pkgName: string, dependency: string, version: string) {
+    let pkg = this.packages.packages.find(a => a.packageJson.name === pkgName);
     if (!pkg) throw new Error("no pkg");
     if (!pkg.packageJson.peerDependencies) {
       pkg.packageJson.peerDependencies = {};
     }
-    pkg.packageJson.peerDependencies[pkgB] = version;
+    pkg.packageJson.peerDependencies[dependency] = version;
   }
 
   addPackage(name: string, version: string) {

--- a/packages/assemble-release-plan/src/types.ts
+++ b/packages/assemble-release-plan/src/types.ts
@@ -5,6 +5,7 @@ export type InternalRelease = {
   type: VersionType;
   oldVersion: string;
   changesets: string[];
+  dependenciesLeavingRange?: string[];
 };
 
 export type PreInfo = {

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -1,5 +1,4 @@
 import { ChangelogFunctions } from "@changesets/types";
-// @ts-ignore
 import { config } from "dotenv";
 import { getInfo } from "@changesets/get-github-info";
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@changesets/parse": "*",
     "@changesets/test-utils": "*",
+    "@types/is-ci": "^2.0.0",
     "fixturez": "^1.1.0",
     "strip-ansi": "^5.2.0"
   }

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -27,7 +27,8 @@ const simpleReleasePlan: ReleasePlan = {
       type: "minor",
       changesets: ["ascii"],
       oldVersion: "1.0.0",
-      newVersion: "1.1.0"
+      newVersion: "1.1.0",
+      dependenciesLeavingRange: ["pkg-b"]
     },
     {
       name: "pkg-b",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -103,7 +103,6 @@ const cwd = process.cwd();
 
   if (input.length < 1) {
     const { empty }: CliOptions = flags;
-    // @ts-ignore if this is undefined, we have already exited
     await add(cwd, { empty }, config);
   } else if (input[0] !== "pre" && input.length > 1) {
     error(
@@ -138,7 +137,6 @@ const cwd = process.cwd();
 
     switch (input[0]) {
       case "add": {
-        // @ts-ignore if this is undefined, we have already exited
         await add(cwd, { empty }, config);
         return;
       }
@@ -165,7 +163,6 @@ const cwd = process.cwd();
           error("A tag must be passed when using prerelese enter");
           throw new ExitError(1);
         }
-        // @ts-ignore
         await pre(cwd, { command, tag });
         return;
       }

--- a/packages/cli/src/utils/isCI.ts
+++ b/packages/cli/src/utils/isCI.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import isCI from "is-ci";
 
 export default !!(isCI || process.env.GITHUB_ACTIONS);

--- a/packages/get-github-info/package.json
+++ b/packages/get-github-info/package.json
@@ -11,6 +11,7 @@
     "node-fetch": "^2.5.0"
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.5.7",
     "nock": "^11.7.0",
     "prettier": "^1.18.2"
   }

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import fetch from "node-fetch";
 import DataLoader from "dataloader";
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,6 +23,8 @@ export type ComprehensiveRelease = {
   oldVersion: string;
   newVersion: string;
   changesets: string[];
+  /** Whether any dependency versions were updated to be compatible with the new version in their release */
+  dependenciesLeavingRange?: string[];
 };
 
 export type Changeset = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/ci-info@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ci-info/-/ci-info-2.0.0.tgz#51848cc0f5c30c064f4b25f7f688bf35825b3971"
+  integrity sha512-5R2/MHILQLDCzTuhs1j4Qqq8AaKUf7Ma4KSSkCtc12+fMs47zfa34qhto9goxpyX00tQK1zxB885VCiawZ5Qhg==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1394,6 +1399,13 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/is-ci@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/is-ci/-/is-ci-2.0.0.tgz#e2b81d0f9275861649d501dbc39a480fbf311459"
+  integrity sha512-J8ytIdkALbTrqcJ6OZiEv0B9skfyok/zCDj1q06GGCDa1rlHnPobUBT0BYR1vku2oZVwVEgCurtXqCASAfjCiQ==
+  dependencies:
+    "@types/ci-info" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -1473,6 +1485,14 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
+
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*", "@types/node@^12.7.1":
   version "12.12.5"
@@ -2194,7 +2214,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3104,6 +3124,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
This fixes an issue with the new `updateInternalDependencies` config setting set to `minor` where patch bumped dependencies that left the semver range of a dependent were not updated.

The fix involves adding a new `dependenciesLeavingRange` field to the release plan that lists dependencies of a released package that leave semver range. This knowledge is required by `apply-release-plan` so that it can always bump these packages regardless of the `updateInternalDependencies` setting.

I've made the field optional to not make a ton of things breaking and because it's only required by this one configuration option.

I also came across some `@ts-ignore`'s so tried to remove as many from source files as I could.