### PR TITLE
fix(cli): Typo in `pre` error and add test

### DIFF
--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -99,4 +99,30 @@ describe("cli", () => {
       );
     });
   });
+  describe("pre", () => {
+    it("should throw an error if tag not passed in", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        ".changeset/config.json": JSON.stringify({}),
+      });
+      try {
+        await run(["pre", "enter"], {}, cwd);
+      } catch (e) {
+        // ignore the error. We just want to validate the error message
+      }
+
+      const loggerErrorCalls = (error as any).mock.calls;
+      expect(loggerErrorCalls.length).toEqual(1);
+      expect(loggerErrorCalls[0][0]).toEqual(
+        `A tag must be passed when using prerelease enter`
+      );
+    });
+  });
 });

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -192,7 +192,7 @@ export async function run(
         }
         let tag = input[2];
         if (command === "enter" && typeof tag !== "string") {
-          error(`A tag must be passed when using prerelese enter`);
+          error(`A tag must be passed when using prerelease enter`);
           throw new ExitError(1);
         }
         // @ts-ignore


### PR DESCRIPTION
When a tag is not passed in to `changeset pre enter`, the error message thrown as a typo:

```
$ yarn changeset pre enter
🦋  error A tag must be passed when using prerelese enter
```

This PR fixes the typo in `prerelease` and adds a test for it as well.