### PR TITLE
docs: don't use `@changesets/cli` in the sample

### DIFF
--- a/docs/detailed-explanation.md
+++ b/docs/detailed-explanation.md
@@ -34,7 +34,8 @@ A changeset is a Markdown file with YAML front matter. The contents of the Markd
 
 ```md
 ---
-"@changesets/cli": major
+"@myproject/cli": major
+"@myproject/core": minor
 ---
 
 Change all the things


### PR DESCRIPTION
When I first read this doc file, I interpreted the sample changeset file as saying that `@changesets/cli` is a special metadata tag (ie, that the use of "changesets" here was semantically meaningful and not just a dogfooding example). Maybe this was just my confusion but if you agree that this can be confusing, I think this would help.