### PR TITLE
fix changeset parser fail when summary is empty

### DIFF
--- a/.changeset/light-cats-flow.md
+++ b/.changeset/light-cats-flow.md
@@ -1,4 +1,5 @@
 ---
+"@changesets/cli": patch
 "@changesets/parse": patch
 ---
 

--- a/.changeset/light-cats-flow.md
+++ b/.changeset/light-cats-flow.md
@@ -1,0 +1,5 @@
+---
+"@changesets/parse": patch
+---
+
+Fixed an issue with failing to parse changesets containing a completely empty summary.

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -136,6 +136,28 @@ describe("parsing a changeset", () => {
       summary: expectedSummary
     });
   });
+  it("should be fine if the summary body is empty", () => {
+    const changesetMd = outdent`---
+    "cool-package": minor
+    ---`;
+
+    const changeset = parse(changesetMd);
+    expect(changeset).toEqual({
+      releases: [{ name: "cool-package", type: "minor" }],
+      summary: ""
+    });
+  });
+  it("should be fine if the summary body contains only an empty space", () => {
+    const changesetMd = outdent`---
+    "cool-package": minor
+    --- `;
+
+    const changeset = parse(changesetMd);
+    expect(changeset).toEqual({
+      releases: [{ name: "cool-package", type: "minor" }],
+      summary: ""
+    });
+  });
   it("should be fine if the changeset is empty", () => {
     const changesetMd = outdent`---
     ---
@@ -149,11 +171,7 @@ describe("parsing a changeset", () => {
     });
   });
   it("should be fine if the changeset only contains frontmatter", () => {
-    const changesetMd = outdent`---
-    ---
-    `;
-
-    const changeset = parse(changesetMd);
+    const changeset = parse(`---\n---`);
     expect(changeset).toEqual({
       releases: [],
       summary: ""

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -148,6 +148,17 @@ describe("parsing a changeset", () => {
       summary: ""
     });
   });
+  it("should be fine if the changeset only contains frontmatter", () => {
+    const changesetMd = outdent`---
+    ---
+    `;
+
+    const changeset = parse(changesetMd);
+    expect(changeset).toEqual({
+      releases: [],
+      summary: ""
+    });
+  });
   it("should be fine if the frontmatter is followed by a whitespace on the same line", () => {
     const changesetMd = outdent`---
     "cool-package": minor

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -147,7 +147,7 @@ describe("parsing a changeset", () => {
       summary: ""
     });
   });
-  it("should be fine if the summary body contains only an empty space", () => {
+  it("should be fine if there is no summary body and the frontmatter has some trailing whitespace", () => {
     const changesetMd = outdent`---
     "cool-package": minor
     --- `;

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -170,7 +170,7 @@ describe("parsing a changeset", () => {
       summary: ""
     });
   });
-  it("should be fine if the changeset only contains frontmatter", () => {
+  it("should be fine if the changeset is empty and without any trailing whitespace", () => {
     const changeset = parse(`---\n---`);
     expect(changeset).toEqual({
       releases: [],

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -136,7 +136,7 @@ describe("parsing a changeset", () => {
       summary: expectedSummary
     });
   });
-  it("should be fine if the summary body is empty", () => {
+  it("should be fine if the summary body is completely empty and there is no trailing whitespace", () => {
     const changesetMd = outdent`---
     "cool-package": minor
     ---`;

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -1,7 +1,7 @@
 import yaml from "js-yaml";
 import { Release, VersionType } from "@changesets/types";
 
-const mdRegex = /\s*---([^]*?)\n\s*---\s*\n([^]*)/;
+const mdRegex = /\s*---([^]*?)\n\s*---(?:\s*\n([^]*))?$/;
 
 export default function parseChangesetFile(
   contents: string
@@ -16,7 +16,7 @@ export default function parseChangesetFile(
     );
   }
   let [, roughReleases, roughSummary] = execResult;
-  let summary = roughSummary.trim();
+  let summary = (roughSummary === undefined ? "" : roughSummary).trim();
 
   let releases: Release[];
   try {

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -1,7 +1,7 @@
 import yaml from "js-yaml";
 import { Release, VersionType } from "@changesets/types";
 
-const mdRegex = /\s*---([^]*?)\n\s*---(?:\s*\n([^]*))?$/;
+const mdRegex = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
 
 export default function parseChangesetFile(
   contents: string
@@ -16,7 +16,7 @@ export default function parseChangesetFile(
     );
   }
   let [, roughReleases, roughSummary] = execResult;
-  let summary = (roughSummary === undefined ? "" : roughSummary).trim();
+  let summary = roughSummary.trim();
 
   let releases: Release[];
   try {


### PR DESCRIPTION
Fix https://github.com/changesets/action/issues/138

@Andarist Could you do me a favor to upgrade `changeset-action` to use the latest parser when we merge this PR? Thank you so much!