### PR TITLE
fix: Support monorepos with no root package

### DIFF
--- a/.changeset/slow-berries-tie.md
+++ b/.changeset/slow-berries-tie.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-dependents-graph": patch
+---
+
+Monorepo tools that do not have a root package.json file are now supported.

--- a/packages/get-dependents-graph/src/get-dependency-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.test.ts
@@ -115,4 +115,32 @@ describe("getting the dependency graph", function () {
       `);
     })
   );
+
+  it("succeeds when there is no root package", function () {
+    const { graph, valid } = getDependencyGraph({
+      packages: [
+        {
+          dir: "foo",
+          packageJson: {
+            name: "foo",
+            version: "1.0.0",
+            dependencies: {
+              bar: "workspace:*",
+            },
+          },
+        },
+        {
+          dir: "bar",
+          packageJson: {
+            name: "bar",
+            version: "1.0.0",
+          },
+        },
+      ],
+      tool: "pnpm",
+    });
+    expect(graph.get("foo")!.dependencies).toEqual(["bar"]);
+    expect(valid).toBeTruthy();
+    expect((console.error as any).mock.calls).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -63,11 +63,13 @@ export default function getDependencyGraph(
   >();
   let valid = true;
 
-  const packagesByName: { [key: string]: Package } = {
-    [packages.root.packageJson.name]: packages.root,
-  };
+  const packagesByName: { [key: string]: Package } = {};
+  const queue: Package[] = [];
 
-  const queue = [packages.root];
+  if (packages.root && packages.root.packageJson) {
+    queue.push(packages.root);
+    packagesByName[packages.root.packageJson.name] = packages.root;
+  };
 
   for (const pkg of packages.packages) {
     queue.push(pkg);

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -66,9 +66,9 @@ export default function getDependencyGraph(
   const packagesByName: { [key: string]: Package } = {};
   const queue: Package[] = [];
 
-  if (packages.root && packages.root.packageJson) {
-    queue.push(packages.root);
-    packagesByName[packages.root.packageJson.name] = packages.root;
+  if (packages.rootPackage && packages.rootPackage.packageJson) {
+    queue.push(packages.rootPackage);
+    packagesByName[packages.rootPackage.packageJson.name] = packages.rootPackage;
   };
 
   for (const pkg of packages.packages) {


### PR DESCRIPTION
### SUMMARY

 - Do not require a "root package.json" when calculating the dependency graph

(Related issues: #1025)

### DETAILS

This change prepares the way for support for monorepo tools like Rush, which do not have a root package.json file.

> **NOTE:** Intended to merge after the type changes coming in https://github.com/Thinkmill/manypkg/pull/151. As-is, the unit tests pass but this change would fail tsc compilation.

