### PR TITLE
Added support for a `--no-git-tag` CLI flag that can be used with `changeset publish`

### DIFF
--- a/.changeset/poor-wolves-film.md
+++ b/.changeset/poor-wolves-film.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Added support for a `--no-git-tag` CLI flag that can be used with `changeset publish` to skip creating git tags for published packages. This is mostly useful when publishing snapshot releases.

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -39,7 +39,7 @@ function showNonLatestTagWarning(tag?: string, preState?: PreState) {
 
 export default async function run(
   cwd: string,
-  { otp, tag }: { otp?: string; tag?: string },
+  { otp, tag, gitTag = true }: { otp?: string; tag?: string; gitTag?: boolean },
   config: Config
 ) {
   const releaseTag = tag && tag.length > 0 ? tag : undefined;
@@ -72,20 +72,23 @@ export default async function run(
   if (successful.length > 0) {
     success("packages published successfully:");
     logReleases(successful);
-    // We create the tags after the push above so that we know that HEAD wont change and that pushing
-    // wont suffer from a race condition if another merge happens in the mean time (pushing tags wont
-    // fail if we are behind the base branch).
-    log(`Creating git tag${successful.length > 1 ? "s" : ""}...`);
-    if (tool !== "root") {
-      for (const pkg of successful) {
-        const tag = `${pkg.name}@${pkg.newVersion}`;
+
+    if (gitTag) {
+      // We create the tags after the push above so that we know that HEAD wont change and that pushing
+      // wont suffer from a race condition if another merge happens in the mean time (pushing tags wont
+      // fail if we are behind the base branch).
+      log(`Creating git tag${successful.length > 1 ? "s" : ""}...`);
+      if (tool !== "root") {
+        for (const pkg of successful) {
+          const tag = `${pkg.name}@${pkg.newVersion}`;
+          log("New tag: ", tag);
+          await git.tag(tag, cwd);
+        }
+      } else {
+        const tag = `v${successful[0].newVersion}`;
         log("New tag: ", tag);
         await git.tag(tag, cwd);
       }
-    } else {
-      const tag = `v${successful[0].newVersion}`;
-      log("New tag: ", tag);
-      await git.tag(tag, cwd);
     }
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,13 +7,13 @@ import { run } from "./run";
 const { input, flags } = meow(
   `
   Usage
-    $ changesets [command]
+    $ changeset [command]
   Commands
     init
     add [--empty] [--open]
-    version [--ignore]
-    publish [--otp=code]
-    status [--since <branch>] [--verbose] [--output=JSON_FILE.json]
+    version [--ignore] [--snapshot <?name>]
+    publish [--tag <name>] [--otp <code>] [--no-git-tag]
+    status [--since <branch>] [--verbose] [--output JSON_FILE.json]
     pre <enter|exit> <tag>
     tag
     `,
@@ -48,7 +48,14 @@ const { input, flags } = meow(
       },
       open: {
         type: "boolean"
+      },
+      gitTag: {
+        type: "boolean",
+        default: true
       }
+      // mixed type like this is not supported by `meow`
+      // if it gets passed explicitly then it's still available on the flags with an inferred type though
+      // snapshot: { type: "boolean" | "string" },
     }
   }
 );

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -82,7 +82,8 @@ export async function run(
       ignore,
       snapshot,
       tag,
-      open
+      open,
+      gitTag
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -104,7 +105,6 @@ export async function run(
 
     switch (input[0]) {
       case "add": {
-        // @ts-ignore if this is undefined, we have already exited
         await add(cwd, { empty, open }, config);
         return;
       }
@@ -166,7 +166,7 @@ export async function run(
         return;
       }
       case "publish": {
-        await publish(cwd, { otp, tag }, config);
+        await publish(cwd, { otp, tag, gitTag }, config);
         return;
       }
       case "status": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,9 +1,4 @@
-import { AccessType } from "@changesets/types";
-
 export type CliOptions = {
-  commit?: boolean;
-  changelog?: string;
-  access?: AccessType;
   sinceMaster?: boolean;
   verbose?: boolean;
   output?: string;
@@ -13,6 +8,7 @@ export type CliOptions = {
   ignore?: string | string[];
   snapshot?: string | boolean;
   tag?: string;
+  gitTag?: boolean;
   open?: boolean;
 };
 


### PR DESCRIPTION
This should be mostly used together with snapshot releases. They are usually created in the CI environment with custom scripts. So even though the tags were always created there it didn't matter that much because nobody has been pushing them on their own.

However, it feels like for snapshot releases the git tags are rarely what you actually want - and this matters especially if you want to prepare a snapshot machine locally, on your own machine. So to make this use case easier I'm proposing to introduce this flag.

It somewhat feels like a stopgap solution - but since `--snapshot` is not used with `changeset publish` I don't currently have a better idea to do this. Unless we'd infer the release type from the released package versions - this kinda seems magical though and I'm worried about introducing such a solution prematurely.