### PR TITLE
feat: Add support for config files in CommonJS format

### DIFF
--- a/.changeset/clever-scissors-dream.md
+++ b/.changeset/clever-scissors-dream.md
@@ -4,8 +4,8 @@
 
 Add support for config file in CommonJS or ESM
 
-The changesets configuration file can now be in CommonJS (config.cjs) or ES6 module (config.mjs) format, in addition to
-JSON. Despite being code, the expected format/type of the config object is the same as the JSON format.
+The changesets configuration file can now be in CommonJS (config.cjs) or JSONC (config.jsonc) format, in addition to
+JSON. Despite being code, the CJS expected format/type of the config object is the same as the JSON format.
 
 Benefits to this change include:
 

--- a/.changeset/clever-scissors-dream.md
+++ b/.changeset/clever-scissors-dream.md
@@ -3,3 +3,11 @@
 ---
 
 Add support for config file in CommonJS or ESM
+
+The changesets configuration file can now be in CommonJS (config.cjs) or ES6 module (config.mjs) format, in addition to
+JSON. Despite being code, the expected format/type of the config object is the same as the JSON format.
+
+Benefits to this change include:
+
+- Comments can now be added to the config file.
+- Configurations for some properties (e.g. fixed and linked package groups) can be calculated at runtime.

--- a/.changeset/clever-scissors-dream.md
+++ b/.changeset/clever-scissors-dream.md
@@ -1,11 +1,12 @@
 ---
 "@changesets/config": minor
+"@changesets/cli": minor
 ---
 
-Add support for config file in CommonJS or ESM
+Add support for config file in CommonJS
 
-The changesets configuration file can now be in CommonJS (config.cjs) or JSONC (config.jsonc) format, in addition to
-JSON. Despite being code, the CJS expected format/type of the config object is the same as the JSON format.
+The changesets configuration file can now be in CommonJS (config.cjs) format in addition to JSON. Despite being code,
+the CJS expected format/type of the config object is the same as the JSON format.
 
 Benefits to this change include:
 

--- a/.changeset/clever-scissors-dream.md
+++ b/.changeset/clever-scissors-dream.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": minor
+---
+
+Add support for config file in CommonJS or ESM

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,8 +30,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "cosmiconfig": "^9.0.0",
     "fs-extra": "^7.0.1",
-    "micromatch": "^4.0.2",
-    "tiny-jsonc": "^1.0.1"
+    "micromatch": "^4.0.2"
   },
   "devDependencies": {
     "@changesets/test-utils": "*",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,6 +28,7 @@
     "@changesets/logger": "^0.1.0",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
+    "cosmiconfig": "^9.0.0",
     "fs-extra": "^7.0.1",
     "micromatch": "^4.0.2"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,7 +30,8 @@
     "@manypkg/get-packages": "^1.1.3",
     "cosmiconfig": "^9.0.0",
     "fs-extra": "^7.0.1",
-    "micromatch": "^4.0.2"
+    "micromatch": "^4.0.2",
+    "tiny-jsonc": "^1.0.1"
   },
   "devDependencies": {
     "@changesets/test-utils": "*",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,4 +1,4 @@
-import { read, parse } from "./";
+import { parse, read, readAnyConfigFile } from "./";
 import jestInCase from "jest-in-case";
 import * as logger from "@changesets/logger";
 import { Config, WrittenConfig } from "@changesets/types";
@@ -37,7 +37,91 @@ test("read reads the config", async () => {
       commit: true,
     }),
   });
-  let config = await read(cwd, defaultPackages);
+  let config = await readAnyConfigFile(cwd, defaultPackages);
+  expect(config).toEqual({
+    fixed: [],
+    linked: [],
+    changelog: false,
+    commit: ["@changesets/cli/commit", { skipCI: "version" }],
+    access: "restricted",
+    baseBranch: "master",
+    changedFilePatterns: ["**"],
+    updateInternalDependencies: "patch",
+    ignore: [],
+    bumpVersionsWithWorkspaceProtocolOnly: false,
+    privatePackages: {
+      tag: false,
+      version: true,
+    },
+    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+      onlyUpdatePeerDependentsWhenOutOfRange: false,
+      updateInternalDependents: "out-of-range",
+    },
+    snapshot: {
+      useCalculatedVersion: false,
+      prereleaseTemplate: null,
+    },
+  });
+});
+
+const cjsConfig = `// @ts-check
+
+/** @type {import("@changesets/types").WrittenConfig} */
+const config = {
+  changelog: false,
+  commit: true,
+};
+
+module.exports = config;
+`;
+
+test("read cjs format", async () => {
+  let cwd = await testdir({
+    ".changeset/config.cjs": cjsConfig,
+  });
+  let config = await read2(cwd, defaultPackages);
+  expect(config).toEqual({
+    fixed: [],
+    linked: [],
+    changelog: false,
+    commit: ["@changesets/cli/commit", { skipCI: "version" }],
+    access: "restricted",
+    baseBranch: "master",
+    changedFilePatterns: ["**"],
+    updateInternalDependencies: "patch",
+    ignore: [],
+    bumpVersionsWithWorkspaceProtocolOnly: false,
+    privatePackages: {
+      tag: false,
+      version: true,
+    },
+    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+      onlyUpdatePeerDependentsWhenOutOfRange: false,
+      updateInternalDependents: "out-of-range",
+    },
+    snapshot: {
+      useCalculatedVersion: false,
+      prereleaseTemplate: null,
+    },
+  });
+});
+
+const mjsConfig = `// @ts-check
+
+/** @type {import("@changesets/types").WrittenConfig} */
+export const config = {
+  changelog: false,
+  commit: true,
+};
+
+// export default config;
+`;
+
+test("read mjs format", async () => {
+  let cwd = await testdir({
+    ".changeset/config.mjs": mjsConfig,
+  });
+  let config = await read2(cwd, defaultPackages);
   expect(config).toEqual({
     fixed: [],
     linked: [],

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -106,45 +106,6 @@ test("read cjs format", async () => {
   });
 });
 
-const jsoncConfig = `{
-  // JSONC supports comments in the config file.
-  changelog: false,
-  // And trailing commas...
-  commit: true,
-}
-`;
-
-test("read jsonc format", async () => {
-  let cwd = await testdir({
-    ".changeset/config.jsonc": jsoncConfig,
-  });
-  let config = await read(cwd, defaultPackages);
-  expect(config).toEqual({
-    fixed: [],
-    linked: [],
-    changelog: false,
-    commit: ["@changesets/cli/commit", { skipCI: "version" }],
-    access: "restricted",
-    baseBranch: "master",
-    changedFilePatterns: ["**"],
-    updateInternalDependencies: "patch",
-    ignore: [],
-    bumpVersionsWithWorkspaceProtocolOnly: false,
-    privatePackages: {
-      tag: false,
-      version: true,
-    },
-    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-      onlyUpdatePeerDependentsWhenOutOfRange: false,
-      updateInternalDependents: "out-of-range",
-    },
-    snapshot: {
-      useCalculatedVersion: false,
-      prereleaseTemplate: null,
-    },
-  });
-});
-
 let defaults: Config = {
   fixed: [],
   linked: [],

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -30,6 +30,13 @@ const withPackages = (pkgNames: string[]) => ({
   })),
 });
 
+test("missing config throws", async () => {
+  let cwd = await testdir({
+    ".changeset/README.md": "",
+  });
+  expect(async () => await read(cwd, defaultPackages)).toThrowError();
+});
+
 test("read reads the config", async () => {
   let cwd = await testdir({
     ".changeset/config.json": JSON.stringify({

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, read } from "./";
+import { read, parse } from "./";
 import jestInCase from "jest-in-case";
 import * as logger from "@changesets/logger";
 import { Config, WrittenConfig } from "@changesets/types";

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, read, readAnyConfigFile } from "./";
+import { parse, read } from "./";
 import jestInCase from "jest-in-case";
 import * as logger from "@changesets/logger";
 import { Config, WrittenConfig } from "@changesets/types";
@@ -37,7 +37,7 @@ test("read reads the config", async () => {
       commit: true,
     }),
   });
-  let config = await readAnyConfigFile(cwd, defaultPackages);
+  let config = await read(cwd, defaultPackages);
   expect(config).toEqual({
     fixed: [],
     linked: [],
@@ -79,7 +79,7 @@ test("read cjs format", async () => {
   let cwd = await testdir({
     ".changeset/config.cjs": cjsConfig,
   });
-  let config = await read2(cwd, defaultPackages);
+  let config = await read(cwd, defaultPackages);
   expect(config).toEqual({
     fixed: [],
     linked: [],
@@ -121,7 +121,7 @@ test("read mjs format", async () => {
   let cwd = await testdir({
     ".changeset/config.mjs": mjsConfig,
   });
-  let config = await read2(cwd, defaultPackages);
+  let config = await read(cwd, defaultPackages);
   expect(config).toEqual({
     fixed: [],
     linked: [],

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -106,20 +106,17 @@ test("read cjs format", async () => {
   });
 });
 
-const mjsConfig = `// @ts-check
-
-/** @type {import("@changesets/types").WrittenConfig} */
-export const config = {
+const jsoncConfig = `{
+  // JSONC supports comments in the config file.
   changelog: false,
+  // And trailing commas...
   commit: true,
-};
-
-// export default config;
+}
 `;
 
-test("read mjs format", async () => {
+test("read jsonc format", async () => {
   let cwd = await testdir({
-    ".changeset/config.mjs": mjsConfig,
+    ".changeset/config.jsonc": jsoncConfig,
   });
   let config = await read(cwd, defaultPackages);
   expect(config).toEqual({

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -30,13 +30,6 @@ const withPackages = (pkgNames: string[]) => ({
   })),
 });
 
-test("missing config throws", async () => {
-  let cwd = await testdir({
-    ".changeset/README.md": "",
-  });
-  expect(async () => await read(cwd, defaultPackages)).toThrowError();
-});
-
 test("read reads the config", async () => {
   let cwd = await testdir({
     ".changeset/config.json": JSON.stringify({

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -99,28 +99,11 @@ export let readConfigJson = async (
   return parse(json, packages);
 };
 
-let readConfigJsonc = async (
-  cwd: string,
-  packages: Packages
-): Promise<Config> => {
-  let json = await fs.readFile(path.join(cwd, ".changeset", "config.jsonc"), {
-    encoding: "utf8",
-  });
-  const JSONC = await import("tiny-jsonc");
-  let configObject: WrittenConfig = JSONC.default.parse(json);
-  return parse(configObject, packages);
-};
-
 export let read = async (cwd: string, packages: Packages): Promise<Config> => {
   // If a config.json file exists in the expected path, short-circuit to the old behavior.
   const originalConfigFilePath = path.join(cwd, ".changeset", "config.json");
   if (fs.existsSync(originalConfigFilePath)) {
     return readConfigJson(cwd, packages);
-  }
-
-  const jsoncConfigPath = path.join(cwd, ".changeset", "config.jsonc");
-  if (fs.existsSync(jsoncConfigPath)) {
-    return readConfigJsonc(cwd, packages);
   }
 
   // Dynamically load cosmiconfig only if we proceed down this code path.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -109,10 +109,10 @@ export let read = async (cwd: string, packages: Packages): Promise<Config> => {
   // Dynamically load cosmiconfig only if we proceed down this code path.
   const { cosmiconfig } = await import("cosmiconfig");
   const configExplorer = cosmiconfig("changesets", {
-    // Only check for CommonJS config; JSON and JSONC formats are loaded by existing logic above. The .mjs file format
-    // is exlcuded because it seems to break tests. The .js extension is excluded because there is code elsewhere that
-    // assumes such a file is a V1 changesets config file. To limit the size of this change, only .cjs config files will
-    // be loaded. A future change could add to this list and fully remove code related to the V1 config format.
+    // Only check for CommonJS config; JSON is loaded by existing logic above. The .mjs file format is exlcuded because
+    // it seems to break tests. The .js extension is excluded because there is code elsewhere that assumes such a file
+    // is a V1 changesets config file. To limit the size of this change, only .cjs config files will be loaded. A future
+    // change could add to this list and fully remove code related to the V1 config format.
     searchPlaces: [".changeset/config.cjs"],
 
     // Don't look up the folder tree for additional config files.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,9 +13,8 @@ import {
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
-import JSONC from "tiny-jsonc";
 
-export let defaultWrittenConfig: WrittenConfig = {
+export let defaultWrittenConfig = {
   $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
   changelog: "@changesets/cli/changelog",
   commit: false,
@@ -107,7 +106,8 @@ let readConfigJsonc = async (
   let json = await fs.readFile(path.join(cwd, ".changeset", "config.jsonc"), {
     encoding: "utf8",
   });
-  let configObject: WrittenConfig = JSONC.parse(json);
+  const JSONC = await import("tiny-jsonc");
+  let configObject: WrittenConfig = JSONC.default.parse(json);
   return parse(configObject, packages);
 };
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -14,7 +14,7 @@ import {
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
 
-export let defaultWrittenConfig = {
+export let defaultWrittenConfig: WrittenConfig = {
   $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
   changelog: "@changesets/cli/changelog",
   commit: false,
@@ -91,45 +91,44 @@ function isArray<T>(
   return Array.isArray(arg);
 }
 
-export let readV2ConfigFile = async (cwd: string, packages: Packages) => {
+export let readConfigJson = async (
+  cwd: string,
+  packages: Packages
+): Promise<Config> => {
   let json = await fs.readJSON(path.join(cwd, ".changeset", "config.json"));
   return parse(json, packages);
 };
 
 export let read = async (cwd: string, packages: Packages): Promise<Config> => {
-  return readV2ConfigFile(cwd, packages);
-};
-
-export let readAnyConfigFile = async (
-  cwd: string,
-  packages: Packages
-): Promise<Config> => {
+  // If a config.json file exists in the expected path, short-circuit to the old behavior.
   const originalConfigFilePath = path.join(cwd, ".changeset", "config.json");
-
   if (fs.existsSync(originalConfigFilePath)) {
-    return readV2ConfigFile(cwd, packages);
+    return readConfigJson(cwd, packages);
   }
 
-  throw new Error(`Cannot find config at path ${originalConfigFilePath}`);
-  // const { cosmiconfig } = await import("cosmiconfig");
-  // // const searchOptions
-  // const configExplorer = cosmiconfig("changesets", {
-  //   searchPlaces: [".changeset/config.cjs", ".changeset/config.json"],
+  // Dynamically load cosmiconfig only if we proceed down this code path.
+  const { cosmiconfig } = await import("cosmiconfig");
+  const configExplorer = cosmiconfig("changesets", {
+    // Only check for CommonJS and ESM (mjs) files; JSON format is loaded by existing logic above.
+    // The .js extension is excluded because there is code elsewhere that assumes such a file is a V1 changesets config
+    // file. To limit the size of this change, only .cjs and .mjs config files will be loaded. A future change could add
+    // to this list and fully remove code related to the V1 config format.
+    searchPlaces: [".changeset/config.cjs", ".changeset/config.mjs"],
 
-  //   // Don't look up the folder tree for additional config files
-  //   searchStrategy: "none",
+    // Don't look up the folder tree for additional config files.
+    searchStrategy: "none",
 
-  //   // Don't look in any of the default search places; only use those defined above
-  //   mergeSearchPlaces: false,
-  // });
+    // Don't look in any of the default search places; only use those defined above.
+    mergeSearchPlaces: false,
+  });
 
-  // const searchResult = await configExplorer.search(cwd);
-  // if (searchResult?.config === undefined) {
-  //   throw new Error(`Cannot find changesets config.`);
-  // }
+  const searchResult = await configExplorer.search(cwd);
+  if (searchResult?.config === undefined) {
+    throw new Error(`Cannot find changesets config.`);
+  }
 
-  // const config: WrittenConfig = searchResult?.config;
-  // return parse(config, packages);
+  const config: WrittenConfig = searchResult?.config;
+  return parse(config, packages);
 };
 
 export let parse = (json: WrittenConfig, packages: Packages): Config => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -91,9 +91,45 @@ function isArray<T>(
   return Array.isArray(arg);
 }
 
-export let read = async (cwd: string, packages: Packages) => {
+export let readV2ConfigFile = async (cwd: string, packages: Packages) => {
   let json = await fs.readJSON(path.join(cwd, ".changeset", "config.json"));
   return parse(json, packages);
+};
+
+export let read = async (cwd: string, packages: Packages): Promise<Config> => {
+  return readV2ConfigFile(cwd, packages);
+};
+
+export let readAnyConfigFile = async (
+  cwd: string,
+  packages: Packages
+): Promise<Config> => {
+  const originalConfigFilePath = path.join(cwd, ".changeset", "config.json");
+
+  if (fs.existsSync(originalConfigFilePath)) {
+    return readV2ConfigFile(cwd, packages);
+  }
+
+  throw new Error(`Cannot find config at path ${originalConfigFilePath}`);
+  // const { cosmiconfig } = await import("cosmiconfig");
+  // // const searchOptions
+  // const configExplorer = cosmiconfig("changesets", {
+  //   searchPlaces: [".changeset/config.cjs", ".changeset/config.json"],
+
+  //   // Don't look up the folder tree for additional config files
+  //   searchStrategy: "none",
+
+  //   // Don't look in any of the default search places; only use those defined above
+  //   mergeSearchPlaces: false,
+  // });
+
+  // const searchResult = await configExplorer.search(cwd);
+  // if (searchResult?.config === undefined) {
+  //   throw new Error(`Cannot find changesets config.`);
+  // }
+
+  // const config: WrittenConfig = searchResult?.config;
+  // return parse(config, packages);
 };
 
 export let parse = (json: WrittenConfig, packages: Packages): Config => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,11 +7090,6 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-tiny-jsonc@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tiny-jsonc/-/tiny-jsonc-1.0.1.tgz#71de47c9d812b411e87a9f3ab4a5fe42cd8d8f9c"
-  integrity sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,6 +7090,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+tiny-jsonc@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-jsonc/-/tiny-jsonc-1.0.1.tgz#71de47c9d812b411e87a9f3ab4a5fe42cd8d8f9c"
+  integrity sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2932,6 +2932,16 @@ core-js-compat@^3.25.1:
   dependencies:
     browserslist "^4.21.4"
 
+cosmiconfig@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
+  dependencies:
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3207,6 +3217,11 @@ enquirer@^2.3.6:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+env-paths@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -4295,7 +4310,7 @@ import-fresh@^3.0.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-fresh@^3.2.1:
+import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==


### PR DESCRIPTION
Fixes https://github.com/changesets/changesets/issues/1125.

The changesets configuration file can now be in CommonJS (config.cjs) format in addition to JSON. Despite being code, the expected format/type of the CJS config object is the same as the JSON format (that is, a `WrittenConfig` object).

To limit potential back-compat issues, the .changeset/config.json path is checked first, and if that file exists, the current code is used to load the config. The new code is only invoked when a config.json file is not found. In the future it may be worthwhile to unify the code more completely.

I didn't add support for .js files because there is code elsewhere that assumes such a file is a V1 changesets config file. To limit the size of this change, only .cjs config files will be loaded. A future change could add to this list and fully remove code related to the V1 config format.

.mjs files were included in an earlier version of this PR but was removed because the test infrastructure seems to always parse them as CJS despite the file extension.

.jsonc support was also included in an earlier version of this PR but was removed because the jsonc parser (tiny-jsonc) exhibited similar behavior as with .mjs files. That is, in the test environment the module was parsed as CJS despite being ESM.