### PR TITLE
Fetch only current HEAD when deepen clone

### DIFF
--- a/.changeset/small-pears-explode.md
+++ b/.changeset/small-pears-explode.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": patch
+---
+
+Fetch only current HEAD when deepen clone

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -168,7 +168,7 @@ export async function isRepoShallow({ cwd }: { cwd: string }) {
 }
 
 export async function deepenCloneBy({ by, cwd }: { by: number; cwd: string }) {
-  await spawn("git", ["fetch", `--deepen=${by}`], { cwd });
+  await spawn("git", ["fetch", `--deepen=${by}`, `origin`, `HEAD`], { cwd });
 }
 async function getRepoRoot({ cwd }: { cwd: string }) {
   const { stdout, code, stderr } = await spawn(


### PR DESCRIPTION
I also face issue #571 at work's CI, but I could work around it by doing this. 

The failure I face is at `deepenCloneBy`. Because my work's repo is huge (lots of commits, branches, and tags), we only use shallow clone at CI jobs. While integrating with Changesets in CI, running `git fetch --deepenBy=50` will fail because apparently it fetches from all branches and the git server at our CI couldn't handle such a huge request in time (i.e. will timeout), and the job will stuck in infinite loop due to #571. 

This change makes changesets to only deepen clone from current HEAD only. I feel that it makes sense too, since the purpose of the usage (`getCommitsThatAddFiles`) is to deepen current branch until it found the relevant commits.

What do you think?

Thanks