### PR TITLE
Replace meow with mri

### DIFF
--- a/.changeset/many-jeans-hammer.md
+++ b/.changeset/many-jeans-hammer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Replace `meow` dependency with `mri` to reduce the number of transitive dependencies

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/jest-in-case": "^1.0.6",
     "@types/js-yaml": "^3.12.1",
     "@types/lodash": "^4.14.136",
-    "@types/meow": "^5.0.0",
     "@types/prettier": "^2.7.1",
     "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -90,7 +90,7 @@
     "external-editor": "^3.1.0",
     "fs-extra": "^7.0.1",
     "human-id": "^1.0.2",
-    "meow": "^6.0.0",
+    "mri": "^1.2.0",
     "outdent": "^0.5.0",
     "p-limit": "^2.2.0",
     "preferred-pm": "^3.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,7 +42,8 @@ if (parsed.snapshot === "" && args[args.indexOf("--snapshot") + 1] !== "") {
   parsed.snapshot = true;
 }
 
-if (parsed.help) {
+// Help message should only be shown if it's the only argument passed
+if (parsed.help && args.length === 1) {
   console.log(
     `
   Organise your package versioning and publishing to make both contributors and maintainers happy

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,52 @@
-import meow from "meow";
+import mri from "mri";
 import { ExitError, InternalError } from "@changesets/errors";
 import { error } from "@changesets/logger";
 import { format } from "util";
 import { run } from "./run";
 
-const { input, flags } = meow(
-  `
+const args = process.argv.slice(2);
+
+const parsed = mri(args, {
+  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot"],
+  string: [
+    "output",
+    "otp",
+    "since",
+    "ignore",
+    "tag",
+    "snapshot",
+    "snapshotPrereleaseTemplate",
+  ],
+  alias: {
+    // Short flags
+    v: "verbose",
+    o: "output",
+    // Support kebab-case flags
+    "since-master": "sinceMaster",
+    "git-tag": "gitTag",
+    "snapshot-prerelease-template": "snapshotPrereleaseTemplate",
+    // Deprecated flags
+    "update-changelog": "updateChangelog",
+    "is-public": "isPublic",
+    "skip-c-i": "skipCI",
+  },
+  default: {
+    gitTag: true,
+  },
+});
+
+// `mri` doesn't handle mixed boolean and strings well. It'll always try to coerce it as
+// a string even if only `--snapshot` is passed. We check here if this was the case and
+// try to coerce it as a boolean
+if (parsed.snapshot === "" && args[args.indexOf("--snapshot") + 1] !== "") {
+  parsed.snapshot = true;
+}
+
+if (parsed.help) {
+  console.log(
+    `
+  Organise your package versioning and publishing to make both contributors and maintainers happy
+
   Usage
     $ changeset [command]
   Commands
@@ -16,56 +57,15 @@ const { input, flags } = meow(
     status [--since <branch>] [--verbose] [--output JSON_FILE.json]
     pre <enter|exit> <tag>
     tag
-    `,
-  {
-    flags: {
-      sinceMaster: {
-        type: "boolean",
-      },
-      verbose: {
-        type: "boolean",
-        alias: "v",
-      },
-      output: {
-        type: "string",
-        alias: "o",
-      },
-      otp: {
-        type: "string",
-      },
-      empty: {
-        type: "boolean",
-      },
-      since: {
-        type: "string",
-      },
-      ignore: {
-        type: "string",
-        isMultiple: true,
-      },
-      tag: {
-        type: "string",
-      },
-      open: {
-        type: "boolean",
-      },
-      gitTag: {
-        type: "boolean",
-        default: true,
-      },
-      snapshotPrereleaseTemplate: {
-        type: "string",
-      },
-      // mixed type like this is not supported by `meow`
-      // if it gets passed explicitly then it's still available on the flags with an inferred type though
-      // snapshot: { type: "boolean" | "string" },
-    },
-  }
-);
+
+    `
+  );
+  process.exit(0);
+}
 
 const cwd = process.cwd();
 
-run(input, flags, cwd).catch((err) => {
+run(parsed._, parsed, cwd).catch((err) => {
   if (err instanceof InternalError) {
     error(
       "The following error is an internal unexpected error, these should never happen."
@@ -73,7 +73,7 @@ run(input, flags, cwd).catch((err) => {
     error("Please open an issue with the following link");
     error(
       `https://github.com/changesets/changesets/issues/new?title=${encodeURIComponent(
-        `Unexpected error during ${input[0] || "add"} command`
+        `Unexpected error during ${parsed._[0] || "add"} command`
       )}&body=${encodeURIComponent(`## Error
 
 \`\`\`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,13 +2003,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
   integrity sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==
 
-"@types/meow@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@types/meow/-/meow-5.0.0.tgz#60653cc3c3f91d6af3a131bd82614acf9b530357"
-  integrity sha512-csdM22P8TFF5KwuHseifUBOzWiGtiLfYmQosrKPGpA/xdK3o3PNo3+4YOpiJ5BQBshwO2kuhdJ7NoAitQ6m/jg==
-  dependencies:
-    "@types/minimist-options" "*"
-
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -2022,14 +2015,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/minimist-options@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/minimist-options/-/minimist-options-3.0.0.tgz#0dabe91d07e21c9b3fe9614ca862aab202566eb5"
-  integrity sha512-FYeTlkAANOr9KR0mQL7X+v7MT7Nb/aWdNNHNKzJ8sPctpS2Ei8ucgMbvQRbLRjaYZH2OVN5AGDGGcHV5x8lSgQ==
-  dependencies:
-    "@types/minimist" "*"
-
-"@types/minimist@*", "@types/minimist@^1.2.0":
+"@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
@@ -5476,23 +5462,6 @@ mdast-util-to-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
 
-meow@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
-  integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "^4.0.2"
-    normalize-package-data "^2.5.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.13.1"
-    yargs-parser "^18.1.3"
-
 meow@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.1.tgz#7c01595e3d337fcb0ec4e8eed1666ea95903d306"
@@ -5589,7 +5558,7 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@4.1.0, minimist-options@^4.0.2:
+minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
   integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
@@ -5642,6 +5611,11 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mri@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`meow` v6 [has 62 transitive dependencies](https://npmgraph.js.org/?q=meow%40v6#zoom=w) and it would be nice to avoid them in a CLI. While we could also upgrade to `meow` v13, which has 0 deps (because bundled), it has a higher nodejs version restriction. Also, the CLI here isn't using `meow` to its fullest potential, only relying on its help message logging and argument parsing.

In this PR, I refactored to use `mri` for argument parsing only. I've tested the CLI calls manually to prevent any syntax regressions.

<table>
<tr>
  <td>Before
  <td>After
</tr>
<tr>
  <td><img width="706" alt="Screenshot 2024-06-24 at 1 43 30 PM" src="https://github.com/changesets/changesets/assets/34116392/0110cac0-11bd-47f7-b2e9-f4b8543201c2">

  <td><img width="704" alt="image" src="https://github.com/changesets/changesets/assets/34116392/0d2343a5-7b44-4055-93bf-5314f57eea02">
</tr>
<tr>
  <td><img width="466" alt="Screenshot 2024-06-24 at 1 45 02 PM" src="https://github.com/changesets/changesets/assets/34116392/9da9bbc3-9b20-447f-8359-75b561bba4c0">

  <td><img width="468" alt="image" src="https://github.com/changesets/changesets/assets/34116392/962cf63e-1079-4528-b2ba-eae1a3eb2ce3">
</tr>
<tr>
  <td><img width="602" alt="Screenshot 2024-06-24 at 1 44 31 PM" src="https://github.com/changesets/changesets/assets/34116392/48992196-e09d-4f56-b13a-0940a0756b38">
  <td><img width="601" alt="image" src="https://github.com/changesets/changesets/assets/34116392/ff46d463-39b6-44d0-8acf-20c0229442ca">
</tr>
<tr>
  <td><img width="439" alt="Screenshot 2024-06-24 at 1 43 42 PM" src="https://github.com/changesets/changesets/assets/34116392/56ee2cad-3e62-40bd-bc10-f619b1b4423a">
  <td><img width="436" alt="image" src="https://github.com/changesets/changesets/assets/34116392/feac5022-4da1-41ea-a763-33e54de15d01">
</tr>
</table>
