### PR TITLE
Fixed the prerelease version parse

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -16,10 +16,10 @@ import { Packages, Package } from "@manypkg/get-packages";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
 import { PreInfo, InternalRelease } from "./types";
 
-function getPreVersion(version: string) {
-  let parsed = semver.parse(version)!;
+function getPreVersion(version?: string) {
+  let parsed = semver.parse(version);
   let preVersion =
-    parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
+    parsed?.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
   if (typeof preVersion !== "number") {
     throw new InternalError("preVersion is not a number");
   }


### PR DESCRIPTION
fix https://github.com/changesets/changesets/issues/835

when i `pnpm changeset version` after enter prerelease stage ( `pnpm changeset pre enter alpha` ), A private package without version field cause error `error TypeError: Cannot read property 'prerelease' of null`. ( It works if no enter pre )