### PR TITLE
Feature: staged packages

### DIFF
--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -13,6 +13,7 @@ import {
   askList,
 } from "../../../utils/cli-utilities";
 import addChangeset from "..";
+import { createNamespacedChoiceMapper } from "../createChangeset";
 
 jest.mock("../../../utils/cli-utilities");
 jest.mock("@changesets/git");
@@ -298,7 +299,9 @@ describe("Changesets", () => {
 
     // @ts-ignore
     const { choices } = askCheckboxPlus.mock.calls[0][1][0];
-    expect(choices).toEqual(["pkg-a", "pkg-c"]);
+    expect(choices).toEqual(
+      ["pkg-a", "pkg-c"].map(createNamespacedChoiceMapper("unchanged"))
+    );
   });
 
   it("should not include private packages without a version in the prompt", async () => {
@@ -326,7 +329,9 @@ describe("Changesets", () => {
 
     // @ts-ignore
     const { choices } = askCheckboxPlus.mock.calls[0][1][0];
-    expect(choices).toEqual(["pkg-a", "pkg-c"]);
+    expect(choices).toEqual(
+      ["pkg-a", "pkg-c"].map(createNamespacedChoiceMapper("unchanged"))
+    );
   });
 
   it("should not include private packages with a version in the prompt if private packages are configured to be not versionable", async () => {
@@ -365,6 +370,8 @@ describe("Changesets", () => {
 
     // @ts-ignore
     const { choices } = askCheckboxPlus.mock.calls[0][1][0];
-    expect(choices).toEqual(["pkg-a", "pkg-c"]);
+    expect(choices).toEqual(
+      ["pkg-a", "pkg-c"].map(createNamespacedChoiceMapper("unchanged"))
+    );
   });
 });

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -28,6 +28,10 @@ git.getChangedPackagesSinceRef.mockImplementation(({ ref }) => {
   expect(ref).toBe("master");
   return [];
 });
+// @ts-ignore
+git.getStagedPackages.mockImplementation(() => {
+  return [];
+});
 
 // @ts-ignore
 const mockUserResponses = (mockResponses) => {

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -46,19 +46,6 @@ export function deNamespace(pkgName: string) {
   return pkgName.replace(/#.*$/, "");
 }
 
-enum ReleaseCategories {
-  StagedPackages = "staged packages",
-  ChangedPackages = "changed packages",
-  UnchangedPakcages = "unchanged packages",
-}
-
-const isReleaseCategory = (x: string): x is ReleaseCategories =>
-  [
-    ReleaseCategories.StagedPackages,
-    ReleaseCategories.ChangedPackages,
-    ReleaseCategories.UnchangedPakcages,
-  ].includes(x as ReleaseCategories);
-
 async function getPackagesToRelease(
   stagedPackages: Array<string>,
   changedPackages: Array<string>,
@@ -75,7 +62,12 @@ async function getPackagesToRelease(
         // of packages shown after selection
         if (Array.isArray(x)) {
           return x
-            .filter((x) => !isReleaseCategory(x))
+            .filter(
+              (x) =>
+                x !== "staged packages" &&
+                x !== "changed packages" &&
+                x !== "unchanged packages"
+            )
             .map((x) => cyan(x))
             .join(", ");
         }
@@ -93,15 +85,15 @@ async function getPackagesToRelease(
       );
     const defaultChoiceList = [
       {
-        name: ReleaseCategories.StagedPackages,
+        name: "staged packages",
         choices: stagedPackages.map(createNamespacedChoiceMapper("staged")),
       },
       {
-        name: ReleaseCategories.ChangedPackages,
+        name: "changed packages",
         choices: changedPackages.map(createNamespacedChoiceMapper("changed")),
       },
       {
-        name: ReleaseCategories.UnchangedPakcages,
+        name: "unchanged packages",
         choices: unchangedPackagesNames.map(
           createNamespacedChoiceMapper("unchanged")
         ),
@@ -120,7 +112,12 @@ async function getPackagesToRelease(
     }
     return packagesToRelease
       .map(deNamespace)
-      .filter((pkgName) => !isReleaseCategory(pkgName));
+      .filter(
+        (pkgName) =>
+          pkgName !== "staged packages" &&
+          pkgName !== "changed packages" &&
+          pkgName !== "unchanged packages"
+      );
   }
   return [allPackages[0].packageJson.name];
 }

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -34,6 +34,10 @@ async function confirmMajorRelease(pkgJSON: PackageJSON) {
   return true;
 }
 
+/**
+ * Because some choices in the list maybe duplicated (even though nested),
+ * we need to namespace them to make sure they are unique.
+ */
 export function createNamespacedChoiceMapper(namespace: string) {
   return (pkgName: string) => ({
     name: `${pkgName}#${namespace}`,

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -42,10 +42,6 @@ export function createNamespacedChoiceMapper(namespace: string) {
   });
 }
 
-export function deNamespace(pkgName: string) {
-  return pkgName.replace(/#.*$/, "");
-}
-
 async function getPackagesToRelease(
   stagedPackages: Array<string>,
   changedPackages: Array<string>,
@@ -110,14 +106,12 @@ async function getPackagesToRelease(
         packagesToRelease = await askInitialReleaseQuestion(defaultChoiceList);
       } while (packagesToRelease.length === 0);
     }
-    return packagesToRelease
-      .map(deNamespace)
-      .filter(
-        (pkgName) =>
-          pkgName !== "staged packages" &&
-          pkgName !== "changed packages" &&
-          pkgName !== "unchanged packages"
-      );
+    return packagesToRelease.filter(
+      (pkgName) =>
+        pkgName !== "staged packages" &&
+        pkgName !== "changed packages" &&
+        pkgName !== "unchanged packages"
+    );
   }
   return [allPackages[0].packageJson.name];
 }

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -42,7 +42,7 @@ export function createNamespacedChoiceMapper(namespace: string) {
   return (pkgName: string) => ({
     name: `${pkgName}#${namespace}`,
     message: pkgName,
-    value: pkgName, // FIXME - this seems not to be working
+    value: pkgName,
   });
 }
 

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -34,12 +34,6 @@ async function confirmMajorRelease(pkgJSON: PackageJSON) {
   return true;
 }
 
-enum ReleaseCategories {
-  StagedPackages = "staged packages",
-  ChangedPackages = "changed packages",
-  UnchangedPakcages = "unchanged packages",
-}
-
 export function createNamespacedChoiceMapper(namespace: string) {
   return (pkgName: string) => ({
     name: `${pkgName}#${namespace}`,
@@ -50,6 +44,12 @@ export function createNamespacedChoiceMapper(namespace: string) {
 
 export function deNamespace(pkgName: string) {
   return pkgName.replace(/#.*$/, "");
+}
+
+enum ReleaseCategories {
+  StagedPackages = "staged packages",
+  ChangedPackages = "changed packages",
+  UnchangedPakcages = "unchanged packages",
 }
 
 const isReleaseCategory = (x: string): x is ReleaseCategories =>

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -40,6 +40,18 @@ enum ReleaseCategories {
   UnchangedPakcages = "unchanged packages",
 }
 
+export function createNamespacedChoiceMapper(namespace: string) {
+  return (pkgName: string) => ({
+    name: `${pkgName}#${namespace}`,
+    message: pkgName,
+    value: pkgName, // FIXME - this seems not to be working
+  });
+}
+
+export function deNamespace(pkgName: string) {
+  return pkgName.replace(/#.*$/, "");
+}
+
 const isReleaseCategory = (x: string): x is ReleaseCategories =>
   [
     ReleaseCategories.StagedPackages,
@@ -70,18 +82,6 @@ async function getPackagesToRelease(
         return x;
       }
     );
-  }
-
-  function createNamespacedChoiceMapper(namespace: string) {
-    return (pkgName: string) => ({
-      name: `${pkgName}#${namespace}`,
-      message: pkgName,
-      value: pkgName, // FIXME - this seems not to be working
-    });
-  }
-
-  function deNamespace(pkgName: string) {
-    return pkgName.replace(/#.*$/, "");
   }
 
   if (allPackages.length > 1) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -11,7 +11,10 @@ import { getPackages } from "@manypkg/get-packages";
 import { ExternalEditor } from "external-editor";
 import { getCommitFunctions } from "../../commit/getCommitFunctions";
 import * as cli from "../../utils/cli-utilities";
-import { getVersionableChangedPackages } from "../../utils/versionablePackages";
+import {
+  getVersionableChangedPackages,
+  getVersionableStagedPackages,
+} from "../../utils/versionablePackages";
 import createChangeset from "./createChangeset";
 import printConfirmationMessage from "./messages";
 
@@ -43,6 +46,12 @@ export default async function add(
       summary: ``,
     };
   } else {
+    const stagedPackagesNames = (
+      await getVersionableStagedPackages(config, {
+        cwd,
+      })
+    ).map((pkg) => pkg.packageJson.name);
+
     const changedPackagesNames = (
       await getVersionableChangedPackages(config, {
         cwd,
@@ -50,6 +59,7 @@ export default async function add(
     ).map((pkg) => pkg.packageJson.name);
 
     newChangeset = await createChangeset(
+      stagedPackagesNames,
       changedPackagesNames,
       versionablePackages
     );

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -52,6 +52,7 @@ async function askCheckboxPlus(
 ): Promise<Array<string>> {
   const name = `CheckboxPlus-${serialId()}`;
 
+  // flatten the choices for easier searching
   const flattened = choices.flatMap((choice) => choice.choices);
 
   return prompt({
@@ -72,10 +73,11 @@ async function askCheckboxPlus(
       return choice.enabled ? state.symbols.checked : state.symbols.indicator;
     },
     result(chosen: any) {
-      return chosen.map(
-        (name: any) =>
-          flattened.find((choice) => choice.name === name)?.value || name
-      );
+      // map the chosen names to their values
+      return chosen.map((name: any) => {
+        // return the value of the choice if it exists, otherwise return the name
+        return flattened.find((choice) => choice.name === name)?.value || name;
+      });
     },
   } as ArrayPromptOptions)
     .then((responses: any) => responses[name])

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -52,6 +52,8 @@ async function askCheckboxPlus(
 ): Promise<Array<string>> {
   const name = `CheckboxPlus-${serialId()}`;
 
+  const flattened = choices.flatMap((choice) => choice.choices);
+
   return prompt({
     type: "autocomplete",
     name,
@@ -68,6 +70,12 @@ async function askCheckboxPlus(
     },
     indicator(state: any, choice: any) {
       return choice.enabled ? state.symbols.checked : state.symbols.indicator;
+    },
+    result(chosen: any) {
+      return chosen.map(
+        (name: any) =>
+          flattened.find((choice) => choice.name === name)?.value || name
+      );
     },
   } as ArrayPromptOptions)
     .then((responses: any) => responses[name])

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -1,6 +1,28 @@
 import { Config } from "@changesets/types";
-import { getChangedPackagesSinceRef } from "@changesets/git";
+import { getChangedPackagesSinceRef, getStagedPackages } from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
+
+export async function getVersionableStagedPackages(
+  config: Config,
+  {
+    cwd,
+  }: {
+    cwd: string;
+    ref?: string;
+  }
+) {
+  const stagedPackages = await getStagedPackages({
+    changedFilePatterns: config.changedFilePatterns,
+    cwd,
+  });
+  return stagedPackages.filter(
+    (pkg) =>
+      !shouldSkipPackage(pkg, {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version,
+      })
+  );
+}
 
 export async function getVersionableChangedPackages(
   config: Config,


### PR DESCRIPTION
Here is a first cut following up on #1399.

This PR introduces `staged packages` as distinct from `changed packages`. Staged packages are those with files currently staged for commit. This is helpful in situations where the working directory contains changes that should be split into multiple commits, each with their own changeset. 

<img width="957" alt="image" src="https://github.com/changesets/changesets/assets/1068356/78b3b1ff-5bf0-47dd-b026-d0c8a9fd16ea">

@Andarist Please take a look and lend some feedback, I'll finish up with tests after I hear from you 👍 The simplest way to test is to make a few changes in the repo and then stage some but not others.
