### PR TITLE
Rework publishing to work with all popular package managers

### DIFF
--- a/.changeset/dry-cows-wait.md
+++ b/.changeset/dry-cows-wait.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Refactored the publishing part of the code to invoke Yarn Berry instead of npm CLI for publishing purposes. This ensures that packages are correctly packed, so for instance workspace ranges can be correctly substituted now.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "meow": "^6.0.0",
     "outdent": "^0.5.0",
     "p-limit": "^2.2.0",
-    "preferred-pm": "^3.0.0",
+    "preferred-pm": "^3.0.3",
     "semver": "^5.4.1",
     "spawndamnit": "^2.0.0",
     "term-size": "^2.1.0",

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -174,7 +174,11 @@ async function internalPublish(
     !isCI &&
     // yarn berry doesn't accept `--otp` and it asks for it on its own
     publishTool.name !== "yarn";
-  let publishFlags = opts.access ? ["--access", opts.access] : [];
+  let publishFlags = publishTool.name !== "yarn" ? ["--json"] : [];
+
+  if (opts.access) {
+    publishFlags.push("--access", opts.access);
+  }
   publishFlags.push("--tag", opts.tag);
 
   if (shouldHandleOtp && (await twoFactorState.isRequired)) {
@@ -189,7 +193,7 @@ async function internalPublish(
   };
   let { code, stdout, stderr } = await spawn(
     publishTool.name,
-    [...publishTool.args, "--json", ...publishFlags, ...publishTool.flags],
+    [...publishTool.args, ...publishFlags, ...publishTool.flags],
     {
       cwd: opts.cwd,
       env: Object.assign({}, process.env, envOverride)

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -36,23 +36,33 @@ function getCorrectRegistry(packageJson?: PackageJSON): string {
 
 async function getPublishTool(
   cwd: string
-): Promise<{ name: "npm" } | { name: "pnpm"; shouldAddNoGitChecks: boolean }> {
+): Promise<{ name: "npm" | "pnpm" | "yarn"; args: string[]; flags: string[] }> {
   const pm = await preferredPM(cwd);
-  if (!pm || pm.name !== "pnpm") return { name: "npm" };
-  try {
-    let result = await spawn("pnpm", ["--version"], { cwd });
-    let version = result.stdout.toString().trim();
-    let parsed = semver.parse(version);
-    return {
-      name: "pnpm",
-      shouldAddNoGitChecks:
-        parsed?.major === undefined ? false : parsed.major >= 5
-    };
-  } catch (e) {
-    return {
-      name: "pnpm",
-      shouldAddNoGitChecks: false
-    };
+  if (!pm) {
+    return { name: "npm", args: ["publish"], flags: [] };
+  }
+  const version = (await spawn(pm.name, ["--version"], { cwd })).stdout
+    .toString()
+    .trim();
+
+  const parsed = semver.parse(version)!;
+
+  switch (pm.name) {
+    case "npm":
+      return { name: "npm", args: ["publish"], flags: [] };
+    case "pnpm":
+      if (parsed.major < 5) {
+        return { name: "pnpm", args: ["publish"], flags: [] };
+      }
+      return { name: "pnpm", args: ["publish"], flags: ["--no-git-checks"] };
+    case "yarn":
+      // classic yarn doesn't do anything special when publishing, let's stick to the npm client in such a case
+      if (parsed.major < 2) {
+        return { name: "npm", args: ["publish"], flags: [] };
+      }
+      return { name: "yarn", args: ["npm", "publish"], flags: [] };
+    default:
+      return { name: "npm", args: ["publish"], flags: [] };
   }
 }
 
@@ -144,6 +154,14 @@ export let getOtpCode = async (twoFactorState: TwoFactorState) => {
   return askForOtpCode(twoFactorState);
 };
 
+const isOtpError = (error: any) => {
+  // The first case is no 2fa provided, the second is when the 2fa is wrong (timeout or wrong words)
+  return (
+    error.code === "EOTP" ||
+    (error.code === "E401" && error.detail.includes("--otp=<code>"))
+  );
+};
+
 // we have this so that we can do try a publish again after a publish without
 // the call being wrapped in the npm request limit and causing the publishes to potentially never run
 async function internalPublish(
@@ -152,14 +170,16 @@ async function internalPublish(
   twoFactorState: TwoFactorState
 ): Promise<{ published: boolean }> {
   let publishTool = await getPublishTool(opts.cwd);
+  let shouldHandleOtp =
+    !isCI &&
+    // yarn berry doesn't accept `--otp` and it asks for it on its own
+    publishTool.name !== "yarn";
   let publishFlags = opts.access ? ["--access", opts.access] : [];
   publishFlags.push("--tag", opts.tag);
-  if ((await twoFactorState.isRequired) && !isCI) {
+
+  if (shouldHandleOtp && (await twoFactorState.isRequired)) {
     let otpCode = await getOtpCode(twoFactorState);
     publishFlags.push("--otp", otpCode);
-  }
-  if (publishTool.name === "pnpm" && publishTool.shouldAddNoGitChecks) {
-    publishFlags.push("--no-git-checks");
   }
 
   // Due to a super annoying issue in yarn, we have to manually override this env variable
@@ -169,12 +189,34 @@ async function internalPublish(
   };
   let { code, stdout, stderr } = await spawn(
     publishTool.name,
-    ["publish", opts.cwd, "--json", ...publishFlags],
+    [
+      ...publishTool.args,
+      opts.cwd,
+      "--json",
+      ...publishFlags,
+      ...publishTool.flags
+    ],
     {
       env: Object.assign({}, process.env, envOverride)
     }
   );
+
   if (code !== 0) {
+    // yarn berry doesn't support --json and we don't attempt to parse its output to a machine-readable format
+    if (publishTool.name === "yarn") {
+      const output = stdout
+        .toString()
+        .trim()
+        .split("\n")
+        // this filters out "unnamed" logs: https://yarnpkg.com/advanced/error-codes/#yn0000---unnamed
+        // this includes a list of packed files and the "summary output" like: "Failed with errors in 0s 75ms"
+        // those are not that interesting so we reduce the noise by dropping them
+        .filter(line => !/YN0000:/.test(line))
+        .join("\n");
+      error(`an error occurred while publishing ${pkgName}:`, `\n${output}`);
+      return { published: false };
+    }
+
     // NPM's --json output is included alongside the `prepublish` and `postpublish` output in terminal
     // We want to handle this as best we can but it has some struggles:
     // - output of those lifecycle scripts can contain JSON
@@ -185,13 +227,7 @@ async function internalPublish(
       getLastJsonObjectFromString(stdout.toString());
 
     if (json?.error) {
-      // The first case is no 2fa provided, the second is when the 2fa is wrong (timeout or wrong words)
-      if (
-        (json.error.code === "EOTP" ||
-          (json.error.code === "E401" &&
-            json.error.detail.includes("--otp=<code>"))) &&
-        !isCI
-      ) {
+      if (shouldHandleOtp && isOtpError(json.error)) {
         if (twoFactorState.token !== null) {
           // the current otp code must be invalid since it errored
           twoFactorState.token = null;
@@ -206,10 +242,10 @@ async function internalPublish(
         json.error.detail ? "\n" + json.error.detail : ""
       );
     }
-
     error(stderr);
     return { published: false };
   }
+
   return { published: true };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -189,14 +189,9 @@ async function internalPublish(
   };
   let { code, stdout, stderr } = await spawn(
     publishTool.name,
-    [
-      ...publishTool.args,
-      opts.cwd,
-      "--json",
-      ...publishFlags,
-      ...publishTool.flags
-    ],
+    [...publishTool.args, "--json", ...publishFlags, ...publishTool.flags],
     {
+      cwd: opts.cwd,
       env: Object.assign({}, process.env, envOverride)
     }
   );

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -56,7 +56,7 @@ async function getPublishTool(
       }
       return { name: "pnpm", args: ["publish"], flags: ["--no-git-checks"] };
     case "yarn":
-      // classic yarn doesn't do anything special when publishing, let's stick to the npm client in such a case
+      // Yarn Classic doesn't do anything special when publishing, let's stick to the npm client in such a case
       if (parsed.major < 2) {
         return { name: "npm", args: ["publish"], flags: [] };
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,10 +3523,18 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-yarn-workspace-root2@^1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.11.tgz#b14a8be43503ec8c0cdf7f5923a3534860bdd92e"
-  integrity sha512-TkwH3kDD1Z8X9LnrU3gbyYw8KtLZZjsym6c2YIRFCDIMJD1JL9+Blkzpm07db+Q6ZVLISqrW9cN0CvXN4rr5ag==
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+find-yarn-workspace-root2@1.2.16:
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz#60287009dd2f324f59646bdb4b7610a6b301c2a9"
+  integrity sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==
   dependencies:
     micromatch "^4.0.2"
     pkg-dir "^4.2.0"
@@ -5198,6 +5206,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -5897,6 +5912,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -6113,13 +6135,13 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-preferred-pm@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.0.0.tgz#26cc7fbbfc1815e4cb8272d5fdde15dc96220fb8"
-  integrity sha512-NbN+2UuqjakJpyHamsuIWyeFdQcFUQHF9nkw16hpFE++z3px+/KDsj+AF1h0BlnsBJi1Z5U4EKBW7XnHriny8g==
+preferred-pm@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.0.3.tgz#1b6338000371e3edbce52ef2e4f65eb2e73586d6"
+  integrity sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==
   dependencies:
-    find-up "^4.1.0"
-    find-yarn-workspace-root2 "^1.2.11"
+    find-up "^5.0.0"
+    find-yarn-workspace-root2 "1.2.16"
     path-exists "^4.0.0"
     which-pm "2.0.0"
 


### PR DESCRIPTION
fixes https://github.com/atlassian/changesets/issues/598
fixes https://github.com/atlassian/changesets/issues/432
fixes https://github.com/changesets/changesets/issues/813
fixes https://github.com/changesets/changesets/issues/1454
(maybe https://github.com/changesets/changesets/issues/1411)

at the moment this is being opened as a draft, to gather initial feedback

The goal of this PR is to delegate as much as possible to yarn berry / pnpm so they can do their magic with rewriting package manifests and stuff

TODO:
- [ ] implement improved authentication setup for yarn berry in the https://github.com/changesets/action since it doesn't rely on `.npmrc`

cc @schickling @zkochan (might be interesting to you)