### PR TITLE
chore: Fix a package name typo

### DIFF
--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -1,8 +1,7 @@
-# @changests/git
+# @changesets/git
 
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/git)
 
-A collection of helper functions used internally in changesets to
-make git operations easier.
+A collection of helper functions used internally in changesets to make git operations easier.
 
 Published documentation is likely to remain sparse.


### PR DESCRIPTION
### SUMMARY

 - Fix a small typo in `README` for `@changesets/git`.
 - No version bump (will wait for next real code change).

### DETAILS

 - Change originally suggested in PR #637.

