### PR TITLE
Skip ignored packages when running `changeset tag`

### DIFF
--- a/.changeset/eleven-parrots-laugh.md
+++ b/.changeset/eleven-parrots-laugh.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Skip ignored packages when running `changeset tag`

--- a/packages/cli/src/commands/tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/tag/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import * as git from "@changesets/git";
+import { defaultConfig } from "@changesets/config";
 import tag from "../index";
 
 jest.mock("@changesets/git");
@@ -30,7 +31,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(2);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
       expect((git.tag as jest.Mock).mock.calls[1][0]).toEqual("pkg-b@1.0.0");
@@ -63,7 +64,7 @@ describe("tag command", () => {
       );
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-b@1.0.0");
     });
@@ -81,7 +82,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("v1.0.0");
     });

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,13 +1,19 @@
 import * as git from "@changesets/git";
 import { getPackages } from "@manypkg/get-packages";
 import { log } from "@changesets/logger";
+import { Config } from "@changesets/types";
+import { isListablePackage } from "../add/isListablePackage";
 
-export default async function run(cwd: string) {
+export default async function run(cwd: string, config: Config) {
   const { packages, tool } = await getPackages(cwd);
+
+  const listablePackages = packages.filter((pkg) =>
+    isListablePackage(config, pkg.packageJson)
+  );
 
   const allExistingTags = await git.getAllTags(cwd);
 
-  for (const pkg of packages) {
+  for (const pkg of listablePackages) {
     const tag =
       tool !== "root"
         ? `${pkg.packageJson.name}@${pkg.packageJson.version}`

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -179,7 +179,7 @@ export async function run(
         return;
       }
       case "tag": {
-        await tagCommand(cwd);
+        await tagCommand(cwd, config);
         return;
       }
       case "pre": {


### PR DESCRIPTION
Use the same ignore logic as the `add` command in the `tag` command.

This fixes #833