### PR TITLE
Fix unversioned private package handling, tagging of ignored

### DIFF
--- a/.changeset/sharp-humans-battle.md
+++ b/.changeset/sharp-humans-battle.md
@@ -1,0 +1,7 @@
+---
+"@changesets/assemble-release-plan": patch
+"@changesets/apply-release-plan": patch
+"@changesets/cli": patch
+---
+
+Ensure that version/tag do not touch private packages with privatePackages config

--- a/.changeset/sharp-humans-battle.md
+++ b/.changeset/sharp-humans-battle.md
@@ -4,4 +4,4 @@
 "@changesets/cli": patch
 ---
 
-Ensure that version/tag do not touch private packages with privatePackages config
+Ensure that `version`/`tag` do not touch private packages with when versioning/tagging is turned off using `versionPackages` config

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -23,6 +23,7 @@
     "@changesets/config": "^3.0.0",
     "@changesets/get-version-range-type": "^0.4.0",
     "@changesets/git": "^3.0.0",
+    "@changesets/should-skip-package": "^0.1.0",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
     "detect-indent": "^6.0.0",

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -191,7 +191,6 @@ export default async function applyReleasePlan(
 }
 
 // Note: if updating this, also update the other copies of createIsVersionablePackage.
-// TODO(jakebailey): don't copy paste
 function createIsVersionablePackage(
   ignoredPackages: readonly string[],
   allowPrivatePackages: boolean

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -163,6 +163,7 @@ export default async function applyReleasePlan(
           // At this point, we know there is no such changeset, because otherwise the program would've already failed,
           // so we just check if any ignored package exists in this changeset, and only remove it if none exists
           // Ignored list is added in v2, so we don't need to do it for v1 changesets
+          // TODO(jakebailey): should this check isVersionablePackage?
           if (
             !changeset.releases.find((release) =>
               config.ignore.includes(release.name)

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -190,8 +190,9 @@ export default async function applyReleasePlan(
   return touchedFiles;
 }
 
+// Note: if updating this, also update the other copies of createIsVersionablePackage.
 // TODO(jakebailey): don't copy paste
-export function createIsVersionablePackage(
+function createIsVersionablePackage(
   ignoredPackages: readonly string[],
   allowPrivatePackages: boolean
 ): (pkg: Package) => boolean {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -1,23 +1,21 @@
-import {
-  ReleasePlan,
-  Config,
-  ChangelogFunctions,
-  NewChangeset,
-  ModCompWithPackage,
-} from "@changesets/types";
-
 import { defaultConfig } from "@changesets/config";
 import * as git from "@changesets/git";
-import resolveFrom from "resolve-from";
-import { Package, Packages } from "@manypkg/get-packages";
+import { shouldSkipPackage } from "@changesets/should-skip-package";
+import {
+  ChangelogFunctions,
+  Config,
+  ModCompWithPackage,
+  NewChangeset,
+  ReleasePlan,
+} from "@changesets/types";
+import { Packages } from "@manypkg/get-packages";
 import detectIndent from "detect-indent";
-
 import fs from "fs-extra";
 import path from "path";
 import prettier from "prettier";
-
-import versionPackage from "./version-package";
+import resolveFrom from "resolve-from";
 import getChangelogEntry from "./get-changelog-entry";
+import versionPackage from "./version-package";
 
 function getPrettierInstance(cwd: string): typeof prettier {
   try {
@@ -78,11 +76,6 @@ export default async function applyReleasePlan(
 
   const packagesByName = new Map(
     packages.packages.map((x) => [x.packageJson.name, x])
-  );
-
-  const isVersionablePackage = createIsVersionablePackage(
-    config.ignore,
-    config.privatePackages.version
   );
 
   let { releases, changesets } = releasePlan;
@@ -163,15 +156,17 @@ export default async function applyReleasePlan(
         let changesetPath = path.resolve(changesetFolder, `${changeset.id}.md`);
         let changesetFolderPath = path.resolve(changesetFolder, changeset.id);
         if (await fs.pathExists(changesetPath)) {
-          // DO NOT remove changeset for ignored packages
-          // Mixed changeset that contains both ignored packages and not ignored packages are disallowed
+          // DO NOT remove changeset for skipped packages
+          // Mixed changeset that contains both skipped packages and not skipped packages are disallowed
           // At this point, we know there is no such changeset, because otherwise the program would've already failed,
-          // so we just check if any ignored package exists in this changeset, and only remove it if none exists
-          // Ignored list is added in v2, so we don't need to do it for v1 changesets
+          // so we just check if any skipped package exists in this changeset, and only remove it if none exists
+          // options to skip packages were added in v2, so we don't need to do it for v1 changesets
           if (
-            !changeset.releases.find(
-              (release) =>
-                !isVersionablePackage(packagesByName.get(release.name)!)
+            !changeset.releases.find((release) =>
+              shouldSkipPackage(packagesByName.get(release.name)!, {
+                ignore: config.ignore,
+                allowPrivatePackages: config.privatePackages.version,
+              })
             )
           ) {
             touchedFiles.push(changesetPath);
@@ -188,26 +183,6 @@ export default async function applyReleasePlan(
 
   // We return the touched files to be committed in the cli
   return touchedFiles;
-}
-
-// Note: if updating this, also update the other copies of createIsVersionablePackage.
-function createIsVersionablePackage(
-  ignoredPackages: readonly string[],
-  allowPrivatePackages: boolean
-): (pkg: Package) => boolean {
-  const ignoredPackagesSet = new Set(ignoredPackages);
-  return ({ packageJson }: Package) => {
-    if (ignoredPackagesSet.has(packageJson.name)) {
-      return false;
-    }
-
-    if (packageJson.private && !allowPrivatePackages) {
-      return false;
-    }
-
-    const hasVersionField = !!packageJson.version;
-    return hasVersionField;
-  };
 }
 
 async function getNewChangelogEntry(

--- a/packages/assemble-release-plan/package.json
+++ b/packages/assemble-release-plan/package.json
@@ -22,6 +22,7 @@
     "@babel/runtime": "^7.20.1",
     "@changesets/errors": "^0.2.0",
     "@changesets/get-dependents-graph": "^2.0.0",
+    "@changesets/should-skip-package": "^0.1.0",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
     "semver": "^7.5.3"

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -8,7 +8,7 @@ import {
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease, PreInfo } from "./types";
 import { incrementVersion } from "./increment";
-import { isVersionablePackage } from "./utils";
+import { createIsVersionablePackage } from "./utils";
 
 /*
   WARNING:
@@ -38,10 +38,10 @@ export default function determineDependents({
   let updated = false;
   // NOTE this is intended to be called recursively
   let pkgsToSearch = [...releases.values()];
-  const isVersionablePackageOptions = {
-    ignoredPackages: new Set(config.ignore),
-    versionPrivatePackages: config.privatePackages.version,
-  };
+  const isVersionablePackage = createIsVersionablePackage(
+    config.ignore,
+    config.privatePackages.version
+  );
 
   while (pkgsToSearch.length > 0) {
     // nextRelease is our dependency, think of it as "avatar"
@@ -61,9 +61,7 @@ export default function determineDependents({
         const dependentPackage = packagesByName.get(dependent);
         if (!dependentPackage) throw new Error("Dependency map is incorrect");
 
-        if (
-          !isVersionablePackage(dependentPackage, isVersionablePackageOptions)
-        ) {
+        if (!isVersionablePackage(dependentPackage)) {
           type = "none";
         } else {
           const dependencyVersionRanges = getDependencyVersionRanges(

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -8,6 +8,7 @@ import {
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease, PreInfo } from "./types";
 import { incrementVersion } from "./increment";
+import { isVersionablePackage } from "./utils";
 
 /*
   WARNING:
@@ -37,6 +38,10 @@ export default function determineDependents({
   let updated = false;
   // NOTE this is intended to be called recursively
   let pkgsToSearch = [...releases.values()];
+  const isVersionablePackageOptions = {
+    ignoredPackages: new Set(config.ignore),
+    versionPrivatePackages: config.privatePackages.version,
+  };
 
   while (pkgsToSearch.length > 0) {
     // nextRelease is our dependency, think of it as "avatar"
@@ -56,7 +61,9 @@ export default function determineDependents({
         const dependentPackage = packagesByName.get(dependent);
         if (!dependentPackage) throw new Error("Dependency map is incorrect");
 
-        if (config.ignore.includes(dependent)) {
+        if (
+          !isVersionablePackage(dependentPackage, isVersionablePackageOptions)
+        ) {
           type = "none";
         } else {
           const dependencyVersionRanges = getDependencyVersionRanges(

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -8,7 +8,7 @@ import { InternalRelease } from "./types";
 export default function flattenReleases(
   changesets: NewChangeset[],
   packagesByName: Map<string, Package>,
-  ignoredPackages: Readonly<string[]>
+  isVersionablePackage: (pkg: Package) => boolean
 ): Map<string, InternalRelease> {
   let releases: Map<string, InternalRelease> = new Map();
 
@@ -16,8 +16,7 @@ export default function flattenReleases(
     changeset.releases
       // Filter out ignored packages because they should not trigger a release
       // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
-      // TODO(jakebailey): should this check isVersionablePackage?
-      .filter(({ name }) => !ignoredPackages.includes(name))
+      .filter(({ name }) => isVersionablePackage(packagesByName.get(name)!))
       .forEach(({ name, type }) => {
         let release = releases.get(name);
         let pkg = packagesByName.get(name);

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -16,6 +16,7 @@ export default function flattenReleases(
     changeset.releases
       // Filter out ignored packages because they should not trigger a release
       // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
+      // TODO(jakebailey): should this check isVersionablePackage?
       .filter(({ name }) => !ignoredPackages.includes(name))
       .forEach(({ name, type }) => {
         let release = releases.get(name);

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -1,22 +1,29 @@
 // This function takes in changesets and returns one release per
 // package listed in the changesets
 
-import { NewChangeset } from "@changesets/types";
+import { shouldSkipPackage } from "@changesets/should-skip-package";
+import { Config, NewChangeset } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease } from "./types";
 
 export default function flattenReleases(
   changesets: NewChangeset[],
   packagesByName: Map<string, Package>,
-  isVersionablePackage: (pkg: Package) => boolean
+  config: Config
 ): Map<string, InternalRelease> {
   let releases: Map<string, InternalRelease> = new Map();
 
   changesets.forEach((changeset) => {
     changeset.releases
-      // Filter out ignored packages because they should not trigger a release
+      // Filter out skipped packages because they should not trigger a release
       // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
-      .filter(({ name }) => isVersionablePackage(packagesByName.get(name)!))
+      .filter(
+        ({ name }) =>
+          !shouldSkipPackage(packagesByName.get(name)!, {
+            ignore: config.ignore,
+            allowPrivatePackages: config.privatePackages.version,
+          })
+      )
       .forEach(({ name, type }) => {
         let release = releases.get(name);
         let pkg = packagesByName.get(name);

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -15,6 +15,7 @@ import { InternalError } from "@changesets/errors";
 import { Packages, Package } from "@manypkg/get-packages";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
 import { PreInfo, InternalRelease } from "./types";
+import { isVersionablePackage } from "./utils";
 
 type SnapshotReleaseParameters = {
   tag?: string | undefined;
@@ -154,6 +155,11 @@ function assembleReleasePlan(
     packages.packages.map((x) => [x.packageJson.name, x])
   );
 
+  const isVersionablePackageOptions = {
+    ignoredPackages: new Set(config.ignore),
+    versionPrivatePackages: config.privatePackages.version,
+  };
+
   const relevantChangesets = getRelevantChangesets(
     changesets,
     refinedConfig.ignore,
@@ -225,7 +231,7 @@ function assembleReleasePlan(
         } else if (
           // TODO(jakebailey): should this check isVersionablePackage?
           existingRelease.type === "none" &&
-          !refinedConfig.ignore.includes(pkg.packageJson.name)
+          !isVersionablePackage(pkg, isVersionablePackageOptions)
         ) {
           existingRelease.type = "patch";
         }

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -223,6 +223,7 @@ function assembleReleasePlan(
             changesets: [],
           });
         } else if (
+          // TODO(jakebailey): should this check isVersionablePackage?
           existingRelease.type === "none" &&
           !refinedConfig.ignore.includes(pkg.packageJson.name)
         ) {
@@ -270,6 +271,7 @@ function getRelevantChangesets(
     const ignoredPackages = [];
     const notIgnoredPackages = [];
     for (const release of changeset.releases) {
+      // TODO(jakebailey): should this check isVersionablePackage?
       if (
         ignored.find(
           (ignoredPackageName) => ignoredPackageName === release.name

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -231,7 +231,7 @@ function assembleReleasePlan(
           });
         } else if (
           existingRelease.type === "none" &&
-          !isVersionablePackage(pkg)
+          isVersionablePackage(pkg)
         ) {
           existingRelease.type = "patch";
         }

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -229,7 +229,6 @@ function assembleReleasePlan(
             changesets: [],
           });
         } else if (
-          // TODO(jakebailey): should this check isVersionablePackage?
           existingRelease.type === "none" &&
           !isVersionablePackage(pkg, isVersionablePackageOptions)
         ) {

--- a/packages/assemble-release-plan/src/match-fixed-constraint.ts
+++ b/packages/assemble-release-plan/src/match-fixed-constraint.ts
@@ -2,9 +2,9 @@ import { Config } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease } from "./types";
 import {
+  createIsVersionablePackage,
   getCurrentHighestVersion,
   getHighestReleaseType,
-  isVersionablePackage,
 } from "./utils";
 
 export default function matchFixedConstraint(
@@ -14,10 +14,10 @@ export default function matchFixedConstraint(
 ): boolean {
   let updated = false;
 
-  const isVersionablePackageOptions = {
-    ignoredPackages: new Set(config.ignore),
-    versionPrivatePackages: config.privatePackages.version,
-  };
+  const isVersionablePackage = createIsVersionablePackage(
+    config.ignore,
+    config.privatePackages.version
+  );
 
   for (let fixedPackages of config.fixed) {
     let releasingFixedPackages = [...releases.values()].filter(
@@ -35,8 +35,7 @@ export default function matchFixedConstraint(
 
     // Finally, we update the packages so all of them are on the highest version
     for (let pkgName of fixedPackages) {
-      const pkg = packagesByName.get(pkgName);
-      if (pkg && !isVersionablePackage(pkg, isVersionablePackageOptions)) {
+      if (!isVersionablePackage(packagesByName.get(pkgName)!)) {
         continue;
       }
       let release = releases.get(pkgName);

--- a/packages/assemble-release-plan/src/match-fixed-constraint.ts
+++ b/packages/assemble-release-plan/src/match-fixed-constraint.ts
@@ -26,6 +26,7 @@ export default function matchFixedConstraint(
 
     // Finally, we update the packages so all of them are on the highest version
     for (let pkgName of fixedPackages) {
+      // TODO(jakebailey): should this check isVersionablePackage?
       if (config.ignore.includes(pkgName)) {
         continue;
       }

--- a/packages/assemble-release-plan/src/match-fixed-constraint.ts
+++ b/packages/assemble-release-plan/src/match-fixed-constraint.ts
@@ -1,11 +1,8 @@
+import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { Config } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease } from "./types";
-import {
-  createIsVersionablePackage,
-  getCurrentHighestVersion,
-  getHighestReleaseType,
-} from "./utils";
+import { getCurrentHighestVersion, getHighestReleaseType } from "./utils";
 
 export default function matchFixedConstraint(
   releases: Map<string, InternalRelease>,
@@ -13,11 +10,6 @@ export default function matchFixedConstraint(
   config: Config
 ): boolean {
   let updated = false;
-
-  const isVersionablePackage = createIsVersionablePackage(
-    config.ignore,
-    config.privatePackages.version
-  );
 
   for (let fixedPackages of config.fixed) {
     let releasingFixedPackages = [...releases.values()].filter(
@@ -35,7 +27,12 @@ export default function matchFixedConstraint(
 
     // Finally, we update the packages so all of them are on the highest version
     for (let pkgName of fixedPackages) {
-      if (!isVersionablePackage(packagesByName.get(pkgName)!)) {
+      if (
+        shouldSkipPackage(packagesByName.get(pkgName)!, {
+          ignore: config.ignore,
+          allowPrivatePackages: config.privatePackages.version,
+        })
+      ) {
         continue;
       }
       let release = releases.get(pkgName);

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -58,23 +58,3 @@ export function getCurrentHighestVersion(
 
   return highestVersion!;
 }
-
-// Note: if updating this, also update the other copies of createIsVersionablePackage.
-export function createIsVersionablePackage(
-  ignoredPackages: readonly string[],
-  allowPrivatePackages: boolean
-): (pkg: Package) => boolean {
-  const ignoredPackagesSet = new Set(ignoredPackages);
-  return ({ packageJson }: Package) => {
-    if (ignoredPackagesSet.has(packageJson.name)) {
-      return false;
-    }
-
-    if (packageJson.private && !allowPrivatePackages) {
-      return false;
-    }
-
-    const hasVersionField = !!packageJson.version;
-    return hasVersionField;
-  };
-}

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -58,3 +58,26 @@ export function getCurrentHighestVersion(
 
   return highestVersion!;
 }
+
+// TODO(jakebailey): don't copy paste
+export function isVersionablePackage(
+  { packageJson }: Package,
+  {
+    ignoredPackages,
+    versionPrivatePackages,
+  }: {
+    ignoredPackages: Set<string>;
+    versionPrivatePackages: boolean;
+  }
+) {
+  if (ignoredPackages.has(packageJson.name)) {
+    return false;
+  }
+
+  if (packageJson.private && !versionPrivatePackages) {
+    return false;
+  }
+
+  const hasVersionField = !!packageJson.version;
+  return hasVersionField;
+}

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -60,24 +60,21 @@ export function getCurrentHighestVersion(
 }
 
 // TODO(jakebailey): don't copy paste
-export function isVersionablePackage(
-  { packageJson }: Package,
-  {
-    ignoredPackages,
-    versionPrivatePackages,
-  }: {
-    ignoredPackages: Set<string>;
-    versionPrivatePackages: boolean;
-  }
-) {
-  if (ignoredPackages.has(packageJson.name)) {
-    return false;
-  }
+export function createIsVersionablePackage(
+  ignoredPackages: readonly string[],
+  allowPrivatePackages: boolean
+): (pkg: Package) => boolean {
+  const ignoredPackagesSet = new Set(ignoredPackages);
+  return ({ packageJson }: Package) => {
+    if (ignoredPackagesSet.has(packageJson.name)) {
+      return false;
+    }
 
-  if (packageJson.private && !versionPrivatePackages) {
-    return false;
-  }
+    if (packageJson.private && !allowPrivatePackages) {
+      return false;
+    }
 
-  const hasVersionField = !!packageJson.version;
-  return hasVersionField;
+    const hasVersionField = !!packageJson.version;
+    return hasVersionField;
+  };
 }

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -59,6 +59,7 @@ export function getCurrentHighestVersion(
   return highestVersion!;
 }
 
+// Note: if updating this, also update the other copies of createIsVersionablePackage.
 // TODO(jakebailey): don't copy paste
 export function createIsVersionablePackage(
   ignoredPackages: readonly string[],

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -60,7 +60,6 @@ export function getCurrentHighestVersion(
 }
 
 // Note: if updating this, also update the other copies of createIsVersionablePackage.
-// TODO(jakebailey): don't copy paste
 export function createIsVersionablePackage(
   ignoredPackages: readonly string[],
   allowPrivatePackages: boolean

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,6 +78,7 @@
     "@changesets/logger": "^0.1.0",
     "@changesets/pre": "^2.0.0",
     "@changesets/read": "^0.6.0",
+    "@changesets/should-skip-package": "^0.1.0",
     "@changesets/types": "^6.0.0",
     "@changesets/write": "^0.3.1",
     "@manypkg/get-packages": "^1.1.3",

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -4,17 +4,14 @@ import path from "path";
 
 import * as git from "@changesets/git";
 import { info, log, warn } from "@changesets/logger";
+import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { Config } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
-import * as cli from "../../utils/cli-utilities";
-
 import { ExternalEditor } from "external-editor";
 import { getCommitFunctions } from "../../commit/getCommitFunctions";
-import {
-  filterVersionablePackages,
-  getVersionableChangedPackages,
-} from "../../utils/versionablePackages";
+import * as cli from "../../utils/cli-utilities";
+import { getVersionableChangedPackages } from "../../utils/versionablePackages";
 import createChangeset from "./createChangeset";
 import printConfirmationMessage from "./messages";
 
@@ -29,9 +26,12 @@ export default async function add(
       `No packages found. You might have ${packages.tool} workspaces configured but no packages yet?`
     );
   }
-  const versionablePackages = filterVersionablePackages(
-    config,
-    packages.packages
+  const versionablePackages = packages.packages.filter(
+    (pkg) =>
+      !shouldSkipPackage(pkg, {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version,
+      })
   );
   const changesetBase = path.resolve(cwd, ".changeset");
 

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -38,7 +38,7 @@ function showNonLatestTagWarning(tag?: string, preState?: PreState) {
   warn(importantEnd);
 }
 
-export default async function run(
+export default async function publish(
   cwd: string,
   { otp, tag, gitTag = true }: { otp?: string; tag?: string; gitTag?: boolean },
   config: Config

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@changesets/types";
 import { getVersionableChangedPackages } from "../../utils/versionablePackages";
 
-export default async function getStatus(
+export default async function status(
   cwd: string,
   {
     sinceMaster,

--- a/packages/cli/src/commands/tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/tag/__tests__/index.test.ts
@@ -82,9 +82,27 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd, defaultConfig);
+      await tag(cwd, {
+        ...defaultConfig,
+        privatePackages: { version: true, tag: true },
+      });
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("v1.0.0");
+    });
+
+    it("does not tag on private", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          name: "root-only",
+          version: "1.0.0",
+        }),
+      });
+      (git.getAllTags as jest.Mock).mockReturnValue(new Set());
+
+      expect(git.tag).not.toHaveBeenCalled();
+      await tag(cwd, defaultConfig);
+      expect(git.tag).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/cli/src/commands/tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/tag/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import * as git from "@changesets/git";
 import tag from "../index";
+import { defaultConfig } from "@changesets/config";
 
 jest.mock("@changesets/git");
 
@@ -30,7 +31,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(2);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
       expect((git.tag as jest.Mock).mock.calls[1][0]).toEqual("pkg-b@1.0.0");
@@ -63,7 +64,7 @@ describe("tag command", () => {
       );
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-b@1.0.0");
     });
@@ -81,7 +82,7 @@ describe("tag command", () => {
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd);
+      await tag(cwd, defaultConfig);
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("v1.0.0");
     });

--- a/packages/cli/src/commands/tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/tag/__tests__/index.test.ts
@@ -1,9 +1,14 @@
-import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
+import { read } from "@changesets/config";
 import * as git from "@changesets/git";
+import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
+import { getPackages } from "@manypkg/get-packages";
 import tag from "../index";
-import { defaultConfig } from "@changesets/config";
 
 jest.mock("@changesets/git");
+
+async function readConfig(cwd: string) {
+  return read(cwd, await getPackages(cwd));
+}
 
 describe("tag command", () => {
   silenceLogsInBlock();
@@ -26,12 +31,13 @@ describe("tag command", () => {
           name: "pkg-b",
           version: "1.0.0",
         }),
+        ".changeset/config.json": JSON.stringify({}),
       });
 
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd, defaultConfig);
+      await tag(cwd, await readConfig(cwd));
       expect(git.tag).toHaveBeenCalledTimes(2);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-a@1.0.0");
       expect((git.tag as jest.Mock).mock.calls[1][0]).toEqual("pkg-b@1.0.0");
@@ -54,6 +60,7 @@ describe("tag command", () => {
           name: "pkg-b",
           version: "1.0.0",
         }),
+        ".changeset/config.json": JSON.stringify({}),
       });
 
       (git.getAllTags as jest.Mock).mockReturnValue(
@@ -64,7 +71,7 @@ describe("tag command", () => {
       );
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd, defaultConfig);
+      await tag(cwd, await readConfig(cwd));
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("pkg-b@1.0.0");
     });
@@ -78,14 +85,17 @@ describe("tag command", () => {
           name: "root-only",
           version: "1.0.0",
         }),
+        ".changeset/config.json": JSON.stringify({
+          privatePackages: {
+            version: true,
+            tag: true,
+          },
+        }),
       });
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd, {
-        ...defaultConfig,
-        privatePackages: { version: true, tag: true },
-      });
+      await tag(cwd, await readConfig(cwd));
       expect(git.tag).toHaveBeenCalledTimes(1);
       expect((git.tag as jest.Mock).mock.calls[0][0]).toEqual("v1.0.0");
     });
@@ -97,11 +107,12 @@ describe("tag command", () => {
           name: "root-only",
           version: "1.0.0",
         }),
+        ".changeset/config.json": JSON.stringify({}),
       });
       (git.getAllTags as jest.Mock).mockReturnValue(new Set());
 
       expect(git.tag).not.toHaveBeenCalled();
-      await tag(cwd, defaultConfig);
+      await tag(cwd, await readConfig(cwd));
       expect(git.tag).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,13 +1,15 @@
 import * as git from "@changesets/git";
 import { getPackages } from "@manypkg/get-packages";
 import { log } from "@changesets/logger";
+import { filterTaggablePackages } from "../../utils/versionablePackages";
+import { Config } from "@changesets/types";
 
-export default async function run(cwd: string) {
+export default async function run(cwd: string, config: Config) {
   const { packages, tool } = await getPackages(cwd);
 
   const allExistingTags = await git.getAllTags(cwd);
 
-  for (const pkg of packages) {
+  for (const pkg of filterTaggablePackages(config, packages)) {
     const tag =
       tool !== "root"
         ? `${pkg.packageJson.name}@${pkg.packageJson.version}`

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,15 +1,23 @@
 import * as git from "@changesets/git";
-import { getPackages } from "@manypkg/get-packages";
 import { log } from "@changesets/logger";
-import { filterTaggablePackages } from "../../utils/versionablePackages";
+import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { Config } from "@changesets/types";
+import { getPackages } from "@manypkg/get-packages";
 
-export default async function run(cwd: string, config: Config) {
+export default async function tag(cwd: string, config: Config) {
   const { packages, tool } = await getPackages(cwd);
 
   const allExistingTags = await git.getAllTags(cwd);
 
-  for (const pkg of filterTaggablePackages(config, packages)) {
+  const taggablePackages = packages.filter(
+    (pkg) =>
+      !shouldSkipPackage(pkg, {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.tag,
+      })
+  );
+
+  for (const pkg of taggablePackages) {
     const tag =
       tool !== "root"
         ? `${pkg.packageJson.name}@${pkg.packageJson.version}`

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -60,8 +60,8 @@ describe("cli", () => {
 
       const loggerErrorCalls = (error as any).mock.calls;
       expect(loggerErrorCalls.length).toEqual(1);
-      expect(loggerErrorCalls[0][0]).toEqual(
-        `The package "pkg-a" depends on the ignored package "pkg-b", but "pkg-a" is not being ignored. Please pass "pkg-a" to the \`--ignore\` flag.`
+      expect(loggerErrorCalls[0][0]).toMatchInlineSnapshot(
+        `"The package "pkg-a" depends on the skipped package "pkg-b" (either by \`ignore\` option or by \`privatePackages.version\`), but "pkg-a" is not being skipped. Please pass "pkg-a" to the \`--ignore\` flag."`
       );
     });
 

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -65,6 +65,41 @@ describe("cli", () => {
       );
     });
 
+    it("should not throw if dependents of unversioned private packages are not explicitly listed in the ignore array", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+          private: true,
+          dependencies: {
+            "pkg-b": "1.0.0",
+          },
+        }),
+        "packages/pkg-b/package.json": JSON.stringify({
+          name: "pkg-b",
+          version: "1.0.0",
+        }),
+        ".changeset/config.json": JSON.stringify({
+          privatePackages: {
+            tag: false,
+            version: false,
+          },
+        }),
+      });
+      try {
+        await run(["version"], { ignore: ["pkg-b"] }, cwd);
+      } catch (e) {
+        // ignore the error. We just want to validate the error message
+      }
+
+      const loggerErrorCalls = (error as any).mock.calls;
+      expect(loggerErrorCalls.length).toEqual(0);
+    });
+
     it("should throw if `--ignore` flag is used while ignore array is also defined in the config file ", async () => {
       const cwd = await testdir({
         "package.json": JSON.stringify({

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -65,7 +65,7 @@ describe("cli", () => {
       );
     });
 
-    it("should not throw if dependents of unversioned private packages are not explicitly listed in the ignore array", async () => {
+    it("should not throw if dependents of unversioned private packages are not explicitly listed by the ignore flag", async () => {
       const cwd = await testdir({
         "package.json": JSON.stringify({
           private: true,

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -179,7 +179,7 @@ export async function run(
         return;
       }
       case "tag": {
-        await tagCommand(cwd);
+        await tagCommand(cwd, config);
         return;
       }
       case "pre": {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -146,9 +146,11 @@ export async function run(
           bumpVersionsWithWorkspaceProtocolOnly:
             config.bumpVersionsWithWorkspaceProtocolOnly,
         });
+        // TODO(jakebailey): should this check isVersionablePackage?
         for (const ignoredPackage of config.ignore) {
           const dependents = dependentsGraph.get(ignoredPackage) || [];
           for (const dependent of dependents) {
+            // TODO(jakebailey): should this check isVersionablePackage?
             if (!config.ignore.includes(dependent)) {
               messages.push(
                 `The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please pass "${dependent}" to the \`--ignore\` flag.`

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -3,7 +3,7 @@ import { getChangedPackagesSinceRef } from "@changesets/git";
 import { Package } from "@manypkg/get-packages";
 
 // Note: if updating this, also update the other copies of createIsVersionablePackage.
-function createIsVersionablePackage(
+export function createIsVersionablePackage(
   ignoredPackages: readonly string[],
   allowPrivatePackages: boolean
 ): (pkg: Package) => boolean {

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -3,7 +3,6 @@ import { getChangedPackagesSinceRef } from "@changesets/git";
 import { Package } from "@manypkg/get-packages";
 
 // Note: if updating this, also update the other copies of createIsVersionablePackage.
-// TODO(jakebailey): don't copy paste
 function createIsVersionablePackage(
   ignoredPackages: readonly string[],
   allowPrivatePackages: boolean

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -32,6 +32,14 @@ export function filterVersionablePackages(config: Config, packages: Package[]) {
   return packages.filter((pkg) => isVersionablePackage(pkg, options));
 }
 
+export function filterTaggablePackages(config: Config, packages: Package[]) {
+  const options = {
+    ignoredPackages: new Set(config.ignore),
+    versionPrivatePackages: config.privatePackages.tag,
+  };
+  return packages.filter((pkg) => isVersionablePackage(pkg, options));
+}
+
 export async function getVersionableChangedPackages(
   config: Config,
   {

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -6,17 +6,17 @@ function isVersionablePackage(
   { packageJson }: Package,
   {
     ignoredPackages,
-    versionPrivatePackages,
+    ignorePrivatePackages,
   }: {
     ignoredPackages: Set<string>;
-    versionPrivatePackages: boolean;
+    ignorePrivatePackages: boolean;
   }
 ) {
   if (ignoredPackages.has(packageJson.name)) {
     return false;
   }
 
-  if (packageJson.private && !versionPrivatePackages) {
+  if (packageJson.private && !ignorePrivatePackages) {
     return false;
   }
 
@@ -27,7 +27,7 @@ function isVersionablePackage(
 export function filterVersionablePackages(config: Config, packages: Package[]) {
   const options = {
     ignoredPackages: new Set(config.ignore),
-    versionPrivatePackages: config.privatePackages.version,
+    ignorePrivatePackages: config.privatePackages.version,
   };
   return packages.filter((pkg) => isVersionablePackage(pkg, options));
 }
@@ -35,7 +35,7 @@ export function filterVersionablePackages(config: Config, packages: Package[]) {
 export function filterTaggablePackages(config: Config, packages: Package[]) {
   const options = {
     ignoredPackages: new Set(config.ignore),
-    versionPrivatePackages: config.privatePackages.tag,
+    ignorePrivatePackages: config.privatePackages.tag,
   };
   return packages.filter((pkg) => isVersionablePackage(pkg, options));
 }

--- a/packages/should-skip-package/package.json
+++ b/packages/should-skip-package/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@changesets/should-skip-package",
+  "version": "0.1.0",
+  "description": "Checks if a package should be skipped for versioning or tagging purposes",
+  "main": "dist/changesets-should-skip-package.cjs.js",
+  "module": "dist/changesets-should-skip-package.esm.js",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/changesets-should-skip-package.cjs.mjs",
+        "default": "./dist/changesets-should-skip-package.cjs.js"
+      },
+      "module": "./dist/changesets-should-skip-package.esm.js",
+      "import": "./dist/changesets-should-skip-package.cjs.mjs",
+      "default": "./dist/changesets-should-skip-package.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/changesets/changesets/tree/main/packages/should-skip-package",
+  "dependencies": {
+    "@babel/runtime": "^7.20.1",
+    "@changesets/types": "^6.0.0",
+    "@manypkg/get-packages": "^1.1.3"
+  },
+  "devDependencies": {
+    "@changesets/test-utils": "*"
+  }
+}

--- a/packages/should-skip-package/src/index.ts
+++ b/packages/should-skip-package/src/index.ts
@@ -1,0 +1,23 @@
+import { Package } from "@manypkg/get-packages";
+import { PackageGroup } from "@changesets/types";
+
+export function shouldSkipPackage(
+  { packageJson }: Package,
+  {
+    ignore,
+    allowPrivatePackages,
+  }: {
+    ignore: PackageGroup;
+    allowPrivatePackages: boolean;
+  }
+) {
+  if (ignore.includes(packageJson.name)) {
+    return true;
+  }
+
+  if (packageJson.private && !allowPrivatePackages) {
+    return true;
+  }
+
+  return !packageJson.version;
+}


### PR DESCRIPTION
This works for `version` and `tag`, at least in my testing for https://github.com/microsoft/TypeScript-Website/pull/3116.

~However, there seem to be other places that should be checking this, but have less convenient access to actual Package objects. That and it's not clear to me if the other cases actually matter.~

~Also, needs tests...~ And to figure out where to move this shared code as there is no common package for these besides `types` which is types only.