### PR TITLE
Errors received from `npm profile get --json` will now always be printed

### DIFF
--- a/.changeset/friendly-mugs-drive.md
+++ b/.changeset/friendly-mugs-drive.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Errors received from `npm profile get --json`, that is used to check if 2FA is required, will now always be printed.

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -65,6 +65,13 @@ export async function getTokenIsRequired() {
   let result = await spawn("npm", ["profile", "get", "--json"], {
     env: Object.assign({}, process.env, envOverride)
   });
+  if (result.code !== 0) {
+    error(
+      "error while checking if token is required",
+      result.stderr.toString().trim() || result.stdout.toString().trim()
+    );
+    return false;
+  }
   let json = jsonParse(result.stdout.toString());
   if (json.error || !json.tfa || !json.tfa.mode) {
     return false;


### PR DESCRIPTION
closes https://github.com/changesets/changesets/issues/707