### PR TITLE
Add snapshot releases for PRs

### DIFF
--- a/.github/workflows/changeset-pr-snapshot-release.yml
+++ b/.github/workflows/changeset-pr-snapshot-release.yml
@@ -1,17 +1,14 @@
-name: Release
+name: Release PR Snapshot
 
-on:
-  push:
-    branches:
-      - main
+on: pull_request
 
 jobs:
-  release:
+  snapshot_release:
     if: github.repository == 'atlassian/changesets'
 
     timeout-minutes: 20
 
-    name: Release
+    name: Release PR Snapshot
     runs-on: ubuntu-latest
 
     steps:
@@ -26,12 +23,14 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 
-      - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@v1
-        with:
-          # this expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: yarn release
-          version: yarn version-packages
+      - name: Bump to Snapshot Versions
+        run: |
+          yarn changeset version --snapshot pr${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Release a PR Snapshot
+        run: |
+          yarn changeset publish --tag pr${{ github.event.pull_request.number }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Please review this extra carefully from the security point of view. I've gone through:
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request

And I think this is OK - but I would lie if I would say that I fully grasp all the intricacies involved here.

One surprising thing is that:
> Workflows will not run on pull_request activity if the pull request has a merge conflict. The merge conflict must be resolved first.

This seems to be counter-intuitive. I understand why this is the case though - it's because those workflows are executed in the context of the merge commit and that cannot be created if there are any conflicts. I'm not sure how to just execute this properly even if there are conflicts 🤷‍♂️ 