### PR TITLE
Improve the error message when a package referenced in a changeset can't be found

### DIFF
--- a/.changeset/ninety-moose-give.md
+++ b/.changeset/ninety-moose-give.md
@@ -1,0 +1,6 @@
+---
+"@changesets/assemble-release-plan": patch
+"@changesets/cli": patch
+---
+
+Improve the error message when a package referenced in a changeset can't be found. The message will now also include the changeset's ID.

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -21,7 +21,9 @@ export default function flattenReleases(
         let release = releases.get(name);
         let pkg = packagesByName.get(name);
         if (!pkg) {
-          throw new Error(`Could not find package information for ${name}`);
+          throw new Error(
+            `"${changeset.id}" changeset mentions a release for a package "${name}" but such a package could not be found.`
+          );
         }
         if (!release) {
           release = {


### PR DESCRIPTION
prompted by https://github.com/changesets/action/issues/158#issuecomment-1059059078