### PR TITLE
feat: add getVersionLine to changelog functions, update docs

### DIFF
--- a/.changeset/cyan-geese-play.md
+++ b/.changeset/cyan-geese-play.md
@@ -1,0 +1,8 @@
+---
+"@changesets/apply-release-plan": minor
+---
+
+Add optional `getVersionLine` changelog function
+
+- By making the version line configurable, it becomes possible for users to override the default display to add a date, or a github tag range like standard-version does
+- This allows users who are doing continuous deploy to implement version-then-publish, without creating risk for other changeset users

--- a/.changeset/great-coats-draw.md
+++ b/.changeset/great-coats-draw.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-github-info": patch
+---
+
+fix crash when github cannot find the commit SHA

--- a/.changeset/popular-boats-behave.md
+++ b/.changeset/popular-boats-behave.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": minor
+---
+
+add typing for `getVersionLine`

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -141,7 +141,9 @@ This option is for setting how the changelog for packages should be generated. I
 ```
 {
   getReleaseLine,
-  getDependencyReleaseLine
+  getDependencyReleaseLine,
+  // and, optionally
+  getVersionLine,
 }
 ```
 

--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -15,7 +15,7 @@ Several of these have associated type definitions, which you can find in [our ty
   - (2) The act of updating a package version to a new version.
 - **single-package repo** - A repository which only contains a single package which is at the root of the repo
 - **multi-package repo/monorepo** - A repository which contains multiple packages, generally managed by [Bolt](https://github.com/boltpkg/bolt) or [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/).
-- **release line generators** - The `getReleaseLine` and `getDependencyReleaseLine` functions which are responsible for creating the lines inserted into changelog. A changelog entry for a particular release can be thought of as `releaseLineGenerators(changesets)`
+- **release line generators** - The `getReleaseLine` and `getDependencyReleaseLine` and (optionally) `getVersionLine` functions which are responsible for creating the lines inserted into changelog. A changelog entry for a particular release can be thought of as `releaseLineGenerators(changesets)`
 - **fixed packages** - Fixed packages share a semver categorisation, such that all fixed packages have the same semver version and are always published together. The logistics of this are best left to our [fixed-packages](./fixed-packages.md) documentation.
 - **linked packages** - Linked packages share a semver categorisation, such that all published linked packages have consistent new semver ranges. The logistics of this are best left to our [linked-packages](./linked-packages.md) documentation.
 - **release instruction** An object containing an intent to release a single package, consisting of the package name and a bump type

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -99,7 +99,11 @@ export default async function getChangelogEntry(
   );
 
   return [
-    `## ${release.newVersion}`,
+    `## ${
+      changelogFuncs.getVersionLine
+        ? await changelogFuncs.getVersionLine(release, changelogOpts)
+        : release.newVersion
+    }`,
     await generateChangesForVersionTypeMarkdown(changelogLines, "major"),
     await generateChangesForVersionTypeMarkdown(changelogLines, "minor"),
     await generateChangesForVersionTypeMarkdown(changelogLines, "patch"),

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2261,6 +2261,113 @@ describe("apply release plan", () => {
         - pkg-a@1.0.4`);
     });
 
+    it("should call changelog functions", async () => {
+      let { changedFiles } = await testSetup(
+        {
+          "package.json": JSON.stringify({
+            private: true,
+            workspaces: ["packages/*"],
+          }),
+          "packages/pkg-a/package.json": JSON.stringify({
+            name: "pkg-a",
+            version: "1.0.3",
+            dependencies: {
+              "pkg-b": "~1.2.0",
+            },
+          }),
+          "packages/pkg-b/package.json": JSON.stringify({
+            name: "pkg-b",
+            version: "1.2.0",
+            dependencies: {
+              "pkg-a": "^1.0.3",
+            },
+          }),
+        },
+        {
+          changesets: [
+            {
+              id: "quick-lions-devour",
+              summary: "Hey, let's have fun with testing!",
+              releases: [
+                { name: "pkg-a", type: "patch" },
+                { name: "pkg-b", type: "patch" },
+              ],
+            },
+          ],
+          releases: [
+            {
+              name: "pkg-a",
+              type: "patch",
+              oldVersion: "1.0.3",
+              newVersion: "1.0.4",
+              changesets: ["quick-lions-devour"],
+            },
+            {
+              name: "pkg-b",
+              type: "patch",
+              oldVersion: "1.2.0",
+              newVersion: "1.2.1",
+              changesets: ["quick-lions-devour"],
+            },
+          ],
+          preState: undefined,
+        },
+        {
+          changelog: [
+            path.resolve(__dirname, "test-utils/changelog-functions.ts"),
+            null,
+          ],
+          commit: false,
+          fixed: [],
+          linked: [],
+          access: "restricted",
+          changedFilePatterns: ["**"],
+          baseBranch: "main",
+          updateInternalDependencies: "patch",
+          ignore: [],
+          privatePackages: { version: true, tag: false },
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
+          },
+          snapshot: {
+            useCalculatedVersion: false,
+            prereleaseTemplate: null,
+          },
+        }
+      );
+
+      let readmePath = changedFiles.find((a) =>
+        a.endsWith(`pkg-a${path.sep}CHANGELOG.md`)
+      );
+      let readmePathB = changedFiles.find((a) =>
+        a.endsWith(`pkg-b${path.sep}CHANGELOG.md`)
+      );
+
+      if (!readmePath || !readmePathB)
+        throw new Error(`could not find an updated changelog`);
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
+
+      expect(readme.trim()).toEqual(outdent`# pkg-a
+
+      ## version line
+
+      ### Patch Changes
+
+      release line
+      dependency release line`);
+
+      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+
+      ## version line
+
+      ### Patch Changes
+
+      release line
+      dependency release line`);
+    });
+
     it("should NOT add updated dependencies line if dependencies have NOT been updated", async () => {
       let { changedFiles } = await testSetup(
         {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -222,7 +222,9 @@ async function getNewChangelogEntry(
   }
   if (
     typeof possibleChangelogFunc.getReleaseLine === "function" &&
-    typeof possibleChangelogFunc.getDependencyReleaseLine === "function"
+    typeof possibleChangelogFunc.getDependencyReleaseLine === "function" &&
+    (possibleChangelogFunc.getVersionLine === undefined ||
+      typeof possibleChangelogFunc.getVersionLine === "function")
   ) {
     getChangelogFuncs = possibleChangelogFunc;
   } else {

--- a/packages/apply-release-plan/src/test-utils/changelog-functions.ts
+++ b/packages/apply-release-plan/src/test-utils/changelog-functions.ts
@@ -1,0 +1,5 @@
+export default {
+  getReleaseLine: async () => "release line",
+  getDependencyReleaseLine: async () => "dependency release line",
+  getVersionLine: async () => "version line",
+};

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -100,6 +100,13 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     body: JSON.stringify({ query: makeQuery(repos) }),
   }).then((x: any) => x.json());
 
+  if (!data) {
+    // this can happen while testing locally and the commit queried is not present on the main branch
+    throw new Error(
+      `An error occurred when fetching data from GitHub, no value found`
+    );
+  }
+
   if (data.errors) {
     throw new Error(
       `An error occurred when fetching data from GitHub\n${JSON.stringify(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -131,6 +131,11 @@ export type ModCompWithPackage = ComprehensiveRelease & {
   dir: string;
 };
 
+export type GetVersionLine = (
+  release: ModCompWithPackage,
+  changelogOpts: null | Record<string, any>
+) => Promise<string>;
+
 export type GetReleaseLine = (
   changeset: NewChangesetWithCommit,
   type: VersionType,
@@ -144,6 +149,7 @@ export type GetDependencyReleaseLine = (
 ) => Promise<string>;
 
 export type ChangelogFunctions = {
+  getVersionLine?: GetVersionLine;
   getReleaseLine: GetReleaseLine;
   getDependencyReleaseLine: GetDependencyReleaseLine;
 };


### PR DESCRIPTION
Our team needs to be able to have more control over the changelog format than what is provided. By adding `getVersionLine` as an optional new changelog generator, this gives us the flexibility we need without introducing any risk for existing users.

I also took it upon myself to document changelog functions because it wasn't that hard.

In addition, I fixed a crash that I encountered while trying to test the github changelog generator locally.