### PR TITLE
feat: allow publishing private packages

### DIFF
--- a/.changeset/breezy-seahorses-arrive.md
+++ b/.changeset/breezy-seahorses-arrive.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+allows git-tagging private packages without publishing them to npm

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -79,8 +79,13 @@ export default async function run(
     if (tool !== "root") {
       for (const pkg of successful) {
         const tag = `${pkg.name}@${pkg.newVersion}`;
-        log("New tag: ", tag);
-        await git.tag(tag, cwd);
+        const isMissingTag = !(await git.tagExists(tag));
+        if (isMissingTag) {
+          log("New tag: ", tag);
+          await git.tag(tag, cwd);
+        } else {
+          log("Skipping existing tag: ", tag);
+        }
       }
     } else {
       const tag = `v${successful[0].newVersion}`;

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -78,7 +78,7 @@ export default async function publishPackages({
           isRequired: Promise.resolve(true)
         };
   const unpublishedPackagesInfo = await getUnpublishedPackages(
-    publicPackages,
+    packages,
     preState
   );
 
@@ -105,31 +105,39 @@ async function publishAPackage(
   twoFactorState: TwoFactorState,
   tag: string
 ): Promise<PublishedResult> {
-  const { name, version, publishConfig } = pkg.packageJson;
+  const { name, version, publishConfig, private: isPrivate } = pkg.packageJson;
   const localAccess = publishConfig && publishConfig.access;
-  info(
-    `Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`
-  );
 
-  const publishDir =
-    publishConfig && publishConfig.directory
-      ? join(pkg.dir, publishConfig.directory)
-      : pkg.dir;
+  let published;
+  if (!isPrivate) {
+    info(
+      `Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`
+    );
 
-  const publishConfirmation = await npmUtils.publish(
-    name,
-    {
-      cwd: publishDir,
-      access: localAccess || access,
-      tag
-    },
-    twoFactorState
-  );
+    const publishDir =
+      publishConfig && publishConfig.directory
+        ? join(pkg.dir, publishConfig.directory)
+        : pkg.dir;
+
+    const publishConfirmation = await npmUtils.publish(
+      name,
+      {
+        cwd: publishDir,
+        access: localAccess || access,
+        tag
+      },
+      twoFactorState
+    );
+
+    published = publishConfirmation.published;
+  } else {
+    published = true;
+  }
 
   return {
     name,
     newVersion: version,
-    published: publishConfirmation.published
+    published
   };
 }
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -34,6 +34,13 @@ async function tag(tagStr: string, cwd: string) {
   return gitCmd.code === 0;
 }
 
+async function tagExists(tagStr: string) {
+  const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
+  const output = gitCmd.stdout.toString().trim();
+  const tagExists = !!output;
+  return tagExists;
+}
+
 // Find the commit where we diverged from `ref` at using `git merge-base`
 export async function getDivergedCommit(cwd: string, ref: string) {
   const cmd = await spawn("git", ["merge-base", ref, "HEAD"], { cwd });
@@ -259,6 +266,7 @@ export {
   add,
   commit,
   tag,
+  tagExists,
   getChangedPackagesSinceRef,
   getChangedChangesetFilesSinceRef
 };


### PR DESCRIPTION
Supersedes https://github.com/atlassian/changesets/pull/420.

We get all packages (instead of just the public ones) and we only publish the public ones, while returning `published = true` for everything else, so that they can be used in the tagging step after publishing.

Context: https://github.com/atlassian/changesets/issues/399, https://github.com/atlassian/changesets/issues/478#issuecomment-780951976

cc @mitchellhamilton 