### PR TITLE
Add a note about `pnpm publish` to publish command

### DIFF
--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -101,7 +101,7 @@ Snapshot is used for a special kind of publishing for testing - it creates tempo
 changeset publish [--otp={token}]
 ```
 
-This publishes changes to npm, and creates git tags. This works by going into each package, checking if the version it has in its `package.json` is published on npm, and if it is not, running the `npm publish`.
+This publishes changes to npm, and creates git tags. This works by going into each package, checking if the version it has in its `package.json` is published on npm, and if it is not, running the `npm publish`. If you are using `pnpm` as a package manager, this automatically detects it and uses `pnpm publish` instead.
 
 Because this command assumes that the last commit is the release commit, you should not commit any changes between calling version and publish. These commands are separate to enable you to check if the release changes are accurate.
 


### PR DESCRIPTION
This PR adds a small note that `changeset publish` is going to use `pnpm` if it detects that the workspace uses `pnpm` package manager.

> I had to check the code to verify that it does indeed correctly switch the package manager and thought other people might have the same problem just checking the docs.