### PR TITLE
Reference correct CLI flag in docs

### DIFF
--- a/docs/checking-for-changesets.md
+++ b/docs/checking-for-changesets.md
@@ -7,5 +7,5 @@ We have a [github bot](https://github.com/apps/changeset-bot) and a
 [bitbucket addon](https://bitbucket.org/atlassian/atlaskit-mk-2/src/master/build/bitbucket-release-addon/) that
 alert users of missing changesets.
 
-If you want to cause a failure in CI on missing changesets (not recommended), you can run `changeset status --since-master`,
+If you want to cause a failure in CI on missing changesets (not recommended), you can run `changeset status --since=master`,
 which will exit with a status code of 1 if there are no new changesets.


### PR DESCRIPTION
I was following the docs and hit a warning when running the command:

```sh
$ npx changeset status --since-master
🦋  warn --sinceMaster is deprecated and will be removed in a future major version
🦋  warn Use --since=master instead
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
```

`--since=master` seems to be correct:

```
$ npx changeset status --since=master
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
```