### PR TITLE
refactor(changelog-github): update `src/index.ts` in order to display contributors thumbnails in GitHub releases

### DIFF
--- a/.changeset/tricky-actors-crash.md
+++ b/.changeset/tricky-actors-crash.md
@@ -1,0 +1,6 @@
+---
+"@changesets/changelog-git": minor
+"@changesets/changelog-github": minor
+---
+
+refactor(changelog-github): update `src/index.ts` in order to display contributors thumbnails in GitHub releases

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -102,10 +102,7 @@ const changelogFunctions: ChangelogFunctions = {
 
     const users = usersFromSummary.length
       ? usersFromSummary
-          .map(
-            (userFromSummary) =>
-              `[@${userFromSummary}](https://github.com/${userFromSummary})`
-          )
+          .map((userFromSummary) => `@${userFromSummary}`)
           .join(", ")
       : links.user;
 


### PR DESCRIPTION
Hello,

I propose this change in order to use built-in "Contributors" section of GitHub releases that shows automatically profiles thumbnails and links.

For this, we just need to replace this markdown:

```md
Thanks [@lauthieb](https://github.com/lauthieb) - ...
```

To this markdown:
```md
Thanks @lauthieb - ...
```

The result will be:

## Before

```md
Thanks [@lauthieb](https://github.com/lauthieb) - ...
```
![CleanShot 2023-08-24 at 13 58 03@2x](https://github.com/changesets/changesets/assets/9600228/8b86529c-9109-4439-b2dc-defbef19513f)

---

## After

```md
Thanks @lauthieb - ...
```

![CleanShot 2023-08-24 at 13 58 39@2x](https://github.com/changesets/changesets/assets/9600228/82cffae6-cbc2-43d2-80ca-79575cc7e574)

Thanks in advance :)

Laurent
