### PR TITLE
Avoid using short commit IDs

### DIFF
--- a/.changeset/thin-pumas-remember.md
+++ b/.changeset/thin-pumas-remember.md
@@ -1,0 +1,6 @@
+---
+"@changesets/apply-release-plan": minor
+"@changesets/cli": minor
+---
+
+Avoid using short commit IDs

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -38,7 +38,7 @@ async function getCommitsThatAddChangesets(
   cwd: string
 ) {
   const paths = changesetIds.map((id) => `.changeset/${id}.md`);
-  const commits = await git.getCommitsThatAddFiles(paths, { cwd, short: true });
+  const commits = await git.getCommitsThatAddFiles(paths, { cwd });
 
   if (commits.every(stringDefined)) {
     // We have commits for all files
@@ -52,8 +52,7 @@ async function getCommitsThatAddChangesets(
 
   const legacyPaths = missingIds.map((id) => `.changeset/${id}/changes.json`);
   const commitsForLegacyPaths = await git.getCommitsThatAddFiles(legacyPaths, {
-    cwd,
-    short: true,
+    cwd
   });
 
   // Fill in the blanks in the array of commits

--- a/packages/apply-release-plan/src/test-utils/get-changelog-entry-with-git-hash.ts
+++ b/packages/apply-release-plan/src/test-utils/get-changelog-entry-with-git-hash.ts
@@ -12,7 +12,7 @@ async function getReleaseLine(changeset: NewChangeset, cwd: string) {
 
   const [commitThatAddsFile] = await getCommitsThatAddFiles(
     [`.changeset/${changeset.id}.md`],
-    { cwd, short: true }
+    { cwd }
   );
 
   return `- [${commitThatAddsFile}] ${firstLine}\n${futureLines

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -14,7 +14,7 @@ const getReleaseLine = async (
     .map((l) => l.trimRight());
 
   let returnVal = `- ${
-    changeset.commit ? `${changeset.commit}: ` : ""
+    changeset.commit ? `${changeset.commit.slice(0, 7)}: ` : ""
   }${firstLine}`;
 
   if (futureLines.length > 0) {
@@ -33,7 +33,7 @@ const getDependencyReleaseLine = async (
   const changesetLinks = changesets.map(
     (changeset) =>
       `- Updated dependencies${
-        changeset.commit ? ` [${changeset.commit}]` : ""
+        changeset.commit ? ` [${changeset.commit.slice(0, 7)}]` : ""
       }`
   );
 

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -78,9 +78,10 @@ const changelogFunctions: ChangelogFunctions = {
           pull: prFromSummary,
         });
         if (commitFromSummary) {
+          const shortCommitId = commitFromSummary.slice(0, 7);
           links = {
             ...links,
-            commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+            commit: `[\`${shortCommitId}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
           };
         }
         return links;

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -75,7 +75,7 @@ export default async function version(
       ? {
           tag: options.snapshot === true ? undefined : options.snapshot,
           commit: config.snapshot.prereleaseTemplate?.includes("{commit}")
-            ? await getCurrentCommitId({ cwd, short: true })
+            ? await getCurrentCommitId({ cwd })
             : undefined,
         }
       : undefined

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -208,7 +208,7 @@ export async function getInfo(request: {
     user: user ? user.login : null,
     pull: associatedPullRequest ? associatedPullRequest.number : null,
     links: {
-      commit: `[\`${request.commit}\`](${data.commitUrl})`,
+      commit: `[\`${request.commit.slice(0, 7)}\`](${data.commitUrl})`,
       pull: associatedPullRequest
         ? `[#${associatedPullRequest.number}](${associatedPullRequest.url})`
         : null,
@@ -255,7 +255,7 @@ export async function getInfoFromPullRequest(request: {
     commit: commit ? commit.abbreviatedOid : null,
     links: {
       commit: commit
-        ? `[\`${commit.abbreviatedOid}\`](${commit.commitUrl})`
+        ? `[\`${commit.abbreviatedOid.slice(0, 7)}\`](${commit.commitUrl})`
         : null,
       pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
       user: user ? `[@${user.login}](${user.url})` : null,


### PR DESCRIPTION
My team and I ran into a wild issue with changesets today that has prompted me to open this PR.

### Setup

We're using GitHub Actions and saw the following output in one of our release builds:

```
The following error was encountered while generating changelog entries
We have escaped applying the changesets, and no files should have been affected
🦋  error TypeError: Cannot read properties of null (reading 'author')
🦋  error     at Object.getInfo (/home/runner/work/primitives/primitives/node_modules/@changesets/get-github-info/dist/get-github-info.cjs.dev.js:235:12)
🦋  error     at processTicksAndRejections (node:internal/process/task_queues:96:5)
🦋  error     at async /home/runner/work/primitives/primitives/node_modules/@changesets/changelog-github/dist/changelog-github.cjs.dev.js:122:13
🦋  error     at async Object.getReleaseLine (/home/runner/work/primitives/primitives/node_modules/@changesets/changelog-github/dist/changelog-github.cjs.dev.js:99:19)
🦋  error     at async Promise.all (index 0)
🦋  error     at async generateChangesForVersionTypeMarkdown (/home/runner/work/primitives/primitives/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:192:22)
🦋  error     at async getChangelogEntry (/home/runner/work/primitives/primitives/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:247:109)
🦋  error     at async /home/runner/work/primitives/primitives/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:420:[21](https://github.com/primer/primitives/actions/runs/6267066703/job/17044280307#step:8:22)
🦋  error     at async Promise.all (index 0)
🦋  error     at async Object.applyReleasePlan [as default] (/home/runner/work/primitives/primitives/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js:[31](https://github.com/primer/primitives/actions/runs/6267066703/job/17044280307#step:8:32)1:31)
```

Looks like it's trying to access the `author` property of `null`. After looking at the changesets code, it appears the error happens when processing the result of executing a GraphQL query via the GitHub API. After sticking some `console.log` statements inside the changesets code, I was able to print out the query:

```graphql
query {
    a0: repository(owner: "primer" name: "primitives") {
        a51dbba8: object(expression: "51dbba8") {
            ... on Commit {
                commitUrl
                associatedPullRequests(first: 50) {
                    nodes {
                        number
                        url
                        mergedAt
                        author {
                            login
                            url
                        }
                    }
                }
                author {
                    user {
                        login
                        url
                    }
                }
            }
        }
        a2565a2d: object(expression: "2565a2d") {
            ... on Commit {
                commitUrl
                associatedPullRequests(first: 50) {
                    nodes {
                        number
                        url
                        mergedAt
                        author {
                            login
                            url
                        }
                    }
                }
                author {
                    user {
                        login
                        url
                    }
                }
            }
        }
    }
}
```

You should be able to copy/paste this query into [GitHub's GraphQL explorer](https://docs.github.com/en/graphql/overview/explorer) and see the following response (modified for brevity):

```json
{
  "data": {
    "a0": {
      "a51dbba8": null,
      "a2565a2d": {
        "commitUrl": "https://github.com/primer/primitives/commit/2565a2d30dbca13b73e21064036910e269385770",
        "associatedPullRequests": {
          "nodes": [
            { ... }
          ]
        },
        "author": {
          "user": { ... }
        }
      }
    }
  }
}
```

Notice the full and complete response for commit `2565a2d` but a `null` value for commit `51dbba8`.

### Diagnosis

So what the heck? Running `git rev-parse 51dbba8` returns the full commit ID of `51dbba881eea1cd1a2d0c601023c9d4b8357b64d`, which [definitely exists](https://github.com/primer/primitives/commit/51dbba881eea1cd1a2d0c601023c9d4b8357b64d).

My only idea, although very unlikely, was a hash collision.

```bash
$> git cat-file -t 51dbba8
error: short object ID 51dbba8 is ambiguous
hint: The candidates are:
hint:   51dbba881 commit 2023-09-21 - update diffStat tokens (#728)
hint:   51dbba865 tree
fatal: Not a valid object name 51dbba8
```

Bingo! There _is_ a hash collision! `51dbba8` is a prefix shared by both a commit _and_ a tree object.

Using the full SHA (or even just one additional digit) in the GraphQL query returns non-null data for both the commits in question. Problem solved.

### Solution

Unless there's a really good reason not to, I think changesets should use full commit IDs everywhere. Since it's a popular project with lots of users, it was only a matter of time before a collision issue like this occurred.

After code spelunking for a few hours, I wasn't able to identify precisely the right part of the code to modify, so I just removed all the instances of `short: true` being passed into the various git functions. Please let me know if a more nuanced change is necessary.