### PR TITLE
fix(changelog-git): typo on variable name

### DIFF
--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -37,11 +37,11 @@ const getDependencyReleaseLine = async (
       }`
   );
 
-  const updatedDependencies = dependenciesUpdated.map(
+  const updatedDependenciesList = dependenciesUpdated.map(
     (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
   );
 
-  return [...changesetLinks, ...updatedDependencies].join("\n");
+  return [...changesetLinks, ...updatedDependenciesList].join("\n");
 };
 
 const defaultChangelogFunctions: ChangelogFunctions = {

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -37,11 +37,11 @@ const getDependencyReleaseLine = async (
       }`
   );
 
-  const updatedDepenenciesList = dependenciesUpdated.map(
+  const updatedDependencies = dependenciesUpdated.map(
     (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
   );
 
-  return [...changesetLinks, ...updatedDepenenciesList].join("\n");
+  return [...changesetLinks, ...updatedDependencies].join("\n");
 };
 
 const defaultChangelogFunctions: ChangelogFunctions = {


### PR DESCRIPTION
In this pr, fixed a typo in a variable name. It is a really very small change that does not affect any functionality or process.
