### PR TITLE
Update docs/modifying-changelog.format.md

### DIFF
--- a/docs/modifying-changelog-format.md
+++ b/docs/modifying-changelog-format.md
@@ -33,7 +33,7 @@ async function getReleaseLine() {}
 
 async function getDependencyReleaseLine() {}
 
-module.exports {
+module.exports = {
     getReleaseLine,
     getDependencyReleaseLine
 }

--- a/docs/modifying-changelog-format.md
+++ b/docs/modifying-changelog-format.md
@@ -34,9 +34,9 @@ async function getReleaseLine() {}
 async function getDependencyReleaseLine() {}
 
 module.exports = {
-    getReleaseLine,
-    getDependencyReleaseLine
-}
+  getReleaseLine,
+  getDependencyReleaseLine
+};
 ```
 
 These functions are run during the `changeset version` and are expected to return a string (or a promise with a string).


### PR DESCRIPTION
Fix missing `=` in the `module.exports` that is needed