### PR TITLE
Update changesets/action version in workflow

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout Repo
         # https://github.com/actions/checkout
         uses: actions/checkout@v2
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
 
       - name: Setup Node.js 12.x
         # https://github.com/actions/setup-node

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v2
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
 
@@ -25,7 +27,8 @@ jobs:
         run: yarn
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        # https://github.com/changesets/action
+        uses: changesets/action@v1
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release


### PR DESCRIPTION
Due to the master branch has deprecated in https://github.com/changesets/action/pull/120

Also update actions/checkout fetch depth to 1, due to it's out of date after changesets/changesets#495