### PR TITLE
Update tag command to exclude private and ignored packages

### DIFF
--- a/.changeset/late-comics-pump.md
+++ b/.changeset/late-comics-pump.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Update tag command to exclude private and ignored packages

--- a/packages/cli/src/commands/tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/tag/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import * as git from "@changesets/git";
+import { defaultConfig } from "@changesets/config";
 import tag from "../index";
 
 jest.mock("@changesets/git");
@@ -30,7 +31,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(2);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
       expect((git.tag as jest.Mock).mock.calls[1][0]).toEqual("pkg-b@1.0.0");
@@ -63,9 +64,86 @@ describe("tag command", () => {
       );
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-b@1.0.0");
+    });
+    it("should not include ignored packages", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        "packages/pkg-b/package.json": JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+        }),
+      });
+
+      (git.getAllTags as jest.Mock).mockReturnValue(new Set());
+
+      await tag(cwd, {
+        ...defaultConfig,
+        ignore: ["pkg-b"],
+      });
+
+      expect(git.tag).toHaveBeenCalledTimes(1);
+      expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
+    });
+
+    it("should not include private packages without a version in the prompt", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        "packages/pkg-b/package.json": JSON.stringify({
+          name: "pkg-b",
+          private: true,
+        }),
+      });
+
+      (git.getAllTags as jest.Mock).mockReturnValue(new Set());
+
+      await tag(cwd, defaultConfig);
+      expect(git.tag).toHaveBeenCalledTimes(1);
+      expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
+    });
+
+    it("should not include private packages with a version if private packages are configured to be not versionable", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        "packages/pkg-b/package.json": JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+          private: true,
+        }),
+      });
+
+      (git.getAllTags as jest.Mock).mockReturnValue(new Set());
+
+      await tag(cwd, {
+        ...defaultConfig,
+        privatePackages: { version: false, tag: false },
+      });
+
+      expect(git.tag).toHaveBeenCalledTimes(1);
+      expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
     });
   });
 
@@ -81,7 +159,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("v1.0.0");
     });

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,13 +1,18 @@
 import * as git from "@changesets/git";
 import { getPackages } from "@manypkg/get-packages";
 import { log } from "@changesets/logger";
+import { Config } from "@changesets/types";
+import { isListablePackage } from "../add/isListablePackage";
 
-export default async function run(cwd: string) {
+export default async function run(cwd: string, config: Config) {
   const { packages, tool } = await getPackages(cwd);
 
   const allExistingTags = await git.getAllTags(cwd);
+  const listablePackages = packages.filter((pkg) =>
+    isListablePackage(config, pkg.packageJson)
+  );
 
-  for (const pkg of packages) {
+  for (const pkg of listablePackages) {
     const tag =
       tool !== "root"
         ? `${pkg.packageJson.name}@${pkg.packageJson.version}`

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -179,7 +179,7 @@ export async function run(
         return;
       }
       case "tag": {
-        await tagCommand(cwd);
+        await tagCommand(cwd, config);
         return;
       }
       case "pre": {


### PR DESCRIPTION
Fixes #833 

This is the third attempt at this change as the two previous went stale, I have included 3 test cases for the new code. 

I just reused the existing logic for determining a private or ignored package from the cli add code.