### PR TITLE
Get correct absolute path of changed files when `.changeset/` is not in the root of the repository

### DIFF
--- a/.changeset/sharp-tools-yell.md
+++ b/.changeset/sharp-tools-yell.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+`changeset add` and `changeset status` should now properly handle the situation where Changesets are managed from a directory different than the root of the repository.

--- a/.changeset/silly-sloths-brush.md
+++ b/.changeset/silly-sloths-brush.md
@@ -2,4 +2,4 @@
 "@changesets/git": patch
 ---
 
-Get correct repository root instead of `cwd`when getting absolute paths of changed files
+`getChangedFilesSince` and `getChangedPackagesSinceRef` will now return the correct absolute paths of the changed files when the passed `cwd` is different from the repository's root.

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -183,14 +183,14 @@ export async function deepenCloneBy({ by, cwd }: { by: number; cwd: string }) {
   await spawn("git", ["fetch", `--deepen=${by}`], { cwd });
 }
 async function getRepoRoot({ cwd }: { cwd: string }) {
-  const { stdout, code } = await spawn(
+  const { stdout, code, stderr } = await spawn(
     "git",
     ["rev-parse", "--show-toplevel"],
     { cwd }
   );
 
   if (code !== 0) {
-    return cwd;
+    throw new Error(stderr.toString());
   }
 
   return stdout

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -217,14 +217,14 @@ export async function getChangedFilesSince({
     );
   }
 
-  const repoRoot = await getRepoRoot({ cwd });
-
   const files = cmd.stdout
     .toString()
     .trim()
     .split("\n")
     .filter(a => a);
   if (!fullPath) return files;
+
+  const repoRoot = await getRepoRoot({ cwd });
   return files.map(file => path.resolve(repoRoot, file));
 }
 


### PR DESCRIPTION
When creating absolute paths from changed files, we assume `cwd` is the repository root but that is not always the case like when .changesets is set in a subfolder. Instead we can ask git for the repository root and create correct absolute path of the files returned from `git diff`