### PR TITLE
Fix for dependent packages not being bumped when exiting prerelease

### DIFF
--- a/.changeset/strong-crews-film.md
+++ b/.changeset/strong-crews-film.md
@@ -1,0 +1,5 @@
+---
+"@changesets/assemble-release-plan": patch
+---
+
+Fixed an issue where dependent packages would not get bumped properly when exiting prerelease mode.

--- a/.changeset/strong-crews-film.md
+++ b/.changeset/strong-crews-film.md
@@ -1,5 +1,6 @@
 ---
 "@changesets/assemble-release-plan": patch
+"@changesets/cli": patch
 ---
 
 Fixed an issue where dependent packages would sometimes not get bumped properly when exiting prerelease mode.

--- a/.changeset/strong-crews-film.md
+++ b/.changeset/strong-crews-film.md
@@ -2,4 +2,4 @@
 "@changesets/assemble-release-plan": patch
 ---
 
-Fixed an issue where dependent packages would not get bumped properly when exiting prerelease mode.
+Fixed an issue where dependent packages would sometimes not get bumped properly when exiting prerelease mode.

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -869,7 +869,7 @@ Mixed changesets that contain both ignored and not ignored packages are not allo
       expect(releases[0].newVersion).toEqual("1.0.1");
     });
 
-    it("should always bump dependents when exiting pre-release mode", () => {
+    it("should bump dev dependents when exiting pre-release mode", () => {
       setup.updatePackage("pkg-a", "1.0.1-next.0");
       setup.updatePackage("pkg-b", "1.0.1-next.0");
       setup.updateDevDependency("pkg-b", "pkg-a", "1.0.1-next.0");
@@ -898,7 +898,7 @@ Mixed changesets that contain both ignored and not ignored packages are not allo
       expect(releases[1].newVersion).toEqual("1.0.1");
     });
 
-    it("should not bump dependents when exiting pre-release mode if ignored", () => {
+    it("should not bump ignored dev dependents when exiting pre-release mode", () => {
       setup.updatePackage("pkg-a", "1.0.1-next.0");
       setup.updatePackage("pkg-b", "1.0.1-next.0");
       setup.updateDevDependency("pkg-b", "pkg-a", "1.0.1-next.0");

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -869,6 +869,65 @@ Mixed changesets that contain both ignored and not ignored packages are not allo
       expect(releases[0].newVersion).toEqual("1.0.1");
     });
 
+    it("should always bump dependents when exiting pre-release mode", () => {
+      setup.updatePackage("pkg-a", "1.0.1-next.0");
+      setup.updatePackage("pkg-b", "1.0.1-next.0");
+      setup.updateDevDependency("pkg-b", "pkg-a", "1.0.1-next.0");
+
+      const { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig
+        },
+        {
+          changesets: ["strange-words-combine"],
+          tag: "next",
+          initialVersions: {
+            "pkg-a": "1.0.0",
+            "pkg-b": "1.0.0"
+          },
+          mode: "exit"
+        }
+      );
+
+      expect(releases.length).toEqual(2);
+      expect(releases[0].name).toEqual("pkg-a");
+      expect(releases[0].newVersion).toEqual("1.0.1");
+      expect(releases[1].name).toEqual("pkg-b");
+      expect(releases[1].newVersion).toEqual("1.0.1");
+    });
+
+    it("should not bump dependents when exiting pre-release mode if ignored", () => {
+      setup.updatePackage("pkg-a", "1.0.1-next.0");
+      setup.updatePackage("pkg-b", "1.0.1-next.0");
+      setup.updateDevDependency("pkg-b", "pkg-a", "1.0.1-next.0");
+
+      const { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ignore: ["pkg-b"]
+        },
+        {
+          changesets: ["strange-words-combine"],
+          tag: "next",
+          initialVersions: {
+            "pkg-a": "1.0.0",
+            "pkg-b": "1.0.0"
+          },
+          mode: "exit"
+        }
+      );
+
+      expect(releases.length).toEqual(2);
+      expect(releases[0].name).toEqual("pkg-a");
+      expect(releases[0].newVersion).toEqual("1.0.1");
+      expect(releases[1].name).toEqual("pkg-b");
+      expect(releases[1].newVersion).toEqual("1.0.1-next.0");
+    });
+
     it("should return a release with the highest bump type within the current release despite of having a higher release among previous prereleases", () => {
       // previous release
       setup.addChangeset({

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -140,13 +140,19 @@ function assembleReleasePlan(
       // we want to give it a patch release.
       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
       if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
-        if (!releases.has(pkg.packageJson.name)) {
+        const existingRelease = releases.get(pkg.packageJson.name);
+        if (!existingRelease) {
           releases.set(pkg.packageJson.name, {
             name: pkg.packageJson.name,
             type: "patch",
             oldVersion: pkg.packageJson.version,
             changesets: []
           });
+        } else if (
+          existingRelease.type === "none" &&
+          !config.ignore.includes(pkg.packageJson.name)
+        ) {
+          existingRelease.type = "patch";
         }
       }
     }


### PR DESCRIPTION
We ran into this issue the other day, where if the release plan logic explicitly determines that a packages doesn't needs a bump, it would be ignored when exiting pre-release too.

