### PR TITLE
Fix changelogs.xyz page for @changesets/cli by adding CHANGELOG.md to package.json’s files array

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
     "default-files",
     "dist",
     "bin.js",
+    "CHANGELOG.md",
     "changelog",
     "commit"
   ],


### PR DESCRIPTION
https://changelogs.xyz/@changesets/cli (linked to from the “Explore Changelog” badge at the top of the main readme) currently can”t find a changelog for `@changesets/cli` and points to https://unpkg.com/browse/@changesets/cli@2.27.1/ as the source it is browsing to find the file

UNPKG doesn’t list CHANGELOG.md because it is listing the distributed files from published versions of the package, and CHANGELOG.md isn’t currently included because it isn’t in the package.json files array.

i believe that adding it to package.json’s `files` (and publishing a new version of the package) will fix the issue, though it would be tricky for me to confirm that on my own. either way, the changelog seems like it could be a useful thing to distribute with the package so that package consumers can refer to it if the need should arise.