### PR TITLE
Fixed dead link that was missing file extension.

### DIFF
--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -87,7 +87,7 @@ This command is used to allow you to skip packages from being published. This al
 1. If the package is mentioned in a changeset that also includes a package that is not ignored, publishing will fail.
 2. If the package requires one of its dependencies to be updated as part of a publish.
 
-These restrictions exist to ensure your repository or published code do not end up in a broken state. For a more detailed intricacies of publishing, check out our guide on [problems publishing in monorepos](./problems-publishing-in-monorepos).
+These restrictions exist to ensure your repository or published code do not end up in a broken state. For a more detailed intricacies of publishing, check out our guide on [problems publishing in monorepos](./problems-publishing-in-monorepos.md).
 
 ```
 changeset version --snapshot


### PR DESCRIPTION
First link for problems publishing in monorepos is missing file extension and therefore is dead.

Made a quick fix to the link.