### PR TITLE
Attempt to log  when publish fails if  is empty and JSON error can't be retrieved from none of those

### DIFF
--- a/.changeset/silver-toys-turn.md
+++ b/.changeset/silver-toys-turn.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Attempt to log `stdout` when publish fails if `stderr` is empty and JSON error can't be retrieved from none of those.

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -214,7 +214,7 @@ async function internalPublish(
       );
     }
 
-    error(stderr.toString());
+    error(stderr.toString() || stdout.toString());
     return { published: false };
   }
   return { published: true };


### PR DESCRIPTION
closes https://github.com/changesets/action/issues/191