### PR TITLE
fix: fix version compare problem during prerelease

### DIFF
--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -36,7 +36,7 @@ export function shouldUpdateDependencyBasedOnConfig(
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ): boolean {
-  if (!semver.satisfies(release.version, depVersionRange)) {
+  if (!semver.satisfies(release.version, depVersionRange, { includePrerelease: true })) {
     // Dependencies leaving semver range should always be updated
     return true;
   }

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -88,7 +88,8 @@ export default function determineDependents({
                 .updateInternalDependents === "always" ||
                 !semver.satisfies(
                   incrementVersion(nextRelease, preInfo),
-                  versionRange
+                  versionRange,
+                  { includePrerelease: true }
                 ))
             ) {
               switch (depType) {
@@ -233,7 +234,8 @@ function shouldBumpMajor({
     (!onlyUpdatePeerDependentsWhenOutOfRange ||
       !semver.satisfies(
         incrementVersion(nextRelease, preInfo),
-        versionRange
+        versionRange,
+        { includePrerelease: true }
       )) &&
     // bump major only if the dependent doesn't already has a major release.
     (!releases.has(dependent) ||


### PR DESCRIPTION
After configuring `onlyUpdatePeerDependentsWhenOutOfRange=true`, changsets need to compare version numbers to determine if they are out of range. However, `{ includePrerelease: true }` is not passed when calling `semver.satisfies`, resulting in unexpected results when using the prerelease version.