### PR TITLE
Make `./bin.js` available through `package.json#exports`

### DIFF
--- a/.changeset/famous-toys-lay.md
+++ b/.changeset/famous-toys-lay.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Make `./bin.js` available through `package.json#exports` to fix compatibility with `changesets/action`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,8 @@
       "import": "./commit/dist/changesets-cli-commit.cjs.mjs",
       "default": "./commit/dist/changesets-cli-commit.cjs.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./bin.js": "./bin.js"
   },
   "author": "Changesets Contributors",
   "contributors": [
@@ -56,7 +57,12 @@
       "./index.ts",
       "./changelog.ts",
       "./commit/index.ts"
-    ]
+    ],
+    "exports": {
+      "extra": {
+        "./bin.js": "./bin.js"
+      }
+    }
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
fixes https://github.com/changesets/changesets/issues/1266