### PR TITLE
Add `since` option to `add` command

### DIFF
--- a/.changeset/calm-rats-train.md
+++ b/.changeset/calm-rats-train.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Add `since` option to `add` command

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -17,7 +17,7 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open }: { empty?: boolean; open?: boolean },
+  { empty, open, since }: { empty?: boolean; open?: boolean; since?: string },
   config: Config
 ) {
   const packages = await getPackages(cwd);
@@ -46,6 +46,7 @@ export default async function add(
     const changedPackagesNames = (
       await getVersionableChangedPackages(config, {
         cwd,
+        ref: since,
       })
     ).map((pkg) => pkg.packageJson.name);
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -64,9 +64,9 @@ export async function run(
   }
 
   if (input.length < 1) {
-    const { empty, open }: CliOptions = flags;
+    const { empty, open, since }: CliOptions = flags;
     // @ts-ignore if this is undefined, we have already exited
-    await add(cwd, { empty, open }, config);
+    await add(cwd, { empty, open, since }, config);
   } else if (input[0] !== "pre" && input.length > 1) {
     error(
       "Too many arguments passed to changesets - we only accept the command name as an argument"
@@ -106,7 +106,7 @@ export async function run(
 
     switch (input[0]) {
       case "add": {
-        await add(cwd, { empty, open }, config);
+        await add(cwd, { empty, open, since }, config);
         return;
       }
       case "version": {


### PR DESCRIPTION
This option is very useful when you only want one changeset by publish, ex:

```sh
git add packages/one
git commit -m "add package one"
git add packages/two
git commit -m "add package two"
changeset add --since origin/main
```