### PR TITLE
Fix(cli): add last newline in the end of default config

### DIFF
--- a/.changeset/hungry-spiders-check.md
+++ b/.changeset/hungry-spiders-check.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-Add newline at the end of the default config file.
+Add a new line at the end of the default config file when invoking `changeset init`.

--- a/.changeset/hungry-spiders-check.md
+++ b/.changeset/hungry-spiders-check.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-Add a new line at the end of the default config file when invoking `changeset init`.
+Add a new line at the end of the default config file generated when invoking `changeset init`.

--- a/.changeset/hungry-spiders-check.md
+++ b/.changeset/hungry-spiders-check.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Add newline at the end of the default config file.

--- a/packages/cli/src/commands/init/__tests__/command.ts
+++ b/packages/cli/src/commands/init/__tests__/command.ts
@@ -37,6 +37,18 @@ describe("init", () => {
       { ...defaultWrittenConfig, baseBranch: "main" }
     );
   });
+  it("should add newline at the end of config", async () => {
+    const cwd = await f.copy("simple-project");
+    await fs.remove(path.join(cwd, ".changeset/config.json"));
+
+    await initializeCommand(cwd);
+
+    const configPath = path.join(cwd, ".changeset/config.json");
+    const config = (await fs.promises.readFile(configPath)).toString();
+    const lastCharacter = config.slice(-1);
+
+    expect(lastCharacter).toBe("\n");
+  });
   it("shouldn't overwrite a config if it does exist", async () => {
     const cwd = await f.copy("simple-project");
     await fs.writeJson(path.join(cwd, ".changeset/config.json"), {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -9,11 +9,11 @@ const pkgPath = path.dirname(require.resolve("@changesets/cli/package.json"));
 
 // Modify base branch to "main" without changing defaultWrittenConfig since it also serves as a fallback
 // for config files that don't specify a base branch. Changing that to main would be a breaking change.
-const defaultConfig = JSON.stringify(
+const defaultConfig = `${JSON.stringify(
   { ...defaultWrittenConfig, baseBranch: "main" },
   null,
   2
-);
+)}\n`;
 
 export default async function init(cwd: string) {
   const changesetBase = path.resolve(cwd, ".changeset");


### PR DESCRIPTION
## Affected Packages
- Cli

## Problem

When using the `init` command, default config file has no newline at the end of a file. Github will complain about it in a Pull Request (screenshot below).

![image](https://user-images.githubusercontent.com/596195/191189723-826fb988-3833-4599-ae77-3e16b7a2b56e.png)

## Solution

Add the newline in the end of config file.
