### PR TITLE
Fix: skip generating changelogs when config.changelog is set to false

### DIFF
--- a/.changeset/friendly-vans-hammer.md
+++ b/.changeset/friendly-vans-hammer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Include the information about `false` being a valid value for the `changelog` option in the validation message for the `changelog` option.

--- a/.changeset/mean-mugs-return.md
+++ b/.changeset/mean-mugs-return.md
@@ -1,0 +1,6 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/config": patch
+---
+
+Fix: skip generating changelogs when config.changelog is set to false

--- a/.changeset/mean-mugs-return.md
+++ b/.changeset/mean-mugs-return.md
@@ -1,6 +1,6 @@
 ---
 "@changesets/apply-release-plan": patch
-"@changesets/config": patch
+"@changesets/cli": patch
 ---
 
-Fix: skip generating changelogs when config.changelog is set to false
+Fixed an issue with generating changelogs not being skipped when the `changelog` config option was set to `false`.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -1465,11 +1465,9 @@ describe("apply release plan", () => {
         }
       );
 
-      let readmePath = changedFiles.find(a =>
-        a.endsWith(`pkg-a${path.sep}CHANGELOG.md`)
-      );
-
-      if (readmePath) throw new Error(`should not have found a changelog`);
+      expect(
+        changedFiles.find(a => a.endsWith(`pkg-a${path.sep}CHANGELOG.md`))
+      ).toBeUndefined();
     });
     it("should update a changelog for one package", async () => {
       const releasePlan = new FakeReleasePlan();

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -1454,6 +1454,23 @@ describe("apply release plan", () => {
     });
   });
   describe("changelogs", () => {
+    it("should not generate any changelogs", async () => {
+      const releasePlan = new FakeReleasePlan();
+      let { changedFiles } = await testSetup(
+        "simple-project",
+        releasePlan.getReleasePlan(),
+        {
+          ...releasePlan.config,
+          changelog: false
+        }
+      );
+
+      let readmePath = changedFiles.find(a =>
+        a.endsWith(`pkg-a${path.sep}CHANGELOG.md`)
+      );
+
+      if (readmePath) throw new Error(`should not have found a changelog`);
+    });
     it("should update a changelog for one package", async () => {
       const releasePlan = new FakeReleasePlan();
       let { changedFiles } = await testSetup(

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -180,9 +180,13 @@ async function getNewChangelogEntry(
   config: Config,
   cwd: string
 ) {
-  // Skip generating changelog entries if config.changelog is false
   if (!config.changelog) {
-    return releasesWithPackage;
+    return Promise.resolve(
+      releasesWithPackage.map(release => ({
+        ...release,
+        changelog: null
+      }))
+    );
   }
 
   let getChangelogFuncs: ChangelogFunctions = {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -180,28 +180,31 @@ async function getNewChangelogEntry(
   config: Config,
   cwd: string
 ) {
+  // Skip generating changelog entries if config.changelog is false
+  if (!config.changelog) {
+    return releasesWithPackage;
+  }
+
   let getChangelogFuncs: ChangelogFunctions = {
     getReleaseLine: () => Promise.resolve(""),
     getDependencyReleaseLine: () => Promise.resolve("")
   };
-  let changelogOpts: any;
-  if (config.changelog) {
-    changelogOpts = config.changelog[1];
-    let changesetPath = path.join(cwd, ".changeset");
-    let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
 
-    let possibleChangelogFunc = require(changelogPath);
-    if (possibleChangelogFunc.default) {
-      possibleChangelogFunc = possibleChangelogFunc.default;
-    }
-    if (
-      typeof possibleChangelogFunc.getReleaseLine === "function" &&
-      typeof possibleChangelogFunc.getDependencyReleaseLine === "function"
-    ) {
-      getChangelogFuncs = possibleChangelogFunc;
-    } else {
-      throw new Error("Could not resolve changelog generation functions");
-    }
+  const changelogOpts = config.changelog[1];
+  let changesetPath = path.join(cwd, ".changeset");
+  let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
+
+  let possibleChangelogFunc = require(changelogPath);
+  if (possibleChangelogFunc.default) {
+    possibleChangelogFunc = possibleChangelogFunc.default;
+  }
+  if (
+    typeof possibleChangelogFunc.getReleaseLine === "function" &&
+    typeof possibleChangelogFunc.getDependencyReleaseLine === "function"
+  ) {
+    getChangelogFuncs = possibleChangelogFunc;
+  } else {
+    throw new Error("Could not resolve changelog generation functions");
   }
 
   let commits = await getCommitsThatAddChangesets(

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -337,7 +337,7 @@ describe("parser errors", () => {
       unsafeParse({ changelog: {} }, defaultPackages);
     }).toThrowErrorMatchingInlineSnapshot(`
 "Some errors occurred when validating the changesets config:
-The \`changelog\` option is set as {} when the only valid values are undefined, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
+The \`changelog\` option is set as {} when the only valid values are undefined, false, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
 `);
   });
   test("changelog array with 3 values", () => {
@@ -352,7 +352,7 @@ The \`changelog\` option is set as [
   \\"some-module\\",
   \\"something\\",
   \\"other\\"
-] when the only valid values are undefined, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
+] when the only valid values are undefined, false, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
 `);
   });
   test("changelog array with first value not string", () => {
@@ -363,7 +363,7 @@ The \`changelog\` option is set as [
 The \`changelog\` option is set as [
   false,
   \\"something\\"
-] when the only valid values are undefined, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
+] when the only valid values are undefined, false, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
 `);
   });
   test("access other string", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -116,7 +116,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         json.changelog,
         null,
         2
-      )} when the only valid values are undefined, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])`
+      )} when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])`
     );
   }
 


### PR DESCRIPTION
Closes https://github.com/changesets/changesets/issues/896