### PR TITLE
Fix an issue with `getDependentsGraph` that doesn't handle some setups

### DIFF
--- a/packages/get-dependents-graph/src/get-dependents-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependents-graph.test.ts
@@ -1,0 +1,89 @@
+import { getDependentsGraph } from "./index";
+
+describe("getting the dependents graph", () => {
+  it("should work with a basic setup", () => {
+    const graph = getDependentsGraph(
+      {
+        root: {
+          dir: ".",
+          packageJson: { name: "root", version: "1.0.0" }
+        },
+        packages: [
+          {
+            dir: "foo",
+            packageJson: {
+              name: "foo",
+              version: "1.0.0",
+              dependencies: {
+                bar: "1.0.0"
+              }
+            }
+          },
+          {
+            dir: "bar",
+            packageJson: {
+              name: "bar",
+              version: "1.0.0"
+            }
+          }
+        ],
+        tool: "yarn"
+      },
+      { bumpVersionsWithWorkspaceProtocolOnly: true }
+    );
+
+    expect(graph).toEqual(
+      new Map([
+        ["foo", []],
+        ["bar", []],
+        ["root", []]
+      ])
+    );
+  });
+
+  it("should properly determine dependents if packages depend on the root", () => {
+    const graph = getDependentsGraph(
+      {
+        root: {
+          dir: ".",
+          packageJson: { name: "root", version: "1.0.0" }
+        },
+        packages: [
+          {
+            dir: "foo",
+            packageJson: {
+              name: "foo",
+              version: "1.0.0",
+              dependencies: {
+                bar: "workspace:*"
+              },
+              devDependencies: {
+                root: "workspace:*"
+              }
+            }
+          },
+          {
+            dir: "bar",
+            packageJson: {
+              name: "bar",
+              version: "1.0.0",
+              devDependencies: {
+                root: "workspace:*"
+              }
+            }
+          }
+        ],
+        tool: "yarn"
+      },
+      { bumpVersionsWithWorkspaceProtocolOnly: true }
+    );
+
+    expect(graph).toEqual(
+      new Map([
+        ["foo", []],
+        ["bar", ["foo"]],
+        ["root", ["foo", "bar"]]
+      ])
+    );
+  });
+});

--- a/packages/get-dependents-graph/src/index.ts
+++ b/packages/get-dependents-graph/src/index.ts
@@ -16,6 +16,11 @@ export function getDependentsGraph(
     [key: string]: { pkg: Package; dependents: Array<string> };
   } = {};
 
+  dependentsLookup[packages.root.packageJson.name] = {
+    dependents: [],
+    pkg: packages.root
+  };
+
   packages.packages.forEach(pkg => {
     dependentsLookup[pkg.packageJson.name] = {
       pkg,


### PR DESCRIPTION
I work in a monorepo where we define all the tools in the workspace root and specify the root as a `devDependency` in all packages to share tools (e.g. ESLint, etc.) from the root instead of redeclaring them for each package.

I noticed an issue where an error is thrown when calculating dependents with this setup.

I added a basic test case to replicate the setup and took a shot at a fix. This may not be the most appropriate solution as I'm not totally sure what the intended behavior is (should the root package show up in the dependents graph?) but it does pass the test I wrote.

Let me know if there's a better way to address this.

Note: this is an issue even if the root workspace has `private: true` and is ignored in `.changeset/config.json`