### PR TITLE
Add some clarification around accidental publishing

### DIFF
--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -103,13 +103,23 @@ changeset publish [--otp={token}]
 
 This publishes changes to npm, and creates git tags. This works by going into each package, checking if the version it has in its `package.json` is published on npm, and if it is not, running the `npm publish`.
 
-**Important:** There is an unintended consequence when doing automatic snapshots on pull requests, please see [snapshot releases](./snapshot-releases.md#automatic-snapshots-on-prs) for more info.
-
 Because this command assumes that last commit is the release commit you should not commit any changes between calling version and publish. These commands are separate to enable you to check if the releases changes are acurate.
 
 `--otp={token}` - allows you to provide an npm one-time password if you have auth and writes enabled on npm. The CLI also prompts for the OTP if it's not provided with the --otp option.
 
 `--tag TAGNAME` - for packages that are published, the chosen tag will be used instead of `latest`, allowing you to publish changes intended for testing and validation, not main consumption. This will most likely be used with [snapshot releases](./snapshot-releases.md).
+
+### Unintended first time publish
+
+You might have a GitHub Action set up that does [automatic snapshots on pull requests](./snapshot-releases.md#automatic-snapshots-on-prs). There is an unintended consequence to this with brand new packages that have never been published to npm before.
+
+`changeset version` and `changeset publish` are decoupled in that no information is shared between them.
+
+`changeset publish` actually doesn't care if a changeset is even generated, it will still publish the version that doesn't exist on npm even if `changeset version` exits because no unreleased changesets were found.
+
+So, if you have automatic snapshots on PRs set up in the repo, and then create a PR adding a brand new package with a version of `0.0.0` in package.json (common scenario when just starting out, a throwaway version number when still in development), the GitHub Action will run on the PR and `changeset publish` will see that `0.0.0` has not been published on npm for this package, and **it will publish that version.**
+
+You can get around this by temporarily marking `private: true` in package.json while setting up the new package, and removing it when you're ready to generate a changeset.
 
 ### Git Tags
 

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -101,25 +101,25 @@ Snapshot is used for a special kind of publishing for testing - it creates tempo
 changeset publish [--otp={token}]
 ```
 
-This publishes changes to npm, and creates git tags. This works by going into each package, checking if the version it has in its `package.json` is published on npm, and if it is not, running the `npm publish`.
+This publishes changes to npm, and creates git tags. The command works by:
+
+- querying current versions in the repository
+- comparing the version it has in its `package.json` with published versions
+- trying to publish what has not been published yet by running `npm publish`
+
+Importantly, `changeset publish` doesn't care about changeset files at all. If invoked, it will still run through the above actions whether a changeset file has been generated or not.
+
+This means an accidental publish can happen if you have an unpublished package (or even an unpublished version of a package), start using Changesets (but don't generate a changeset yet), and use our [changesets/action](https://github.com/changesets/action). If you don't immediately add a changeset file then the first run of the action just calls `changeset publish` and it publishes what has not been published yet. Unfortunately, this means something marked with a throwaway version of say `0.0.0` in package.json would still get published.
+
+You are more likely to run into this if you have a GitHub Action set up that does [automatic snapshots on pull requests](./snapshot-releases.md#automatic-snapshots-on-prs), because running `changeset version && changeset publish` sequentially in CI means that `changeset publish` will run regardless if `changeset version` did anything or exited.
+
+You can get around this behavior by temporarily marking `private: true` in package.json while in development, and removing it when you're ready to generate a changeset and publish the package.
 
 Because this command assumes that last commit is the release commit you should not commit any changes between calling version and publish. These commands are separate to enable you to check if the releases changes are acurate.
 
 `--otp={token}` - allows you to provide an npm one-time password if you have auth and writes enabled on npm. The CLI also prompts for the OTP if it's not provided with the --otp option.
 
 `--tag TAGNAME` - for packages that are published, the chosen tag will be used instead of `latest`, allowing you to publish changes intended for testing and validation, not main consumption. This will most likely be used with [snapshot releases](./snapshot-releases.md).
-
-### Unintended first time publish
-
-You might have a GitHub Action set up that does [automatic snapshots on pull requests](./snapshot-releases.md#automatic-snapshots-on-prs). There is an unintended consequence to this with brand new packages that have never been published to npm before.
-
-`changeset version` and `changeset publish` are decoupled in that no information is shared between them.
-
-`changeset publish` actually doesn't care if a changeset is even generated, it will still publish the version that doesn't exist on npm even if `changeset version` exits because no unreleased changesets were found.
-
-So, if you have automatic snapshots on PRs set up in the repo, and then create a PR adding a brand new package with a version of `0.0.0` in package.json (common scenario when just starting out, a throwaway version number when still in development), the GitHub Action will run on the PR and `changeset publish` will see that `0.0.0` has not been published on npm for this package, and **it will publish that version.**
-
-You can get around this by temporarily marking `private: true` in package.json while setting up the new package, and removing it when you're ready to generate a changeset.
 
 ### Git Tags
 

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -103,6 +103,8 @@ changeset publish [--otp={token}]
 
 This publishes changes to npm, and creates git tags. This works by going into each package, checking if the version it has in its `package.json` is published on npm, and if it is not, running the `npm publish`.
 
+**Important:** There is an unintended consequence when doing automatic snapshots on pull requests, please see [snapshot releases](./snapshot-releases.md#automatic-snapshots-on-prs) for more info.
+
 Because this command assumes that last commit is the release commit you should not commit any changes between calling version and publish. These commands are separate to enable you to check if the releases changes are acurate.
 
 `--otp={token}` - allows you to provide an npm one-time password if you have auth and writes enabled on npm. The CLI also prompts for the OTP if it's not provided with the --otp option.

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -64,6 +64,7 @@ on: pull_request
 jobs:
   publish_prerelease:
     runs-on: ubuntu-latest
+    if: github.repository == 'johndoe/examplerepo' # replace with yours
     steps:
       - uses: actions/checkout@v2
 
@@ -74,8 +75,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Pre-release
         run: |
@@ -85,8 +84,11 @@ jobs:
           yarn changeset publish --tag prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 This will generate a snapshot on each commit to a PR using the commit `SHA`, and publish it under the `prerelease` tag. This is very handy if you need to incrementally test out changes in your PR and don't want to generate snapshots manually for each commit.
 
 There is an **unintended consequence** to this for brand new packages that have never been published to npm before. You can read more about it in the [changeset publish docs](./command-line-options.md#unintended-first-time-publish).
+
+**Please note:** In addition to the repository check (`if: github.repository == ...`), we recommend that you also [turn off workflow runs for forks](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-required-approval-for-workflows-from-public-forks). This will prevent the workflow from running on public forks, unless you approve it.

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -59,16 +59,13 @@ You can automatically generate snapshots on pull requests with GitHub Actions:
 ```yaml
 name: Pre-release
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   publish_prerelease:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
@@ -88,21 +85,8 @@ jobs:
           yarn changeset publish --tag prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 This will generate a snapshot on each commit to a PR using the commit `SHA`, and publish it under the `prerelease` tag. This is very handy if you need to incrementally test out changes in your PR and don't want to generate snapshots manually for each commit.
 
-However, there is an **unintended consequence** to this for brand new packages that have never been published to npm before.
-
-`changeset version` and `changeset publish` are decoupled in that no information is shared between them.
-
-`changeset publish` actually doesn't care if a changeset is even generated, it will still publish the version that doesn't exist on npm even if `changeset version` exits because no unreleased changesets were found.
-
-So, if you have the GitHub Action set up in the repo, and then create a PR adding a brand new package with a version of `0.0.0` in package.json (common scenario when just starting out, a throwaway version number when still in development), the GitHub Action will run on the PR and `changeset publish` will see that `0.0.0` has not been published on npm for this package, and **it will publish that version.**
-
-You can get around this in two ways:
-
-- By temporarily marking `private: true` in package.json while setting up the new package, and removing it when you're ready to generate a changeset.
-
-- By utilizing the [ignore option](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages) temporarily.
+There is an **unintended consequence** to this for brand new packages that have never been published to npm before. You can read more about it in the [changeset publish docs](./command-line-options#unintended-first-time-publish.md).

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -73,7 +73,7 @@ jobs:
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
 
       - name: Install Dependencies
         run: yarn

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -51,3 +51,58 @@ yarn add your-package-name@bulbasaur
 ## What to do with the snapshot branch
 
 In almost all circumstances, we recommend that the changes after you have run `version` get merged back into your main branch. With snapshots, this is not the case. We recommend that you do not push the changes from this running of `version` to any branch. This is because the snapshot is intended for installation only, not to represent the correct published state of the repo. Save the generated version, and the tag you used, but do not push this to a branch you are planning to merge into the main branch, or merge it into the main branch.
+
+## Automatic snapshots on PRs
+
+You can automatically generate snapshots on pull requests with GitHub Actions:
+
+```yaml
+name: Pre-release
+
+on:
+  pull_request:
+
+jobs:
+  publish_prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install Dependencies
+        run: yarn
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish Pre-release
+        run: |
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          COMMIT_SHA_SHORT=$(git rev-parse --short "$COMMIT_SHA")
+          yarn changeset version --snapshot prerelease-$COMMIT_SHA_SHORT
+          yarn changeset publish --tag prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+This will generate a snapshot on each commit to a PR using the commit `SHA`, and publish it under the `prerelease` tag. This is very handy if you need to incrementally test out changes in your PR and don't want to generate snapshots manually for each commit.
+
+However, there is an **unintended consequence** to this for brand new packages that have never been published to npm before.
+
+`changeset version` and `changeset publish` are decoupled in that no information is shared between them.
+
+`changeset publish` actually doesn't care if a changeset is even generated, it will still publish the version that doesn't exist on npm even if `changeset version` exits because no unreleased changesets were found.
+
+So, if you have the GitHub Action set up in the repo, and then create a PR adding a brand new package with a version of `0.0.0` in package.json (common scenario when just starting out, a throwaway version number when still in development), the GitHub Action will run on the PR and `changeset publish` will see that `0.0.0` has not been published on npm for this package, and **it will publish that version.**
+
+You can get around this in two ways:
+
+- By temporarily marking `private: true` in package.json while setting up the new package, and removing it when you're ready to generate a changeset.
+
+- By utilizing the [ignore option](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages) temporarily.

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -89,4 +89,4 @@ jobs:
 
 This will generate a snapshot on each commit to a PR using the commit `SHA`, and publish it under the `prerelease` tag. This is very handy if you need to incrementally test out changes in your PR and don't want to generate snapshots manually for each commit.
 
-There is an **unintended consequence** to this for brand new packages that have never been published to npm before. You can read more about it in the [changeset publish docs](./command-line-options#unintended-first-time-publish.md).
+There is an **unintended consequence** to this for brand new packages that have never been published to npm before. You can read more about it in the [changeset publish docs](./command-line-options.md#unintended-first-time-publish).

--- a/docs/snapshot-releases.md
+++ b/docs/snapshot-releases.md
@@ -90,5 +90,3 @@ jobs:
 This will generate a snapshot on each commit to a PR using the commit `SHA`, and publish it under the `prerelease` tag. This is very handy if you need to incrementally test out changes in your PR and don't want to generate snapshots manually for each commit.
 
 There is an **unintended consequence** to this for brand new packages that have never been published to npm before. You can read more about it in the [changeset publish docs](./command-line-options.md#unintended-first-time-publish).
-
-**Please note:** In addition to the repository check (`if: github.repository == ...`), we recommend that you also [turn off workflow runs for forks](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-required-approval-for-workflows-from-public-forks). This will prevent the workflow from running on public forks, unless you approve it.


### PR DESCRIPTION
Document the possibility of publishing unwanted versions to npm when doing automatic snapshots on PRs.

Ref: https://github.com/changesets/changesets/issues/756