### PR TITLE
Stop requiring `tool` as part of `Packages` in certain packages

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -122,7 +122,7 @@ type OptionalProp<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 function assembleReleasePlan(
   changesets: NewChangeset[],
-  packages: Packages,
+  packages: Omit<Packages, "tool">,
   config: OptionalProp<Config, "snapshot">,
   // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
   preState: PreState | undefined,

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -54,7 +54,7 @@ const getValidRange = (potentialRange: string) => {
 };
 
 export default function getDependencyGraph(
-  packages: Packages,
+  packages: Omit<Packages, "tool">,
   {
     ignoreDevDependencies = false,
     bumpVersionsWithWorkspaceProtocolOnly = false,

--- a/packages/get-dependents-graph/src/index.ts
+++ b/packages/get-dependents-graph/src/index.ts
@@ -2,7 +2,7 @@ import { Packages, Package } from "@manypkg/get-packages";
 import getDependencyGraph from "./get-dependency-graph";
 
 export function getDependentsGraph(
-  packages: Packages,
+  packages: Omit<Packages, "tool">,
   opts?: {
     ignoreDevDependencies?: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;


### PR DESCRIPTION
It turns out that it's difficult for `changesets/bot` to create the proper `Packages` object. It's only forced to do it because types expect the `tool` property but it's not actually needed at runtime

This should be cleaned up further but I don't have the energy to figure out the more proper code organization right now.