### PR TITLE
Throw error when no package has a version field

### DIFF
--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -367,4 +367,18 @@ describe("Changesets", () => {
     const { choices } = askCheckboxPlus.mock.calls[0][1][0];
     expect(choices).toEqual(["pkg-a", "pkg-c"]);
   });
+
+  it("should report an error if no package has a version field", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        name: "root",
+      }),
+    });
+
+    await expect(async () =>
+      addChangeset(cwd, { empty: false }, defaultConfig)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"No publishable packages found. Maybe the "version" field is missing in package.json?"`
+    );
+  });
 });

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -29,6 +29,11 @@ export default async function add(
   const listablePackages = packages.packages.filter((pkg) =>
     isListablePackage(config, pkg.packageJson)
   );
+  if (listablePackages.length === 0) {
+    throw new Error(
+      `No publishable packages found. Maybe the "version" field is missing in package.json?`
+    );
+  }
   const changesetBase = path.resolve(cwd, ".changeset");
 
   let newChangeset: Awaited<ReturnType<typeof createChangeset>>;


### PR DESCRIPTION
I encountered this issue when I added Changeset to a repo with a single package. The package was missing the `version` field which reports the follwing error:

```sh
pnpm changeset                
🦋  error TypeError: Cannot read properties of undefined (reading 'packageJson')
🦋  error     at createChangeset (/Users/luka.hartwig/Playground/changesets-bug/node_modules/.pnpm/@changesets+cli@2.26.2/node_modules/@changesets/cli/dist/cli.cjs.dev.js:421:75)
🦋  error     at add (/Users/luka.hartwig/Playground/changesets-bug/node_modules/.pnpm/@changesets+cli@2.26.2/node_modules/@changesets/cli/dist/cli.cjs.dev.js:535:26)
🦋  error     at async run$2 (/Users/luka.hartwig/Playground/changesets-bug/node_modules/.pnpm/@changesets+cli@2.26.2/node_modules/@changesets/cli/dist/cli.cjs.dev.js:1334:5)
```

I added a nicer error message (maybe the wording could be improved?).