### PR TITLE
Fix issues with pre-release versions and pnpm

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -24,7 +24,7 @@ type SnapshotReleaseParameters = {
 function getPreVersion(version: string) {
   let parsed = semver.parse(version)!;
   let preVersion =
-    parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
+    parsed?.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
   if (typeof preVersion !== "number") {
     throw new InternalError("preVersion is not a number");
   }


### PR DESCRIPTION
`parsed` is falsey on many of my pnpm repos (pre version 1?) 

Examples of where I've used a patch:
- https://github.com/NullVoxPopuli/limber/tree/main/patches
- https://github.com/NullVoxPopuli/glimdown/tree/main/patches
- https://github.com/NullVoxPopuli/ember-resources/tree/main/patches

I haven't noticed any downsides to this change/patch in the above repos. I don't have much context, nor do I know if this is a good fix. I kinda just guessed when I was [encountering this error](https://github.com/NullVoxPopuli/limber/actions/runs/4964203882/jobs/8884161570#step:5:32):
```
 🦋  warn ===============================IMPORTANT!===============================
🦋  warn You are in prerelease mode
🦋  warn If you meant to do a normal release you should revert these changes and run `changeset pre exit`
🦋  warn You can then run `changeset version` again to do a normal release
🦋  warn ----------------------------------------------------------------------
🦋  error TypeError: Cannot read properties of null (reading 'prerelease')
🦋  error     at getPreVersion (/home/runner/work/limber/limber/node_modules/.pnpm/@changesets+assemble-release-plan@5.2.3/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js:433:27)
🦋  error     at getPreInfo (/home/runner/work/limber/limber/node_modules/.pnpm/@changesets+assemble-release-plan@5.2.3/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js:642:43)
🦋  error     at Object.assembleReleasePlan [as default] (/home/runner/work/limber/limber/node_modules/.pnpm/@changesets+assemble-release-plan@5.2.3/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js:523:19)
🦋  error     at version (/home/runner/work/limber/limber/node_modules/.pnpm/@changesets+cli@2.26.1/node_modules/@changesets/cli/dist/cli.cjs.dev.js:637:60)
🦋  error     at async run$2 (/home/runner/work/limber/limber/node_modules/.pnpm/@changesets+cli@2.26.1/node_modules/@changesets/cli/dist/cli.cjs.dev.js:1430:11)
Error: Error: The process '/usr/local/bin/node' failed with exit code 1
```