### PR TITLE
Tag private packages when their version changes

### DIFF
--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -4,6 +4,6 @@
 
 Private packages can now be tagged in the same way public packages do when they are published to npm.
 
-To enable set `privatePackages: 'version-and-tag'` in your config.json.
+To enable set `privatePackages: { version: true, tag: true }` in your config.json.
 
-You can also now opt private packages out of versioning entirely by setting `privatePackages: 'ignore'`.
+You can also now opt private packages out of versioning entirely by setting `privatePackages: false`.

--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -1,7 +1,5 @@
 ---
 "@changesets/cli": minor
-"@changesets/config": minor
-"@changesets/types": minor
 ---
 
 Private packages can now be tagged in the same way public packages do when they are published to npm.

--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -2,7 +2,7 @@
 "@changesets/cli": minor
 ---
 
-Private packages can now be tagged in the same way public packages do when they are published to npm. 
+Private packages can now be tagged in the same way public packages do when they are published to npm.
 
 To enable set `privatePackages: 'version-and-tag'` in your config.json.
 

--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -2,4 +2,8 @@
 "@changesets/cli": minor
 ---
 
-Private packages will now be tagged in the same way public packages do when they are published to npm
+Private packages can now be tagged in the same way public packages do when they are published to npm. 
+
+To enable set `privatePackages: 'version-and-tag'` in your config.json.
+
+You can also now opt private packages out of versioning entirely by setting `privatePackages: 'ignore'`.

--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -1,5 +1,7 @@
 ---
 "@changesets/cli": minor
+"@changesets/config": minor
+"@changesets/types": minor
 ---
 
 Private packages can now be tagged in the same way public packages do when they are published to npm.

--- a/.changeset/fast-jars-thank.md
+++ b/.changeset/fast-jars-thank.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Private packages will now be tagged in the same way public packages do when they are published to npm

--- a/.changeset/khaki-kangaroos-tie.md
+++ b/.changeset/khaki-kangaroos-tie.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": minor
+---
+
+Add tagExists git helper

--- a/.changeset/khaki-kangaroos-tie.md
+++ b/.changeset/khaki-kangaroos-tie.md
@@ -2,4 +2,4 @@
 "@changesets/git": minor
 ---
 
-Add tagExists git helper
+Add `tagExists` git helper

--- a/.changeset/khaki-kangaroos-tie.md
+++ b/.changeset/khaki-kangaroos-tie.md
@@ -2,4 +2,4 @@
 "@changesets/git": minor
 ---
 
-Add `tagExists` git helper
+Add `tagExists` & `remoteTagExists` git helpers

--- a/.changeset/rich-horses-push.md
+++ b/.changeset/rich-horses-push.md
@@ -1,0 +1,6 @@
+---
+"@changesets/config": minor
+"@changesets/types": minor
+---
+
+Added support for the `privatePackages` property in the config.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To make releasing easier, you can use [this changesets github action](https://gi
 - [Prereleases](./docs/prereleases.md)
 - [Problems publishing in monorepos](./docs/problems-publishing-in-monorepos.md)
 - [Snapshot releases](./docs/snapshot-releases.md)
+- [Versioning applications and other non-npm packages](./docs/versioning-apps.md)
 - [Experimental Options](./docs/experimental-options.md)
 
 ## Cool Projects already using Changesets for versioning and changelogs

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -4,13 +4,10 @@ Changesets can also be used to manage application versions or non-npm packages (
 
 The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
 
-To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file.
+To enable this feature set `privatePackages` to `version-and-tag` in your `.changesets/config.json` file. By default changesets will only update the changelog and version
 
 > **Note**
 > Changesets only versions NPM package.json files, you can trigger releases for other package formats by creating workflows which trigger on tags/releases being created by changesets.
-
-> **Note**
-> This feature relies on git tags to track releases, ensure you fetch tags before you publish.
 
 ## Setting up a package
 

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -1,10 +1,16 @@
 # Managing applications or non-npm packages
 
-Changesets can also be used to manage application versions or non-npm packages (ie dotnet NuGet packages, ruby gems, etc).
+Changesets can also be used to manage application versions or non-npm packages (ie dotnet NuGet packages, ruby gems, docker images etc).
 
 The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
 
-To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file. This will become
+To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file.
+
+> **Note**
+> Changesets only versions NPM package.json files, you can trigger releases for other package formats by creating workflows which trigger on tags/releases being created by changesets.
+
+> **Note**
+> This feature relies on git tags to track releases, ensure you fetch tags before you publish.
 
 ## Setting up a package
 
@@ -17,7 +23,3 @@ To enable a project to be tracked by changesets, it needs a minimal package.json
   "version": "0.0.1"
 }
 ```
-
-## Tracking releases
-
-This feature relies on git tags to track releases, ensure you fetch tags before you publish.

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -4,7 +4,7 @@ Changesets can also be used to manage application versions or non-npm packages (
 
 The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
 
-To enable this feature set `privatePackages` to `version-and-tag` in your `.changesets/config.json` file. By default changesets will only update the changelog and version
+To enable this feature set `privatePackages` to `{ version: true, tag: true }` in your `.changesets/config.json` file. By default changesets will only update the changelog and version (ie `{ version: true, tag: false }`).
 
 > **Note**
 > Changesets only versions NPM package.json files, you can trigger releases for other package formats by creating workflows which trigger on tags/releases being created by changesets.

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -1,0 +1,23 @@
+# Managing applications or non-npm packages
+
+Changesets can also be used to manage application versions or non-npm packages (ie dotnet NuGet packages, ruby gems, etc).
+
+The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
+
+To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file. This will become 
+
+## Setting up a package
+
+To enable a project to be tracked by changesets, it needs a minimal package.json with at least `name`, `private` and `version`.
+
+``` json
+{
+  "name": "my-project",
+  "private": true,
+  "version": "0.0.1"
+}
+```
+
+## Tracking releases
+
+This feature relies on git tags to track releases, ensure you fetch tags before you publish.

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -4,13 +4,13 @@ Changesets can also be used to manage application versions or non-npm packages (
 
 The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
 
-To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file. This will become 
+To enable this feature set `enablePrivatePackageTracking` to `true` in your `.changesets/config.json` file. This will become
 
 ## Setting up a package
 
 To enable a project to be tracked by changesets, it needs a minimal package.json with at least `name`, `private` and `version`.
 
-``` json
+```json
 {
   "name": "my-project",
   "private": true,

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -49,6 +49,7 @@ class FakeReleasePlan {
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
+      enablePrivatePackageTracking: true,
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
         updateInternalDependents: "out-of-range",
@@ -90,6 +91,7 @@ async function testSetup(
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
+      enablePrivatePackageTracking: true,
       snapshot: {
         useCalculatedVersion: false,
         prereleaseTemplate: null,
@@ -493,6 +495,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          enablePrivatePackageTracking: true,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -559,6 +562,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          enablePrivatePackageTracking: true,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -753,6 +757,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -841,6 +846,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -921,6 +927,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1001,6 +1008,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1084,6 +1092,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1172,6 +1181,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1252,6 +1262,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1332,6 +1343,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
+              enablePrivatePackageTracking: true,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1416,6 +1428,7 @@ describe("apply release plan", () => {
             baseBranch: "main",
             updateInternalDependencies: "patch",
             ignore: [],
+            enablePrivatePackageTracking: true,
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
               updateInternalDependents: "out-of-range",
@@ -1596,6 +1609,7 @@ describe("apply release plan", () => {
           ],
           updateInternalDependencies: "patch",
           ignore: [],
+          enablePrivatePackageTracking: true,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1704,6 +1718,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "patch",
           ignore: [],
+          enablePrivatePackageTracking: true,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1792,6 +1807,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
+          enablePrivatePackageTracking: true,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1884,6 +1900,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
+          enablePrivatePackageTracking: true,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1990,6 +2007,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
+          enablePrivatePackageTracking: true,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -3,7 +3,7 @@ import {
   ReleasePlan,
   Config,
   NewChangeset,
-  ComprehensiveRelease
+  ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
 import fs from "fs-extra";

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -50,7 +50,7 @@ class FakeReleasePlan {
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      privatePackages: PrivatePackages.VersionAndTag,
+      privatePackages: PrivatePackages.Version,
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
         updateInternalDependents: "out-of-range",
@@ -92,7 +92,7 @@ async function testSetup(
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      privatePackages: PrivatePackages.VersionAndTag,
+      privatePackages: PrivatePackages.Version,
       snapshot: {
         useCalculatedVersion: false,
         prereleaseTemplate: null,
@@ -496,7 +496,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -563,7 +563,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -758,7 +758,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -847,7 +847,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -928,7 +928,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1009,7 +1009,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1093,7 +1093,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1182,7 +1182,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1263,7 +1263,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1344,7 +1344,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.VersionAndTag,
+              privatePackages: PrivatePackages.Version,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1429,7 +1429,7 @@ describe("apply release plan", () => {
             baseBranch: "main",
             updateInternalDependencies: "patch",
             ignore: [],
-            privatePackages: PrivatePackages.VersionAndTag,
+            privatePackages: PrivatePackages.Version,
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
               updateInternalDependents: "out-of-range",
@@ -1610,7 +1610,7 @@ describe("apply release plan", () => {
           ],
           updateInternalDependencies: "patch",
           ignore: [],
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1719,7 +1719,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "patch",
           ignore: [],
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1808,7 +1808,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1901,7 +1901,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -2008,7 +2008,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.VersionAndTag,
+          privatePackages: PrivatePackages.Version,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -3,8 +3,7 @@ import {
   ReleasePlan,
   Config,
   NewChangeset,
-  ComprehensiveRelease,
-  PrivatePackages
+  ComprehensiveRelease
 } from "@changesets/types";
 import * as git from "@changesets/git";
 import fs from "fs-extra";
@@ -50,7 +49,7 @@ class FakeReleasePlan {
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      privatePackages: PrivatePackages.Version,
+      privatePackages: { version: true, tag: false },
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
         updateInternalDependents: "out-of-range",
@@ -92,7 +91,7 @@ async function testSetup(
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      privatePackages: PrivatePackages.Version,
+      privatePackages: { version: true, tag: false },
       snapshot: {
         useCalculatedVersion: false,
         prereleaseTemplate: null,
@@ -496,7 +495,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -563,7 +562,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -758,7 +757,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -847,7 +846,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -928,7 +927,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1009,7 +1008,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1093,7 +1092,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1182,7 +1181,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1263,7 +1262,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1344,7 +1343,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              privatePackages: PrivatePackages.Version,
+              privatePackages: { version: true, tag: false },
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1429,7 +1428,7 @@ describe("apply release plan", () => {
             baseBranch: "main",
             updateInternalDependencies: "patch",
             ignore: [],
-            privatePackages: PrivatePackages.Version,
+            privatePackages: { version: true, tag: false },
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
               updateInternalDependents: "out-of-range",
@@ -1610,7 +1609,7 @@ describe("apply release plan", () => {
           ],
           updateInternalDependencies: "patch",
           ignore: [],
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1719,7 +1718,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "patch",
           ignore: [],
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1808,7 +1807,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1901,7 +1900,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -2008,7 +2007,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          privatePackages: PrivatePackages.Version,
+          privatePackages: { version: true, tag: false },
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   Config,
   NewChangeset,
   ComprehensiveRelease,
+  PrivatePackages
 } from "@changesets/types";
 import * as git from "@changesets/git";
 import fs from "fs-extra";
@@ -49,7 +50,7 @@ class FakeReleasePlan {
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      enablePrivatePackageTracking: true,
+      privatePackages: PrivatePackages.VersionAndTag,
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
         updateInternalDependents: "out-of-range",
@@ -91,7 +92,7 @@ async function testSetup(
       baseBranch: "main",
       updateInternalDependencies: "patch",
       ignore: [],
-      enablePrivatePackageTracking: true,
+      privatePackages: PrivatePackages.VersionAndTag,
       snapshot: {
         useCalculatedVersion: false,
         prereleaseTemplate: null,
@@ -495,7 +496,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -562,7 +563,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -757,7 +758,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -846,7 +847,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -927,7 +928,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1008,7 +1009,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1092,7 +1093,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1181,7 +1182,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1262,7 +1263,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1343,7 +1344,7 @@ describe("apply release plan", () => {
               baseBranch: "main",
               updateInternalDependencies,
               ignore: [],
-              enablePrivatePackageTracking: true,
+              privatePackages: PrivatePackages.VersionAndTag,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
                 updateInternalDependents: "out-of-range",
@@ -1428,7 +1429,7 @@ describe("apply release plan", () => {
             baseBranch: "main",
             updateInternalDependencies: "patch",
             ignore: [],
-            enablePrivatePackageTracking: true,
+            privatePackages: PrivatePackages.VersionAndTag,
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
               updateInternalDependents: "out-of-range",
@@ -1609,7 +1610,7 @@ describe("apply release plan", () => {
           ],
           updateInternalDependencies: "patch",
           ignore: [],
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1718,7 +1719,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "patch",
           ignore: [],
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1807,7 +1808,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -1900,7 +1901,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",
@@ -2007,7 +2008,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           updateInternalDependencies: "minor",
           ignore: [],
-          enablePrivatePackageTracking: true,
+          privatePackages: PrivatePackages.VersionAndTag,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
             updateInternalDependents: "out-of-range",

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -116,7 +116,7 @@ describe("Changesets", () => {
     "should read summary",
     // @ts-ignore
     async ({ consoleSummaries, editorSummaries, expectedSummary }) => {
-      const cwd = await f.copy("simple-project");
+      const cwd = f.copy("simple-project");
 
       mockUserResponses({
         releases: { "pkg-a": "patch" },
@@ -137,7 +137,7 @@ describe("Changesets", () => {
   );
 
   it("should generate a changeset in a single package repo", async () => {
-    const cwd = await f.copy("single-package");
+    const cwd = f.copy("single-package");
 
     const summary = "summary message mock";
 
@@ -175,7 +175,7 @@ describe("Changesets", () => {
   });
 
   it("should commit when the commit flag is passed in", async () => {
-    const cwd = await f.copy("simple-project-custom-config");
+    const cwd = f.copy("simple-project-custom-config");
 
     mockUserResponses({ releases: { "pkg-a": "patch" } });
     await addChangeset(
@@ -191,7 +191,7 @@ describe("Changesets", () => {
   });
 
   it("should create empty changeset when empty flag is passed in", async () => {
-    const cwd = await f.copy("simple-project");
+    const cwd = f.copy("simple-project");
 
     await addChangeset(cwd, { empty: true }, defaultConfig);
 
@@ -204,8 +204,9 @@ describe("Changesets", () => {
       })
     );
   });
+
   it("should not include ignored packages in the prompt", async () => {
-    const cwd = await f.copy("internal-dependencies");
+    const cwd = f.copy("internal-dependencies");
 
     mockUserResponses({ releases: { "pkg-a": "patch" } });
     await addChangeset(
@@ -218,8 +219,9 @@ describe("Changesets", () => {
     const { choices } = askCheckboxPlus.mock.calls[0][1][0];
     expect(choices).toEqual(["pkg-a", "pkg-c"]);
   });
+
   it("should not include private packages without a version in the prompt", async () => {
-    const cwd = await f.copy("private-package-without-version-field");
+    const cwd = f.copy("private-package-without-version-field");
 
     mockUserResponses({ releases: { "pkg-a": "patch" } });
     await addChangeset(cwd, { empty: false }, defaultConfig);

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -115,7 +115,7 @@ function getPkgJsonsByName(packages: Package[]) {
   );
 }
 
-function isValidChangesetPackage(
+function canPackageBeVersioned(
   packageJson: PackageJSON,
   ignorePrivatePackages: boolean
 ) {

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -7,6 +7,7 @@ import { error, log } from "@changesets/logger";
 import { Release, PackageJSON } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
+import { isListablePackage } from "./isListablePackage";
 
 const { green, yellow, red, bold, blue, cyan } = chalk;
 
@@ -65,14 +66,10 @@ async function getPackagesToRelease(
 
   // filter out packages which changesets is not tracking
   allPackages = allPackages.filter(pkg =>
-    isValidChangesetPackage(pkg.packageJson, ignorePrivatePackages)
+    isListablePackage(config, pkg.packageJson)
   );
   changedPackages = changedPackages.filter(
-    pkgName =>
-      !isValidChangesetPackage(
-        pkgJsonsByName.get(pkgName)!,
-        ignorePrivatePackages
-      )
+    pkgName => !isListablePackage(config, pkgJsonsByName.get(pkgName)!)
   );
 
   if (allPackages.length > 1) {
@@ -113,19 +110,6 @@ function getPkgJsonsByName(packages: Package[]) {
   return new Map(
     packages.map(({ packageJson }) => [packageJson.name, packageJson])
   );
-}
-
-function canPackageBeVersioned(
-  packageJson: PackageJSON,
-  ignorePrivatePackages: boolean
-) {
-  const hasVersionField = !!packageJson.version;
-
-  if (ignorePrivatePackages && packageJson.private) {
-    return false;
-  }
-
-  return hasVersionField;
 }
 
 function formatPkgNameAndVersion(pkgName: string, version: string) {

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -64,8 +64,8 @@ async function getPackagesToRelease(
   const pkgJsonsByName = getPkgJsonByName(allPackages);
 
   // filter out packages which changesets is not tracking
-  allPackages = allPackages.filter(
-    pkg => !isValidChangesetPackage(pkg.packageJson, trackPrivatePackages)
+  allPackages = allPackages.filter(pkg =>
+    isValidChangesetPackage(pkg.packageJson, trackPrivatePackages)
   );
   changedPackages = changedPackages.filter(
     pkgName =>

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -132,12 +132,6 @@ function formatPkgNameAndVersion(pkgName: string, version: string) {
   return `${bold(pkgName)}@${bold(version)}`;
 }
 
-function getPkgJsonByName(packages: Package[]) {
-  return new Map(
-    packages.map(({ packageJson }) => [packageJson.name, packageJson])
-  );
-}
-
 export default async function createChangeset(
   changedPackages: Array<string>,
   allPackages: Package[],

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -4,10 +4,9 @@ import semver from "semver";
 
 import * as cli from "../../utils/cli-utilities";
 import { error, log } from "@changesets/logger";
-import { Release, PackageJSON, Config } from "@changesets/types";
+import { Release, PackageJSON } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
-import { isListablePackage } from "./isListablePackage";
 
 const { green, yellow, red, bold, blue, cyan } = chalk;
 
@@ -37,8 +36,7 @@ async function confirmMajorRelease(pkgJSON: PackageJSON) {
 
 async function getPackagesToRelease(
   changedPackages: Array<string>,
-  allPackages: Array<Package>,
-  config: Config
+  allPackages: Array<Package>
 ) {
   function askInitialReleaseQuestion(defaultChoiceList: Array<any>) {
     return cli.askCheckboxPlus(
@@ -61,16 +59,6 @@ async function getPackagesToRelease(
       }
     );
   }
-
-  const pkgJsonsByName = getPkgJsonsByName(allPackages);
-
-  // filter out packages which changesets is not tracking
-  allPackages = allPackages.filter(pkg =>
-    isListablePackage(config, pkg.packageJson)
-  );
-  changedPackages = changedPackages.filter(
-    pkgName => !isListablePackage(config, pkgJsonsByName.get(pkgName)!)
-  );
 
   if (allPackages.length > 1) {
     const unchangedPackagesNames = allPackages
@@ -118,16 +106,14 @@ function formatPkgNameAndVersion(pkgName: string, version: string) {
 
 export default async function createChangeset(
   changedPackages: Array<string>,
-  allPackages: Package[],
-  config: Config
+  allPackages: Package[]
 ): Promise<{ confirmed: boolean; summary: string; releases: Array<Release> }> {
   const releases: Array<Release> = [];
 
   if (allPackages.length > 1) {
     const packagesToRelease = await getPackagesToRelease(
       changedPackages,
-      allPackages,
-      config
+      allPackages
     );
 
     let pkgJsonsByName = getPkgJsonsByName(allPackages);

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -4,7 +4,7 @@ import semver from "semver";
 
 import * as cli from "../../utils/cli-utilities";
 import { error, log } from "@changesets/logger";
-import { Release, PackageJSON } from "@changesets/types";
+import { Release, PackageJSON, Config } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
 import { isListablePackage } from "./isListablePackage";
@@ -38,7 +38,7 @@ async function confirmMajorRelease(pkgJSON: PackageJSON) {
 async function getPackagesToRelease(
   changedPackages: Array<string>,
   allPackages: Array<Package>,
-  ignorePrivatePackages: boolean
+  config: Config
 ) {
   function askInitialReleaseQuestion(defaultChoiceList: Array<any>) {
     return cli.askCheckboxPlus(
@@ -119,7 +119,7 @@ function formatPkgNameAndVersion(pkgName: string, version: string) {
 export default async function createChangeset(
   changedPackages: Array<string>,
   allPackages: Package[],
-  ignorePrivatePackages: boolean
+  config: Config
 ): Promise<{ confirmed: boolean; summary: string; releases: Array<Release> }> {
   const releases: Array<Release> = [];
 
@@ -127,7 +127,7 @@ export default async function createChangeset(
     const packagesToRelease = await getPackagesToRelease(
       changedPackages,
       allPackages,
-      ignorePrivatePackages
+      config
     );
 
     let pkgJsonsByName = getPkgJsonsByName(allPackages);

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -48,7 +48,7 @@ export default async function add(
       .filter((pkg) => isListablePackage(config, pkg.packageJson))
       .map((pkg) => pkg.packageJson.name);
 
-    newChangeset = await createChangeset(changedPackagesName, packages);
+    newChangeset = await createChangeset(changedPackagesName, packages, config.enablePrivateTracking);
     printConfirmationMessage(newChangeset, packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -13,14 +13,7 @@ import { getCommitFunctions } from "../../commit/getCommitFunctions";
 import createChangeset from "./createChangeset";
 import printConfirmationMessage from "./messages";
 import { ExternalEditor } from "external-editor";
-import { PackageJSON } from "@changesets/types";
-
-function isListablePackage(config: Config, packageJson: PackageJSON) {
-  return (
-    !config.ignore.includes(packageJson.name) &&
-    (packageJson.version || !packageJson.private)
-  );
-}
+import { isListablePackage } from "./isListablePackage";
 
 export default async function add(
   cwd: string,

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -48,7 +48,11 @@ export default async function add(
       .filter((pkg) => isListablePackage(config, pkg.packageJson))
       .map((pkg) => pkg.packageJson.name);
 
-    newChangeset = await createChangeset(changedPackagesName, packages, config.privatePackages === PrivatePackages.Ignore);
+    newChangeset = await createChangeset(
+      changedPackagesName,
+      packages,
+      config.privatePackages === PrivatePackages.Ignore
+    );
     printConfirmationMessage(newChangeset, packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -41,7 +41,7 @@ export default async function add(
       .filter((pkg) => isListablePackage(config, pkg.packageJson))
       .map((pkg) => pkg.packageJson.name);
 
-    newChangeset = await createChangeset(changedPackagesName, packages, config);
+    newChangeset = await createChangeset(changedPackagesName, packages);
     printConfirmationMessage(newChangeset, packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -5,7 +5,7 @@ import { spawn } from "child_process";
 import * as cli from "../../utils/cli-utilities";
 import * as git from "@changesets/git";
 import { info, log, warn } from "@changesets/logger";
-import { Config } from "@changesets/types";
+import { Config, PrivatePackages } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
 import writeChangeset from "@changesets/write";
 
@@ -48,7 +48,7 @@ export default async function add(
       .filter((pkg) => isListablePackage(config, pkg.packageJson))
       .map((pkg) => pkg.packageJson.name);
 
-    newChangeset = await createChangeset(changedPackagesName, packages, config.enablePrivateTracking);
+    newChangeset = await createChangeset(changedPackagesName, packages, config.privatePackages === PrivatePackages.Ignore);
     printConfirmationMessage(newChangeset, packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -5,7 +5,7 @@ import { spawn } from "child_process";
 import * as cli from "../../utils/cli-utilities";
 import * as git from "@changesets/git";
 import { info, log, warn } from "@changesets/logger";
-import { Config, PrivatePackages } from "@changesets/types";
+import { Config } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
 import writeChangeset from "@changesets/write";
 
@@ -41,11 +41,7 @@ export default async function add(
       .filter((pkg) => isListablePackage(config, pkg.packageJson))
       .map((pkg) => pkg.packageJson.name);
 
-    newChangeset = await createChangeset(
-      changedPackagesName,
-      packages,
-      config.privatePackages === PrivatePackages.Ignore
-    );
+    newChangeset = await createChangeset(changedPackagesName, packages, config);
     printConfirmationMessage(newChangeset, packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/isListablePackage.ts
+++ b/packages/cli/src/commands/add/isListablePackage.ts
@@ -1,0 +1,17 @@
+import { Config } from "@changesets/types";
+import { PackageJSON } from "@changesets/types";
+
+export function isListablePackage(config: Config, packageJson: PackageJSON) {
+  const packageIgnoredInConfig = config.ignore.includes(packageJson.name);
+
+  if (packageIgnoredInConfig) {
+    return false;
+  }
+
+  if (!config.privatePackages && packageJson.private) {
+    return false;
+  }
+
+  const hasVersionField = !!packageJson.version;
+  return hasVersionField;
+}

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -38,11 +38,9 @@ describe("publishPackages", () => {
   describe("when isCI", () => {
     it("does not call out to npm to see if otp is required", async () => {
       await publishPackages({
-        cwd,
         packages: (await getPackages(cwd)).packages,
         access: "public",
-        preState: undefined,
-        tagPrivatePackages: true
+        preState: undefined
       });
       expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -41,7 +41,7 @@ describe("publishPackages", () => {
         packages: (await getPackages(cwd)).packages,
         access: "public",
         preState: undefined,
-        trackPrivatePackages: true
+        tagPrivatePackages: true
       });
       expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -40,7 +40,7 @@ describe("publishPackages", () => {
       await publishPackages({
         packages: (await getPackages(cwd)).packages,
         access: "public",
-        preState: undefined
+        preState: undefined,
       });
       expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -41,6 +41,7 @@ describe("publishPackages", () => {
         packages: (await getPackages(cwd)).packages,
         access: "public",
         preState: undefined,
+        trackPrivatePackages: true
       });
       expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -38,6 +38,7 @@ describe("publishPackages", () => {
   describe("when isCI", () => {
     it("does not call out to npm to see if otp is required", async () => {
       await publishPackages({
+        cwd,
         packages: (await getPackages(cwd)).packages,
         access: "public",
         preState: undefined,

--- a/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
@@ -22,10 +22,15 @@ git.tag.mockImplementation(() => Promise.resolve(true));
 
 // @ts-ignore
 publishPackages.mockImplementation(() =>
-  Promise.resolve([
-    { name: "pkg-a", newVersion: "1.1.0", published: true },
-    { name: "pkg-b", newVersion: "1.0.1", published: true },
-  ])
+  Promise.resolve({
+    publishedPackages: [
+      { name: "pkg-a", newVersion: "1.1.0", published: true },
+      { name: "pkg-b", newVersion: "1.0.1", published: true },
+    ],
+    untaggedPrivatePackages: [
+      { name: "project-a", newVersion: "2.0.5", published: true },
+    ]
+  })
 );
 
 describe("running release", () => {

--- a/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
@@ -24,7 +24,7 @@ git.tag.mockImplementation(() => Promise.resolve(true));
 publishPackages.mockImplementation(() =>
   Promise.resolve([
     { name: "pkg-a", newVersion: "1.1.0", published: true },
-    { name: "pkg-b", newVersion: "1.0.1", published: true }
+    { name: "pkg-b", newVersion: "1.0.1", published: true },
   ])
 );
 

--- a/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/releaseCommand.test.ts
@@ -22,15 +22,10 @@ git.tag.mockImplementation(() => Promise.resolve(true));
 
 // @ts-ignore
 publishPackages.mockImplementation(() =>
-  Promise.resolve({
-    publishedPackages: [
-      { name: "pkg-a", newVersion: "1.1.0", published: true },
-      { name: "pkg-b", newVersion: "1.0.1", published: true },
-    ],
-    untaggedPrivatePackages: [
-      { name: "project-a", newVersion: "2.0.5", published: true },
-    ]
-  })
+  Promise.resolve([
+    { name: "pkg-a", newVersion: "1.1.0", published: true },
+    { name: "pkg-b", newVersion: "1.0.1", published: true }
+  ])
 );
 
 describe("running release", () => {
@@ -38,7 +33,7 @@ describe("running release", () => {
   let cwd: string;
 
   beforeEach(async () => {
-    cwd = await f.copy("simple-project");
+    cwd = f.copy("simple-project");
   });
 
   describe("When there is no changeset commits", () => {

--- a/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
+++ b/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
@@ -1,14 +1,18 @@
 import * as git from "@changesets/git";
-import { Package } from "@manypkg/get-packages";
+import { Package, Tool } from "@manypkg/get-packages";
 import { PublishedResult } from "./publishPackages";
 
 export async function getUntaggedPrivatePackages(
   privatePackages: Package[],
-  cwd: string
+  cwd: string,
+  tool: Tool
 ) {
   const packageWithTags = await Promise.all(
     privatePackages.map(async privatePkg => {
-      const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
+      const tagName =
+        tool === "root"
+          ? `v${privatePkg.packageJson.version}`
+          : `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
       const isMissingTag = !(
         (await git.tagExists(tagName, cwd)) ||
         (await git.remoteTagExists(tagName))

--- a/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
+++ b/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
@@ -1,0 +1,34 @@
+import * as git from "@changesets/git";
+import { Package } from "@manypkg/get-packages";
+import { PublishedResult } from "./publishPackages";
+
+export async function getUntaggedPrivatePackages(
+  privatePackages: Package[],
+  cwd: string
+) {
+  const packageWithTags = await Promise.all(
+    privatePackages.map(async privatePkg => {
+      const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
+      const isMissingTag = !(
+        (await git.tagExists(tagName, cwd)) ||
+        (await git.remoteTagExists(tagName))
+      );
+
+      return { pkg: privatePkg, isMissingTag };
+    })
+  );
+
+  const untagged: PublishedResult[] = [];
+
+  for (const packageWithTag of packageWithTags) {
+    if (packageWithTag.isMissingTag) {
+      untagged.push({
+        name: packageWithTag.pkg.packageJson.name,
+        newVersion: packageWithTag.pkg.packageJson.version,
+        published: false
+      });
+    }
+  }
+
+  return untagged;
+}

--- a/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
+++ b/packages/cli/src/commands/publish/getUntaggedPrivatePackages.ts
@@ -8,7 +8,7 @@ export async function getUntaggedPrivatePackages(
   tool: Tool
 ) {
   const packageWithTags = await Promise.all(
-    privatePackages.map(async privatePkg => {
+    privatePackages.map(async (privatePkg) => {
       const tagName =
         tool === "root"
           ? `v${privatePkg.packageJson.version}`
@@ -29,7 +29,7 @@ export async function getUntaggedPrivatePackages(
       untagged.push({
         name: packageWithTag.pkg.packageJson.name,
         newVersion: packageWithTag.pkg.packageJson.version,
-        published: false
+        published: false,
       });
     }
   }

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -3,7 +3,7 @@ import { ExitError } from "@changesets/errors";
 import { error, log, success, warn } from "@changesets/logger";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
-import { Config, PreState, PrivatePackages } from "@changesets/types";
+import { Config, PreState } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
 import chalk from "chalk";
 
@@ -64,10 +64,7 @@ export default async function run(
     otp,
     preState,
     tag: releaseTag,
-    tagPrivatePackages: isFlagEnabled(
-      config.privatePackages,
-      PrivatePackages.Tag
-    )
+    tagPrivatePackages: config.privatePackages && config.privatePackages.tag
   });
 
   const successfulNpmPublishes = response.publishedPackages.filter(
@@ -124,8 +121,4 @@ export default async function run(
     logReleases(unsuccessfulNpmPublishes);
     throw new ExitError(1);
   }
-}
-
-function isFlagEnabled(value: number, tag: number): boolean {
-  return (value & tag) === tag;
 }

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -64,6 +64,7 @@ export default async function run(
     otp,
     preState,
     tag: releaseTag,
+    trackPrivatePackages: config.enablePrivatePackageTracking
   });
 
   const successfulNpmPublishes = response.publishedPackages.filter(

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -58,6 +58,7 @@ export default async function run(
   const { packages, tool } = await getPackages(cwd);
 
   const response = await publishPackages({
+    cwd,
     packages,
     // if not public, we won't pass the access, and it works as normal
     access: config.access,

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -66,10 +66,10 @@ export default async function run(
     access: config.access,
     otp,
     preState,
-    tag: releaseTag
+    tag: releaseTag,
   });
   const privatePackages = packages.filter(
-    pkg => pkg.packageJson.private && pkg.packageJson.version
+    (pkg) => pkg.packageJson.private && pkg.packageJson.version
   );
   const untaggedPrivatePackageReleases = tagPrivatePackages
     ? await getUntaggedPrivatePackages(privatePackages, cwd, tool)
@@ -82,8 +82,10 @@ export default async function run(
     warn("No unpublished projects to publish");
   }
 
-  const successfulNpmPublishes = publishedPackages.filter(p => p.published);
-  const unsuccessfulNpmPublishes = publishedPackages.filter(p => !p.published);
+  const successfulNpmPublishes = publishedPackages.filter((p) => p.published);
+  const unsuccessfulNpmPublishes = publishedPackages.filter(
+    (p) => !p.published
+  );
 
   if (successfulNpmPublishes.length > 0) {
     success("packages published successfully:");

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -3,7 +3,7 @@ import { ExitError } from "@changesets/errors";
 import { error, log, success, warn } from "@changesets/logger";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
-import { Config, PreState } from "@changesets/types";
+import { Config, PreState, PrivatePackages } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
 import chalk from "chalk";
 
@@ -64,7 +64,10 @@ export default async function run(
     otp,
     preState,
     tag: releaseTag,
-    trackPrivatePackages: config.enablePrivatePackageTracking
+    tagPrivatePackages: isFlagEnabled(
+      config.privatePackages,
+      PrivatePackages.Tag
+    )
   });
 
   const successfulNpmPublishes = response.publishedPackages.filter(
@@ -121,4 +124,8 @@ export default async function run(
     logReleases(unsuccessfulNpmPublishes);
     throw new ExitError(1);
   }
+}
+
+function isFlagEnabled(value: number, tag: number): boolean {
+  return (value & tag) === tag;
 }

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -97,14 +97,21 @@ export default async function publishPackages({
   const privatePackages = packages.filter(
     pkg => pkg.packageJson.private && pkg.packageJson.version
   );
-  const twoFactorState: TwoFactorState = getTwoFactorState({
-    otp,
-    publicPackages,
-  });
   const unpublishedPackagesInfo = await getUnpublishedPackages(
     publicPackages,
     preState
   );
+
+  const twoFactorState: TwoFactorState =
+    unpublishedPackagesInfo.length > 0
+      ? getTwoFactorState({
+          otp,
+          publicPackages
+        })
+      : {
+          token: null,
+          isRequired: Promise.resolve(false)
+        };
 
   const npmPackagePublish = Promise.all(
     unpublishedPackagesInfo.map((pkgInfo) => {

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -80,17 +80,17 @@ export default async function publishPackages({
   otp,
   preState,
   tag,
-  trackPrivatePackages
+  tagPrivatePackages
 }: {
   packages: Package[];
   access: AccessType;
   otp?: string;
   preState: PreState | undefined;
   tag?: string;
-  trackPrivatePackages: boolean;
+  tagPrivatePackages: boolean;
 }): Promise<{
   publishedPackages: PublishedResult[];
-  untaggedPrivatePackages: PublishedResult[];
+  untaggedPrivatePackages: Omit<PublishedResult, "published">[];
 }> {
   const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
   const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
@@ -125,7 +125,7 @@ export default async function publishPackages({
     })
   );
 
-  const untaggedPrivatePackageReleases = trackPrivatePackages
+  const untaggedPrivatePackageReleases = tagPrivatePackages
     ? getUntaggedPrivatePackages(privatePackages)
     : Promise.resolve([]);
 

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -78,7 +78,7 @@ export default async function publishPackages({
   access,
   otp,
   preState,
-  tag
+  tag,
 }: {
   packages: Package[];
   access: AccessType;
@@ -99,7 +99,7 @@ export default async function publishPackages({
 
   const twoFactorState: TwoFactorState = getTwoFactorState({
     otp,
-    publicPackages
+    publicPackages,
   });
 
   return Promise.all(

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -80,19 +80,23 @@ export default async function publishPackages({
   otp,
   preState,
   tag,
+  trackPrivatePackages
 }: {
   packages: Package[];
   access: AccessType;
   otp?: string;
   preState: PreState | undefined;
   tag?: string;
+  trackPrivatePackages: boolean;
 }): Promise<{
   publishedPackages: PublishedResult[];
   untaggedPrivatePackages: PublishedResult[];
 }> {
   const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
   const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
-  const privatePackages = packages.filter(pkg => pkg.packageJson.private);
+  const privatePackages = packages.filter(
+    pkg => pkg.packageJson.private && pkg.packageJson.version
+  );
   const twoFactorState: TwoFactorState = getTwoFactorState({
     otp,
     publicPackages,
@@ -114,9 +118,9 @@ export default async function publishPackages({
     })
   );
 
-  const untaggedPrivatePackageReleases = getUntaggedPrivatePackages(
-    privatePackages
-  );
+  const untaggedPrivatePackageReleases = trackPrivatePackages
+    ? getUntaggedPrivatePackages(privatePackages)
+    : Promise.resolve([]);
 
   const result: {
     publishedPackages: PublishedResult[];

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -75,6 +75,7 @@ const getTwoFactorState = ({
 };
 
 export default async function publishPackages({
+  cwd,
   packages,
   access,
   otp,
@@ -82,6 +83,7 @@ export default async function publishPackages({
   tag,
   tagPrivatePackages
 }: {
+  cwd: string;
   packages: Package[];
   access: AccessType;
   otp?: string;
@@ -126,7 +128,7 @@ export default async function publishPackages({
   );
 
   const untaggedPrivatePackageReleases = tagPrivatePackages
-    ? getUntaggedPrivatePackages(privatePackages)
+    ? getUntaggedPrivatePackages(privatePackages, cwd)
     : Promise.resolve([]);
 
   const result: {
@@ -147,12 +149,16 @@ export default async function publishPackages({
   return result;
 }
 
-async function getUntaggedPrivatePackages(privatePackages: Package[]) {
+async function getUntaggedPrivatePackages(
+  privatePackages: Package[],
+  cwd: string
+) {
   const packageWithTags = await Promise.all(
     privatePackages.map(async privatePkg => {
       const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
       const isMissingTag = !(
-        (await git.tagExists(tagName)) || (await git.remoteTagExists(tagName))
+        (await git.tagExists(tagName, cwd)) ||
+        (await git.remoteTagExists(tagName))
       );
 
       return { pkg: privatePkg, isMissingTag };

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -151,7 +151,7 @@ async function getUntaggedPrivatePackages(privatePackages: Package[]) {
   const packageWithTags = await Promise.all(
     privatePackages.map(async privatePkg => {
       const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
-      const isMissingTag = !(await git.tagExists(tagName));
+      const isMissingTag = !(await git.remoteTagExists(tagName));
 
       return { pkg: privatePkg, isMissingTag };
     })

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -93,16 +93,14 @@ export default async function publishPackages({
     preState
   );
 
-  const twoFactorState: TwoFactorState =
-    unpublishedPackagesInfo.length > 0
-      ? getTwoFactorState({
-          otp,
-          publicPackages
-        })
-      : {
-          token: null,
-          isRequired: Promise.resolve(false)
-        };
+  if (unpublishedPackagesInfo.length === 0) {
+    return [];
+  }
+
+  const twoFactorState: TwoFactorState = getTwoFactorState({
+    otp,
+    publicPackages
+  });
 
   return Promise.all(
     unpublishedPackagesInfo.map((pkgInfo) => {

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -151,7 +151,7 @@ async function getUntaggedPrivatePackages(privatePackages: Package[]) {
   const packageWithTags = await Promise.all(
     privatePackages.map(async privatePkg => {
       const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
-      const isMissingTag = !(await git.remoteTagExists(tagName));
+      const isMissingTag = !(await git.tagExists(tagName) || await git.remoteTagExists(tagName));
 
       return { pkg: privatePkg, isMissingTag };
     })

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -151,7 +151,9 @@ async function getUntaggedPrivatePackages(privatePackages: Package[]) {
   const packageWithTags = await Promise.all(
     privatePackages.map(async privatePkg => {
       const tagName = `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
-      const isMissingTag = !(await git.tagExists(tagName) || await git.remoteTagExists(tagName));
+      const isMissingTag = !(
+        (await git.tagExists(tagName)) || (await git.remoteTagExists(tagName))
+      );
 
       return { pkg: privatePkg, isMissingTag };
     })

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -75,6 +75,20 @@
       "description": "Determines whether Changesets should commit the results of the add and version command.",
       "default": false
     },
+    "privatePackages": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "tag": { "type": "boolean" },
+            "version": { "type": "boolean" }
+          }
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
     "access": {
       "enum": ["restricted", "public"],
       "type": "string",

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -85,7 +85,7 @@
           }
         },
         {
-          "type": "boolean"
+          "const": false
         }
       ]
     },

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -645,4 +645,11 @@ The \`snapshot.useCalculatedVersion\` option is set as \\"not true\\" when the o
 The \`useCalculatedVersionForSnapshots\` option is set as \\"not true\\" when the only valid values are undefined or a boolean"
 `);
   });
+
+  test("privatePackages false disables versioning and tagging", () => {
+    expect(unsafeParse({ privatePackages: false }, defaultPackages)).toEqual({
+      ...defaults,
+      privatePackages: { version: false, tag: false },
+    });
+  });
 });

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -45,6 +45,7 @@ test("read reads the config", async () => {
     updateInternalDependencies: "patch",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
+    enablePrivatePackageTracking: false,
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
       onlyUpdatePeerDependentsWhenOutOfRange: false,
       updateInternalDependents: "out-of-range",
@@ -65,7 +66,7 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ignore: [],
-  enablePrivatePackageTracking: true,
+  enablePrivatePackageTracking: false,
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
     updateInternalDependents: "out-of-range",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -65,6 +65,7 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ignore: [],
+  enablePrivatePackageTracking: true,
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
     updateInternalDependents: "out-of-range",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -2,7 +2,7 @@ import fixturez from "fixturez";
 import { read, parse } from "./";
 import jestInCase from "jest-in-case";
 import * as logger from "@changesets/logger";
-import { Config, PrivatePackages, WrittenConfig } from "@changesets/types";
+import { Config, WrittenConfig } from "@changesets/types";
 import { Packages } from "@manypkg/get-packages";
 
 jest.mock("@changesets/logger");
@@ -45,7 +45,10 @@ test("read reads the config", async () => {
     updateInternalDependencies: "patch",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
-    privatePackages: 1,
+    privatePackages: {
+      tag: false,
+      version: true
+    },
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
       onlyUpdatePeerDependentsWhenOutOfRange: false,
       updateInternalDependents: "out-of-range",
@@ -57,7 +60,7 @@ test("read reads the config", async () => {
   });
 });
 
-let defaults = {
+let defaults: Config = {
   fixed: [],
   linked: [],
   changelog: ["@changesets/cli/changelog", null],
@@ -66,7 +69,7 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ignore: [],
-  privatePackages: PrivatePackages.Version,
+  privatePackages: { version: true, tag: false },
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
     updateInternalDependents: "out-of-range",
@@ -76,7 +79,7 @@ let defaults = {
     prereleaseTemplate: null,
   },
   bumpVersionsWithWorkspaceProtocolOnly: false,
-} as const;
+};
 
 let correctCases: Record<string, CorrectCase> = {
   defaults: {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -2,7 +2,7 @@ import fixturez from "fixturez";
 import { read, parse } from "./";
 import jestInCase from "jest-in-case";
 import * as logger from "@changesets/logger";
-import { Config, WrittenConfig } from "@changesets/types";
+import { Config, PrivatePackages, WrittenConfig } from "@changesets/types";
 import { Packages } from "@manypkg/get-packages";
 
 jest.mock("@changesets/logger");
@@ -66,7 +66,7 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ignore: [],
-  enablePrivatePackageTracking: false,
+  privatePackages: PrivatePackages.VersionAndTag,
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
     updateInternalDependents: "out-of-range",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -47,7 +47,7 @@ test("read reads the config", async () => {
     bumpVersionsWithWorkspaceProtocolOnly: false,
     privatePackages: {
       tag: false,
-      version: true
+      version: true,
     },
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
       onlyUpdatePeerDependentsWhenOutOfRange: false,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -45,7 +45,7 @@ test("read reads the config", async () => {
     updateInternalDependencies: "patch",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
-    enablePrivatePackageTracking: false,
+    privatePackages: 1,
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
       onlyUpdatePeerDependentsWhenOutOfRange: false,
       updateInternalDependents: "out-of-range",
@@ -66,7 +66,7 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ignore: [],
-  privatePackages: PrivatePackages.VersionAndTag,
+  privatePackages: PrivatePackages.Version,
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
     updateInternalDependents: "out-of-range",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -462,7 +462,11 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           ?.updateInternalDependents ?? "out-of-range",
     },
+
+    // TODO default this to being enabled in the next major version
+    enablePrivatePackageTracking: json.enablePrivatePackageTracking === true
   };
+
   return config;
 };
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,8 +9,7 @@ import {
   WrittenConfig,
   Fixed,
   Linked,
-  PackageGroup,
-  PrivatePackages
+  PackageGroup
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
@@ -465,13 +464,12 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     },
 
     // TODO consider enabling this by default in the next major version
-    privatePackages:
-      json.privatePackages === "ignore"
-        ? PrivatePackages.Ignore
-        : json.privatePackages === "version-and-tag"
-        ? PrivatePackages.VersionAndTag
-        : // Default value
-          PrivatePackages.Version
+    privatePackages: json.privatePackages
+      ? {
+          version: json.privatePackages.version ?? true,
+          tag: json.privatePackages.tag ?? false
+        }
+      : { version: true, tag: false }
   };
 
   return config;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -476,7 +476,6 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   };
 
   if (
-    config.privatePackages &&
     config.privatePackages.version === false &&
     config.privatePackages.tag === true
   ) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -463,7 +463,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           ?.updateInternalDependents ?? "out-of-range",
     },
 
-    // TODO default this to being enabled in the next major version
+    // TODO consider enabling this by default in the next major version
     enablePrivatePackageTracking: json.enablePrivatePackageTracking === true
   };
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -464,13 +464,26 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     },
 
     // TODO consider enabling this by default in the next major version
-    privatePackages: json.privatePackages
-      ? {
-          version: json.privatePackages.version ?? true,
-          tag: json.privatePackages.tag ?? false,
-        }
-      : { version: true, tag: false },
+    privatePackages:
+      json.privatePackages === false
+        ? { tag: false, version: false }
+        : json.privatePackages
+        ? {
+            version: json.privatePackages.version ?? true,
+            tag: json.privatePackages.tag ?? false,
+          }
+        : { version: true, tag: false },
   };
+
+  if (
+    config.privatePackages &&
+    config.privatePackages.version === false &&
+    config.privatePackages.tag === true
+  ) {
+    throw new ValidationError(
+      `The \`privatePackages.tag\` option is set to \`true\` but \`privatePackages.version\` is set to \`false\`. This is not allowed.`
+    );
+  }
 
   return config;
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,7 +9,7 @@ import {
   WrittenConfig,
   Fixed,
   Linked,
-  PackageGroup
+  PackageGroup,
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
@@ -467,9 +467,9 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     privatePackages: json.privatePackages
       ? {
           version: json.privatePackages.version ?? true,
-          tag: json.privatePackages.tag ?? false
+          tag: json.privatePackages.tag ?? false,
         }
-      : { version: true, tag: false }
+      : { version: true, tag: false },
   };
 
   return config;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,7 @@ import {
   Fixed,
   Linked,
   PackageGroup,
+  PrivatePackages
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
@@ -464,7 +465,12 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     },
 
     // TODO consider enabling this by default in the next major version
-    enablePrivatePackageTracking: json.enablePrivatePackageTracking === true
+    privatePackages:
+      json.privatePackages === "version-without-tag"
+        ? PrivatePackages.Tag
+        : json.privatePackages === "version-and-tag"
+        ? PrivatePackages.VersionAndTag
+        : PrivatePackages.Ignore
   };
 
   return config;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -466,11 +466,12 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
 
     // TODO consider enabling this by default in the next major version
     privatePackages:
-      json.privatePackages === "version-without-tag"
-        ? PrivatePackages.Tag
+      json.privatePackages === "ignore"
+        ? PrivatePackages.Ignore
         : json.privatePackages === "version-and-tag"
         ? PrivatePackages.VersionAndTag
-        : PrivatePackages.Ignore
+        : // Default value
+          PrivatePackages.Version
   };
 
   return config;

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   getChangedPackagesSinceRef,
   getChangedChangesetFilesSinceRef,
   getAllTags,
+  tagExists
 } from "./";
 
 const f = fixtures(__dirname);
@@ -223,6 +224,23 @@ describe("git", () => {
 
       expect(firstTagRef).toEqual(initialHead);
       expect(secondTagRef).toEqual(newHead);
+    });
+  });
+
+  describe("tagExists", () => {
+    beforeEach(async () => {
+      await add("packages/pkg-a/package.json", cwd);
+      await commit("added packageA package.json", cwd);
+    });
+
+    it("returns false when no tag exists", async () => {
+      expect(await tagExists("tag_name")).toBe(false);
+    });
+
+    it("should create a tag for the current head", async () => {
+      await tag("tag_message", cwd);
+
+      expect(await tagExists("tag_name")).toBe(false);
     });
   });
 

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -231,15 +231,16 @@ describe("git", () => {
     it("returns false when no tag exists", async () => {
       await add("packages/pkg-a/package.json", cwd);
       await commit("added packageA package.json", cwd);
-      expect(await tagExists("tag_name")).toBe(false);
+
+      expect(await tagExists("tag_which_doesn't_exist", cwd)).toBe(false);
     });
 
-    it("should create a tag for the current head", async () => {
+    it("returns true when tag exists", async () => {
       await add("packages/pkg-a/package.json", cwd);
       await commit("added packageA package.json", cwd);
       await tag("tag_message", cwd);
 
-      expect(await tagExists("tag_name")).toBe(false);
+      expect(await tagExists("tag_message", cwd)).toBe(true);
     });
   });
 

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -13,7 +13,7 @@ import {
   getChangedPackagesSinceRef,
   getChangedChangesetFilesSinceRef,
   getAllTags,
-  tagExists
+  tagExists,
 } from "./";
 
 const f = fixtures(__dirname);

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -228,16 +228,15 @@ describe("git", () => {
   });
 
   describe("tagExists", () => {
-    beforeEach(async () => {
+    it("returns false when no tag exists", async () => {
       await add("packages/pkg-a/package.json", cwd);
       await commit("added packageA package.json", cwd);
-    });
-
-    it("returns false when no tag exists", async () => {
       expect(await tagExists("tag_name")).toBe(false);
     });
 
     it("should create a tag for the current head", async () => {
+      await add("packages/pkg-a/package.json", cwd);
+      await commit("added packageA package.json", cwd);
       await tag("tag_message", cwd);
 
       expect(await tagExists("tag_name")).toBe(false);

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -281,14 +281,12 @@ export async function getChangedPackagesSinceRef({
   );
 }
 
-async function tagExists(tagStr: string) {
+export async function tagExists(tagStr: string) {
   const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
   const output = gitCmd.stdout.toString().trim();
   const tagExists = !!output;
   return tagExists;
 }
-
-  tagExists,
 
 export async function getCurrentCommitId({
   cwd,

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -281,6 +281,15 @@ export async function getChangedPackagesSinceRef({
   );
 }
 
+async function tagExists(tagStr: string) {
+    const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
+    const output = gitCmd.stdout.toString().trim();
+    const tagExists = !!output;
+    return tagExists;
+  }
+
+  tagExists,
+
 export async function getCurrentCommitId({
   cwd,
 }: {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -304,7 +304,7 @@ export async function remoteTagExists(tagStr: string) {
     "--tags",
     "origin",
     "-l",
-    tagStr
+    tagStr,
   ]);
   const output = gitCmd.stdout.toString().trim();
   const tagExists = !!output;

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -281,8 +281,8 @@ export async function getChangedPackagesSinceRef({
   );
 }
 
-export async function tagExists(tagStr: string) {
-  const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
+export async function tagExists(tagStr: string, cwd: string) {
+  const gitCmd = await spawn("git", ["tag", "-l", tagStr], { cwd });
   const output = gitCmd.stdout.toString().trim();
   const tagExists = !!output;
   return tagExists;

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -297,3 +297,16 @@ export async function getCurrentCommitId({
     .toString()
     .trim();
 }
+
+export async function remoteTagExists(tagStr: string) {
+  const gitCmd = await spawn("git", [
+    "ls-remote",
+    "--tags",
+    "origin",
+    "-l",
+    tagStr
+  ]);
+  const output = gitCmd.stdout.toString().trim();
+  const tagExists = !!output;
+  return tagExists;
+}

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -282,11 +282,11 @@ export async function getChangedPackagesSinceRef({
 }
 
 async function tagExists(tagStr: string) {
-    const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
-    const output = gitCmd.stdout.toString().trim();
-    const tagExists = !!output;
-    return tagExists;
-  }
+  const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
+  const output = gitCmd.stdout.toString().trim();
+  const tagExists = !!output;
+  return tagExists;
+}
 
   tagExists,
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,16 +61,10 @@ export type PackageGroup = ReadonlyArray<string>;
 export type Fixed = ReadonlyArray<PackageGroup>;
 export type Linked = ReadonlyArray<PackageGroup>;
 
-/**
- * bitwise flag for private packages
- * Check if the flag is enabled with `(flags & PrivatePackages.Version) === PrivatePackages.Version`
- */
-export const PrivatePackages = {
-  Ignore: 0,
-  Version: 1,
-  Tag: 2,
-  VersionAndTag: 3
-} as const;
+export interface PrivatePackages {
+  version: boolean;
+  tag: boolean;
+}
 
 export type Config = {
   changelog: false | readonly [string, any];
@@ -80,7 +74,7 @@ export type Config = {
   access: AccessType;
   baseBranch: string;
   /** Features enabled for Private packages */
-  privatePackages: typeof PrivatePackages[keyof typeof PrivatePackages];
+  privatePackages: false | PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -104,7 +98,10 @@ export type WrittenConfig = {
   access?: AccessType;
   baseBranch?: string;
   /** Opt in to tracking non-npm / private packages */
-  privatePackages?: "ignore" | "version-without-tag" | "version-and-tag";
+  privatePackages?: {
+    version?: boolean;
+    tag?: boolean;
+  };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -98,10 +98,12 @@ export type WrittenConfig = {
   access?: AccessType;
   baseBranch?: string;
   /** Opt in to tracking non-npm / private packages */
-  privatePackages?: {
-    version?: boolean;
-    tag?: boolean;
-  };
+  privatePackages?:
+    | false
+    | {
+        version?: boolean;
+        tag?: boolean;
+      };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -68,6 +68,8 @@ export type Config = {
   linked: Linked;
   access: AccessType;
   baseBranch: string;
+  /** Opt in to tracking non-npm / private packages */
+  enablePrivatePackageTracking: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -90,6 +92,8 @@ export type WrittenConfig = {
   linked?: Linked;
   access?: AccessType;
   baseBranch?: string;
+  /** Opt in to tracking non-npm / private packages */
+  enablePrivatePackageTracking?: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,6 +61,13 @@ export type PackageGroup = ReadonlyArray<string>;
 export type Fixed = ReadonlyArray<PackageGroup>;
 export type Linked = ReadonlyArray<PackageGroup>;
 
+export const enum PrivatePackages {
+  Ignore,
+  Version = 1 << 1,
+  Tag = 1 << 2,
+  VersionAndTag = Version | Tag
+}
+
 export type Config = {
   changelog: false | readonly [string, any];
   commit: false | readonly [string, any];
@@ -68,8 +75,8 @@ export type Config = {
   linked: Linked;
   access: AccessType;
   baseBranch: string;
-  /** Opt in to tracking non-npm / private packages */
-  enablePrivatePackageTracking: boolean;
+  /** Features enabled for Private packages */
+  privatePackages: PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -93,7 +100,7 @@ export type WrittenConfig = {
   access?: AccessType;
   baseBranch?: string;
   /** Opt in to tracking non-npm / private packages */
-  enablePrivatePackageTracking?: boolean;
+  privatePackages?: "ignore" | "version-without-tag" | "version-and-tag";
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,12 +61,16 @@ export type PackageGroup = ReadonlyArray<string>;
 export type Fixed = ReadonlyArray<PackageGroup>;
 export type Linked = ReadonlyArray<PackageGroup>;
 
-export const enum PrivatePackages {
-  Ignore,
-  Version = 1 << 1,
-  Tag = 1 << 2,
-  VersionAndTag = Version | Tag
-}
+/**
+ * bitwise flag for private packages
+ * Check if the flag is enabled with `(flags & PrivatePackages.Version) === PrivatePackages.Version`
+ */
+export const PrivatePackages = {
+  Ignore: 0,
+  Version: 1,
+  Tag: 2,
+  VersionAndTag: 3
+} as const;
 
 export type Config = {
   changelog: false | readonly [string, any];
@@ -76,7 +80,7 @@ export type Config = {
   access: AccessType;
   baseBranch: string;
   /** Features enabled for Private packages */
-  privatePackages: PrivatePackages;
+  privatePackages: typeof PrivatePackages[keyof typeof PrivatePackages];
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -74,7 +74,7 @@ export type Config = {
   access: AccessType;
   baseBranch: string;
   /** Features enabled for Private packages */
-  privatePackages: false | PrivatePackages;
+  privatePackages: PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;


### PR DESCRIPTION
Replaces #420 and #569. Also addresses comment in https://github.com/atlassian/changesets/issues/478#issuecomment-780951976

This updates the publishPackage function so it returns 2 things, the publishedPackages and the untaggedPrivatePackages. I wasn't sure how far to take the separation, it could have been it's own module.

Possibly a further step would be to gather up the `projects` which need to be published & tagged. This would allow changesets to be extended to publish .NET packages to NuGet for instance.

This could also be considered as a breaking change. We possibly should add a new config option to opt into this?

