### PR TITLE
fix: avoid version changing for release type "none"

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -242,7 +242,7 @@ function assembleReleasePlan(
 
   return {
     changesets: relevantChangesets,
-    releases: [...releases.values()].map((incompleteRelease) => {
+    releases: Array.from(releases.values()).filter(r => r.type !== 'none').map((incompleteRelease) => {
       return {
         ...incompleteRelease,
         newVersion: snapshotSuffix


### PR DESCRIPTION
Before, it would assemble unnecessary version change for packages, output example:

```
{
  changesets: [
    {
      releases: [Array],
      summary: 'composite',
      id: 'feat+image-new_2024-03-05'
    }
  ],
  releases: [
    {
      name: '@scopeA/image-filter',
      type: 'patch',
      oldVersion: '13.0.0',
      changesets: [Array],
      newVersion: '13.0.1'
    },
    {
      name: '@scopeB/app1',
      type: 'none',
      oldVersion: '1.0.0',
      changesets: [],
      newVersion: '1.0.0'
    },
    {
      name: '@scopeB/app2',
      type: 'none',
      oldVersion: '1.0.0',
      changesets: [],
      newVersion: '1.0.0'
    },
  ],
  preState: undefined
}
```

It would touch `package.json` for `@scopeB/app1` and `@scopeB/app2` with unnecessary file change.

This Pull Request just skip this event totally.