### PR TITLE
Errors resulting from the GitHub API calls should now be properly raised

### DIFF
--- a/.changeset/tough-rats-sip.md
+++ b/.changeset/tough-rats-sip.md
@@ -1,0 +1,6 @@
+---
+"@changesets/get-github-info": patch
+"@changesets/changelog-github": patch
+---
+
+Errors resulting from the GitHub API calls should now be properly raised.

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -103,7 +103,9 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
   if (data.errors) {
     throw new Error(
       `An error occurred when fetching data from GitHub\n${JSON.stringify(
-        data.errors
+        data.errors,
+        null,
+        2
       )}`
     );
   }

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -58,7 +58,7 @@ function makeQuery(repos: ReposWithCommitsAndPRsToFetch) {
                     mergeCommit {
                       commitUrl
                       abbreviatedOid
-                    }            
+                    }
                   }`
               )
               .join("\n")}
@@ -99,6 +99,14 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     },
     body: JSON.stringify({ query: makeQuery(repos) })
   }).then((x: any) => x.json());
+
+  if (data.errors) {
+    throw new Error(
+      `An error occurred when fetching data from GitHub\n${JSON.stringify(
+        data.errors
+      )}`
+    );
+  }
 
   // this is mainly for the case where there's an authentication problem
   if (!data.data) {


### PR DESCRIPTION
I got a report from @mikearnaldi that `data` can be returned in a shape like this:
```
{
  data: { a0: null },
  errors: [
    {
      type: 'NOT_FOUND',
      path: [Array],
      locations: [Array],
      message: "Could not resolve to a Repository with the name 'repo-tooling/eslint-plugin-dprint'."
    }
  ]
}
```

This is a simple fix to at least make those errors pop up in the CLI logs.