### PR TITLE
Add `showUsers` option to changelog-github

### DIFF
--- a/.changeset/funny-carrots-exercise.md
+++ b/.changeset/funny-carrots-exercise.md
@@ -1,0 +1,5 @@
+---
+"@changesets/changelog-github": minor
+---
+
+Add `showUsers` option

--- a/packages/changelog-github/src/index.test.ts
+++ b/packages/changelog-github/src/index.test.ts
@@ -41,7 +41,11 @@ jest.mock(
   }
 );
 
-const getChangeset = (content: string, commit: string | undefined) => {
+const getChangeset = (
+  content: string,
+  commit: string | undefined,
+  showUsers?: boolean
+) => {
   return [
     {
       ...parse(
@@ -57,7 +61,7 @@ const getChangeset = (content: string, commit: string | undefined) => {
       commit
     },
     "minor",
-    { repo: data.repo }
+    { repo: data.repo, ...(showUsers === false && { showUsers }) }
   ] as const;
 };
 
@@ -130,6 +134,16 @@ it("with multiple authors", async () => {
     "
 
     - [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@Andarist](https://github.com/Andarist), [@mitchellhamilton](https://github.com/mitchellhamilton)! - something
+    "
+  `);
+});
+
+it("without authors", async () => {
+  expect(await getReleaseLine(...getChangeset("", data.commit, false)))
+    .toMatchInlineSnapshot(`
+    "
+
+    - [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) - something
     "
   `);
 });

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -46,6 +46,9 @@ const changelogFunctions: ChangelogFunctions = {
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
       );
     }
+    if (options.showUsers !== false) {
+      options.showUsers = true;
+    }
 
     let prFromSummary: number | undefined;
     let commitFromSummary: string | undefined;
@@ -112,7 +115,7 @@ const changelogFunctions: ChangelogFunctions = {
     const prefix = [
       links.pull === null ? "" : ` ${links.pull}`,
       links.commit === null ? "" : ` ${links.commit}`,
-      users === null ? "" : ` Thanks ${users}!`
+      users === null || options.showUsers === false ? "" : ` Thanks ${users}!`
     ].join("");
 
     return `\n\n-${prefix ? `${prefix} -` : ""} ${firstLine}\n${futureLines


### PR DESCRIPTION
With this we can show/hide the users thanks in the changelog.

With something simpler like:
>- [#1613](https://github.com/emotion-js/emotion/pull/1613) [`a085003`](https://github.com/emotion-js/emotion/commit/a085003) - something