### PR TITLE
Improve distinction bewtween selected and unselected prompt items

### DIFF
--- a/.changeset/green-meals-cough.md
+++ b/.changeset/green-meals-cough.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Improved accessibility of the CLI prompts by using selected/unselected indicators that don't rely solely on the colors.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "@types/is-ci": "^3.0.0",
     "@types/semver": "^6.0.0",
+    "ansi-colors": "^4.1.3",
     "chalk": "^2.1.0",
     "enquirer": "^2.3.0",
     "external-editor": "^3.1.0",

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -3,6 +3,7 @@ import termSize from "term-size";
 import { error, prefix, success } from "@changesets/logger";
 import { prompt } from "enquirer";
 import { edit } from "external-editor";
+import { symbols } from "ansi-colors";
 
 // those types are not exported from `enquirer` so we extract them here
 // so we can make type assertions using them because `enquirer` types do no support `prefix` right now
@@ -60,7 +61,14 @@ async function askCheckboxPlus(
     choices,
     format,
     limit,
-    onCancel: cancelFlow
+    onCancel: cancelFlow,
+    symbols: {
+      indicator: symbols.radioOff,
+      checked: symbols.radioOn
+    },
+    indicator(state: any, choice: any) {
+      return choice.enabled ? state.symbols.checked : state.symbols.indicator;
+    }
   } as ArrayPromptOptions)
     .then((responses: any) => responses[name])
     .catch((err: unknown) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,11 @@
   resolved "https://registry.yarnpkg.com/@changesets/types/-/types-0.4.0.tgz#3413badb2c3904357a36268cb9f8c7e0afc3a804"
   integrity sha512-TclHHKDVYQ8rJGZgVeWiF7c91yWzTTWdPagltgutelGu/Psup5PQlUq6svx7S8suj+jXcaE34yEEsfIvzXXB2Q==
 
+"@changesets/types@^4.0.1":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.1.0.tgz#fb8f7ca2324fd54954824e864f9a61a82cb78fe0"
+  integrity sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -1919,6 +1924,11 @@ ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Fixes #809 

Two alternative ways to distinguish between selected and unselected prompt items.

## Radio on and off

This is the method that is implemented.

![radio-icons](https://user-images.githubusercontent.com/11774595/169668909-935bd51a-2a89-4fbd-90f0-2ea5de158d3a.gif)

## Check and no icon

This is to demonstrate another alternative.

![check-and-no-icon](https://user-images.githubusercontent.com/11774595/169668894-e21a1177-c177-4bc3-94ef-2f57694391e0.gif)

