### PR TITLE
Fixed an issue with logging non-stringified Buffers in case of publish errors

### DIFF
--- a/.changeset/chilly-swans-approve.md
+++ b/.changeset/chilly-swans-approve.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Fixed an issue with logging non-stringified Buffers in case of publish errors.

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -214,7 +214,7 @@ async function internalPublish(
       );
     }
 
-    error(stderr);
+    error(stderr.toString());
     return { published: false };
   }
   return { published: true };


### PR DESCRIPTION
fixes https://github.com/changesets/changesets/issues/737

The problem is that all functions in `@changesets/logger` accept `any`s and I think that should be fixed cause it can lead to mistakes like this.

This could be fixed with this patch:
<details>
<summary>patch</summary>

```diff
diff --git a/packages/logger/src/index.ts b/packages/logger/src/index.ts
index d0d3f51..8992673 100644
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -15,22 +15,22 @@ function format(args: Array<any>, customPrefix?: string) {
   );
 }
 
-export function error(...args: Array<any>) {
+export function error(...args: Array<string>) {
   console.error(format(args, chalk.red("error")));
 }
 
-export function info(...args: Array<any>) {
+export function info(...args: Array<string>) {
   console.info(format(args, chalk.cyan("info")));
 }
 
-export function log(...args: Array<any>) {
+export function log(...args: Array<string>) {
   console.log(format(args));
 }
 
-export function success(...args: Array<any>) {
+export function success(...args: Array<string>) {
   console.log(format(args, chalk.green("success")));
 }
 
-export function warn(...args: Array<any>) {
+export function warn(...args: Array<string>) {
   console.warn(format(args, chalk.yellow("warn")));
 }

```
</details>

However, this would require further changes in the codebase and I didn't want to make them right now. Mainly all `.catch`ed errors would become harder to pass to `logger.error`:
https://github.com/changesets/changesets/blob/75c30fc58b236392832fcffc2d64a16ba5ebed02/packages/cli/src/utils/cli-utilities.ts#L84-L86

On the other hand, this is somewhat desirable, because at least we'd have to make the explicit conversion at those call sites. Thoughts?