### PR TITLE
Use node 20.x in release flow

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - name: Checkout Repo
         # https://github.com/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 20.x
         # https://github.com/actions/setup-node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
Refs: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Warnings are currently shown in [publish workflow](https://github.com/changesets/changesets/actions/runs/7956397365)
```console
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-node@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

cc @Andarist 