### PR TITLE
docs: fix changelog config path

### DIFF
--- a/docs/modifying-changelog-format.md
+++ b/docs/modifying-changelog-format.md
@@ -21,7 +21,7 @@ Next, change your `.changeset/config.json` to point to the new package:
 If you want to write your own, you can reference a file path. For example, you can create a new file `.changeset/my-changelog-config.js`, then you can reference it in the `.changeset/config.json` file as:
 
 ```
-"changelog": ".changeset/my-changelog-config.js"
+"changelog": "./my-changelog-config.js"
 ```
 
 ## Writing Changelog Formatting Functions


### PR DESCRIPTION
When you create `.changeset/my-changelog-config.js` to customize the changelog generation function, the import path in the configuration file `.changeset/config.json` should be based on the .changeset directory。
Because `resolveFrom` function params -- `fromDirectory`'s value is `.changeset` directory.
```typescript packages/apply-release-plan/src/index.ts
let changesetPath = path.join(cwd, ".changeset");
let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
```