### PR TITLE
Add initial zeroes to snapshot date string suffix

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -33,7 +33,9 @@ function getSnapshotSuffix(snapshot?: string | boolean): string | undefined {
     now.getUTCHours(),
     now.getUTCMinutes(),
     now.getUTCSeconds()
-  ].join("");
+  ]
+    .map(number => number.toString().padStart(2, "0"))
+    .join("");
 
   let tag = "";
   if (typeof snapshot === "string") tag = `-${snapshot}`;


### PR DESCRIPTION
### Problem

When changesets generates a date string suffix for a snapshot, leading zeroes are not added to single-digit numbers, which means that it’s possible for newer generated versions to be lower than older versions. Here’s the one that bit me:

`0.0.0-canary-20217561928` — old version, published 2021-08-05 06:19:28
`0.0.0-canary-2021714575` — new version, published 2021-08-14 05:07:05

202175 is greater than 202171, therefore installing version `2021714575` will give you deps matching `20217561928`.

### Solution

Add leading zeroes to the date numbers in `getSnapshotSuffix`:

```typescript
let dateAndTime = [
  now.getUTCFullYear(),
  now.getUTCMonth(),
  now.getUTCDate(),
  now.getUTCHours(),
  now.getUTCMinutes(),
  now.getUTCSeconds()
]
  .map(number => number.toString().padStart(2, "0"))
  .join("");
```

---

### Potential issue, needs discussion

After this change lands, all new versions will now start with `202107`, which happens to be lower than `20217`, meaning that all new versions will now be lower than any version published this year. Not good!

### Potential solution

1. Use single digits for numbers less than 36 but use `toString(36)` to ensure that there will always be one digit. If `now.getUTCHours()` returns 12, it’ll be stringified to `c`.

    ```typescript
    const now = Date('2021-08-14T15:33:42.426Z');

    let dateAndTime = [
      now.getUTCFullYear(),
      now.getUTCMonth().toString(36),
      now.getUTCDate().toString(36),
      now.getUTCHours().toString(36),
      now.getUTCMinutes().toString(36).padStart(2, '0'),
      now.getUTCSeconds().toString(36).padStart(2, '0'),
    ].join("");
    ```

    output: `20217ef0x16`

2. Shorten the year to two digits. 21 is greater than 20, problem solved.

    ```typescript
    const now = Date('2021-08-14T15:33:42.426Z');

    let dateAndTime = [
      now.getUTCFullYear() - 2000,
      now.getUTCMonth(),
      now.getUTCDate(),
      now.getUTCHours(),
      now.getUTCMinutes(),
      now.getUTCSeconds(),
    ]
      .map(number => number.toString().padStart(2, "0"))
      .join("");
    ```

    output: `210714153342`