### PR TITLE
Switch default commit message to sentence case

### DIFF
--- a/packages/release-utils/src/run.ts
+++ b/packages/release-utils/src/run.ts
@@ -105,7 +105,7 @@ type VersionOptions = {
 export async function runVersion({
   script,
   cwd = process.cwd(),
-  commitMessage = "Version Packages"
+  commitMessage = "Version packages"
 }: VersionOptions) {
   let branch = await gitUtils.getCurrentBranch(cwd);
   let versionBranch = `changeset-release/${branch}`;


### PR DESCRIPTION
## Motivation
I've worked with teams that like Conventional Commits, but most projects I've encountered (including this repo), write their commit messages in _Sentence case_.

I didn't find evidence that using _Title Case_ was an intentional choice, but if it is, we can close this suggestion.

Related to https://github.com/atlassian/changesets/issues/246

## Next Steps
If merged, https://github.com/changesets/action and https://github.com/changesets/bot may need similar updates.