### PR TITLE
Fix: Log errors if git tag fails during publish

### DIFF
--- a/.changeset/plenty-colts-join.md
+++ b/.changeset/plenty-colts-join.md
@@ -1,0 +1,6 @@
+---
+"@changesets/git": patch
+"@changesets/cli": patch
+---
+
+Fix tag step in `changeset publish` so it can display errors as well as successful operations.

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -78,16 +78,22 @@ export default async function run(
       // won't suffer from a race condition if another merge happens in the mean time (pushing tags won't
       // fail if we are behind the base branch).
       log(`Creating git tag${successful.length > 1 ? "s" : ""}...`);
+
+      const tagAndLogSuccess = async (tag: string) => {
+        const isSuccessful = await git.tag(tag, cwd);
+        isSuccessful === true
+          ? log("New tag: ", tag)
+          : error("Unable to create git tag:", tag);
+      };
+
       if (tool !== "root") {
         for (const pkg of successful) {
           const tag = `${pkg.name}@${pkg.newVersion}`;
-          log("New tag: ", tag);
-          await git.tag(tag, cwd);
+          await tagAndLogSuccess(tag);
         }
       } else {
         const tag = `v${successful[0].newVersion}`;
-        log("New tag: ", tag);
-        await git.tag(tag, cwd);
+        await tagAndLogSuccess(tag);
       }
     }
   }

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -199,6 +199,20 @@ describe("git", () => {
       expect(tagRef).toEqual(head);
     });
 
+    it("should log error and return false if git command fails", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementationOnce(() => {});
+
+      const resultSuccess = await tag("v1", cwd);
+      const resultFail = await tag("v1", cwd);
+
+      expect(consoleSpy).toBeCalledTimes(1);
+      expect(consoleSpy).toBeCalledWith("fatal: tag 'v1' already exists");
+      expect(resultSuccess).toBe(true);
+      expect(resultFail).toBe(false);
+    });
+
     it("should create a tag, make a new commit, then create a second tag", async () => {
       const initialHead = await spawn("git", ["rev-parse", "HEAD"], {
         cwd

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -45,7 +45,14 @@ export async function getAllTags(cwd: string): Promise<Set<string>> {
 export async function tag(tagStr: string, cwd: string) {
   // NOTE: it's important we use the -m flag to create annotated tag otherwise 'git push --follow-tags' won't actually push
   // the tags
-  const gitCmd = await spawn("git", ["tag", tagStr, "-m", tagStr], { cwd });
+  const gitCmd = await spawn("git", ["tag", tagStr, "-m", tagStr], {
+    cwd
+  });
+
+  if (gitCmd.code !== 0) {
+    console.error(gitCmd.stderr.toString().trim());
+  }
+
   return gitCmd.code === 0;
 }
 


### PR DESCRIPTION
This PR adds better error logging, and will make `changeset publish` only show "tag created" on success. Under the previous logic, the following error from `git tag` was being suppressed, making  something like this hard to debug:
```
--
await tag("v1", cwd)
await tag("v1", cwd)

// => "fatal: tag 'v1' already exists"
```
 
... or errors like this (which can happen because the `git.tag` method uses _annotated_ tags):
```

*** Please tell me who you are.
 
Run
 
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
 
to set your account's default identity.
Omit --global to set the identity only in this repository.
 
fatal: empty ident name (for <buildkite-agent@localhost>) not allowed

```

