### PR TITLE
Execute CLI as ESM

### DIFF
--- a/packages/cli/bin.mjs
+++ b/packages/cli/bin.mjs
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 "use strict";
 
-require("./");
+import './';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.26.2",
   "description": "Organise your package versioning and publishing to make both contributors and maintainers happy",
   "bin": {
-    "changeset": "bin.js"
+    "changeset": "bin.mjs"
   },
   "repository": "https://github.com/changesets/changesets/tree/main/packages/cli",
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,9 @@
     "changelog",
     "commit"
   ],
+  "engines": {
+    "node": "^12.20.0 || >= 14.13.0"
+  }
   "main": "dist/changesets-cli.cjs.js",
   "module": "dist/changesets-cli.esm.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   ],
   "engines": {
     "node": "^12.20.0 || >= 14.13.0"
-  }
+  },
   "main": "dist/changesets-cli.cjs.js",
   "module": "dist/changesets-cli.esm.js",
   "exports": {


### PR DESCRIPTION
This is the first part of https://github.com/changesets/changesets/issues/587. If it's accepted I will follow up with additional changes

This would require the user to use a version of Node released within the past four years