### PR TITLE
Default privatePackages.tag to true to match old buggy behavior

### DIFF
--- a/.changeset/spicy-bottles-try.md
+++ b/.changeset/spicy-bottles-try.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Default privatePackages.tag to true to match old buggy behavior

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -486,9 +486,9 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         : json.privatePackages
         ? {
             version: json.privatePackages.version ?? true,
-            tag: json.privatePackages.tag ?? false,
+            tag: json.privatePackages.tag ?? true,
           }
-        : { version: true, tag: false },
+        : { version: true, tag: true },
   };
 
   if (


### PR DESCRIPTION
Per https://github.com/changesets/changesets/issues/1383#issuecomment-2181280964

Due to a bug fixed in https://github.com/changesets/changesets/pull/1361, `tag: false` did not actually have any effect, so private packages were still tagged. This surprised many people, so I think it may be worthwile to just default this to "true" to match the buggy behavior.