### PR TITLE
bugfix: ignore ranges when snapshot versioning is performed (use exact version)

### DIFF
--- a/.changeset/stupid-jars-rest.md
+++ b/.changeset/stupid-jars-rest.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+bugfix: ignore ranges when snapshot versioning is performed (use exact version)

--- a/.changeset/stupid-jars-rest.md
+++ b/.changeset/stupid-jars-rest.md
@@ -1,5 +1,6 @@
 ---
+"@changesets/cli": patch
 "@changesets/apply-release-plan": patch
 ---
 
-bugfix: ignore ranges when snapshot versioning is performed (use exact version)
+Fixed an issue with dependency ranges still using pre-existing range modifiers instead of fixed package versions when performing a snapshot release. This ensures that installs of snapshot versions are always reproducible.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -74,11 +74,8 @@ async function testSetup(
   fixtureName: string,
   releasePlan: ReleasePlan,
   config?: Config,
-  setupFunc?: (tempDir: string) => Promise<any>,
-  snapshotConfig?: {
-    snapshot: string | undefined;
-    useCalculatedVersionForSnapshots: boolean;
-  }
+  snapshot?: string | undefined,
+  setupFunc?: (tempDir: string) => Promise<any>
 ) {
   if (!config) {
     config = {
@@ -93,8 +90,7 @@ async function testSetup(
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
         updateInternalDependents: "out-of-range",
-        useCalculatedVersionForSnapshots:
-          snapshotConfig?.useCalculatedVersionForSnapshots ?? false
+        useCalculatedVersionForSnapshots: false
       }
     };
   }
@@ -114,7 +110,7 @@ async function testSetup(
       releasePlan,
       await getPackages(tempDir),
       config,
-      snapshotConfig?.snapshot
+      snapshot
     ),
     tempDir
   };
@@ -682,11 +678,7 @@ describe("apply release plan", () => {
         "simple-project-caret-dep",
         releasePlan.getReleasePlan(),
         releasePlan.config,
-        undefined,
-        {
-          snapshot: "canary",
-          useCalculatedVersionForSnapshots: false
-        }
+        "canary"
       );
 
       let pkgPath = changedFiles.find(a =>
@@ -2139,6 +2131,7 @@ describe("apply release plan", () => {
         "simple-project",
         releasePlan.getReleasePlan(),
         releasePlan.config,
+        undefined,
         setupFunc
       );
 
@@ -2165,6 +2158,7 @@ describe("apply release plan", () => {
         "simple-project",
         releasePlan.getReleasePlan(),
         { ...releasePlan.config, ignore: ["pkg-a"] },
+        undefined,
         setupFunc
       );
 
@@ -2207,6 +2201,7 @@ describe("apply release plan", () => {
         "simple-project",
         releasePlan.getReleasePlan(),
         releasePlan.config,
+        undefined,
         setupFunc
       );
 
@@ -2263,6 +2258,7 @@ describe("apply release plan", () => {
           null
         ]
       },
+      undefined,
       setupFunc
     );
 
@@ -2345,6 +2341,7 @@ describe("apply release plan", () => {
             null
           ]
         },
+        undefined,
         setupFunc
       );
 

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -111,14 +111,19 @@ export default async function applyReleasePlan(
 
   // iterate over releases updating packages
   let finalisedRelease = releaseWithChangelogs.map(release => {
-    return versionPackage(release, versionsToUpdate, {
-      updateInternalDependencies: config.updateInternalDependencies,
-      onlyUpdatePeerDependentsWhenOutOfRange:
-        config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          .onlyUpdatePeerDependentsWhenOutOfRange,
-      bumpVersionsWithWorkspaceProtocolOnly:
-        config.bumpVersionsWithWorkspaceProtocolOnly
-    });
+    return versionPackage(
+      release,
+      versionsToUpdate,
+      {
+        updateInternalDependencies: config.updateInternalDependencies,
+        onlyUpdatePeerDependentsWhenOutOfRange:
+          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+            .onlyUpdatePeerDependentsWhenOutOfRange,
+        bumpVersionsWithWorkspaceProtocolOnly:
+          config.bumpVersionsWithWorkspaceProtocolOnly
+      },
+      snapshot
+    );
   });
 
   let prettierConfig = await prettier.resolveConfig(cwd);

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -111,19 +111,15 @@ export default async function applyReleasePlan(
 
   // iterate over releases updating packages
   let finalisedRelease = releaseWithChangelogs.map(release => {
-    return versionPackage(
-      release,
-      versionsToUpdate,
-      {
-        updateInternalDependencies: config.updateInternalDependencies,
-        onlyUpdatePeerDependentsWhenOutOfRange:
-          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-            .onlyUpdatePeerDependentsWhenOutOfRange,
-        bumpVersionsWithWorkspaceProtocolOnly:
-          config.bumpVersionsWithWorkspaceProtocolOnly
-      },
+    return versionPackage(release, versionsToUpdate, {
+      updateInternalDependencies: config.updateInternalDependencies,
+      onlyUpdatePeerDependentsWhenOutOfRange:
+        config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+          .onlyUpdatePeerDependentsWhenOutOfRange,
+      bumpVersionsWithWorkspaceProtocolOnly:
+        config.bumpVersionsWithWorkspaceProtocolOnly,
       snapshot
-    );
+    });
   });
 
   let prettierConfig = await prettier.resolveConfig(cwd);

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -24,13 +24,14 @@ export default function versionPackage(
   {
     updateInternalDependencies,
     onlyUpdatePeerDependentsWhenOutOfRange,
-    bumpVersionsWithWorkspaceProtocolOnly
+    bumpVersionsWithWorkspaceProtocolOnly,
+    snapshot
   }: {
     updateInternalDependencies: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
-  },
-  snapshot?: string | boolean | undefined
+    snapshot?: string | boolean | undefined;
+  }
 ) {
   let { newVersion, packageJson } = release;
 

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -92,8 +92,9 @@ export default function versionPackage(
           // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
           semver.prerelease(version) !== null
         ) {
-          let rangeType = getVersionRangeType(depCurrentVersion);
-          let newNewRange = snapshot ? version : `${rangeType}${version}`;
+          let newNewRange = snapshot
+            ? version
+            : `${getVersionRangeType(depCurrentVersion)}${version}`;
           if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
           deps[name] = newNewRange;
         }

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -29,7 +29,8 @@ export default function versionPackage(
     updateInternalDependencies: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
-  }
+  },
+  snapshot?: string | boolean | undefined
 ) {
   let { newVersion, packageJson } = release;
 
@@ -92,7 +93,7 @@ export default function versionPackage(
           semver.prerelease(version) !== null
         ) {
           let rangeType = getVersionRangeType(depCurrentVersion);
-          let newNewRange = `${rangeType}${version}`;
+          let newNewRange = snapshot ? version : `${rangeType}${version}`;
           if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
           deps[name] = newNewRange;
         }


### PR DESCRIPTION

Related: https://github.com/changesets/changesets/issues/855