### PR TITLE
fix: use correct prettier configuration

### DIFF
--- a/.changeset/flat-jars-talk.md
+++ b/.changeset/flat-jars-talk.md
@@ -1,0 +1,6 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/write": patch
+---
+
+Fix prettier configuration file resolution using correct path

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -122,8 +122,6 @@ export default async function applyReleasePlan(
     });
   });
 
-  let prettierConfig = await prettier.resolveConfig(cwd);
-
   for (let release of finalisedRelease) {
     let { changelog, packageJson, dir, name } = release;
 
@@ -133,6 +131,7 @@ export default async function applyReleasePlan(
 
     if (changelog && changelog.length > 0) {
       const changelogPath = path.resolve(dir, "CHANGELOG.md");
+      const prettierConfig = await prettier.resolveConfig(changelogPath);
       await updateChangelog(changelogPath, changelog, name, prettierConfig);
       touchedFiles.push(changelogPath);
     }

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -19,9 +19,8 @@ async function writeChangeset(
     capitalize: false
   });
 
-  const prettierConfig = await prettier.resolveConfig(cwd);
-
   const newChangesetPath = path.resolve(changesetBase, `${changesetID}.md`);
+  const prettierConfig = await prettier.resolveConfig(newChangesetPath);
 
   // NOTE: The quotation marks in here are really important even though they are
   // not spec for yaml. This is because package names can contain special


### PR DESCRIPTION
### Problem

Using `overrides` in `prettierrc.js` doesn't work on generated files. It is an issue for us, as we want a specific configuration for changesets generated files (large `printWidth`).

### Why

We use `cwd` to resolve the current configuration file. The configuration object returned doesn't resolve overrides as it doesn't match anything.

`.prettierrc.js`
```js
{
  printWidth: 120,
  overrides: [
    {
      files: '*.md',
      options: {
        printWidth: 300,
      },
    },
  ],
}
```

Resolved configuration object using `cwd`:
```js
{
  printWidth: 120,
}
```

### Fix

Resolve configuration's file specific to the current file path.

Resolved configuration object using file path:
```js
{
  printWidth: 300,
}
```

