### PR TITLE
Add the pnpm package manager to the alternate invocations.

### DIFF
--- a/docs/adding-a-changeset.md
+++ b/docs/adding-a-changeset.md
@@ -12,7 +12,7 @@ A changeset is a piece of information about changes made in a branch or commit. 
 
 ## I am in a multi-package repository (a mono-repo)
 
-1. Run the command line script `npx changeset` or `yarn changeset`.
+1. Run the command line script `npx changeset` or `pnpm changeset` or `yarn changeset`.
 2. Select the packages you want to include in the changeset using <kbd>↑</kbd> and <kbd>↓</kbd> to navigate to packages, and <kbd>space</kbd> to select a package. Hit enter when all desired packages are selected.
 3. You will be prompted to select a bump type for each selected package. Select an appropriate bump type for the changes made. See [here](https://semver.org/) for information on semver versioning
 4. Your final prompt will be to provide a message to go alongside the changeset. This will be written into the changelog when the next release occurs.
@@ -36,7 +36,7 @@ While not every changeset is going to need a huge amount of detail, a good idea 
 
 ## I am in a single-package repository
 
-1. Run the command line script `npx changeset` or `yarn changeset`.
+1. Run the command line script `npx changeset` or `pnpm changeset` or `yarn changeset`.
 2. Select an appropriate bump type for the changes made. See [here](https://semver.org/) for information on semver versioning
 3. Your final prompt will be to provide a message to go alongside the changeset. This will be written into the changelog when the next release occurs.
 


### PR DESCRIPTION
The integration with [changesets-gitlab](https://www.npmjs.com/package/changesets-gitlab) points to this documentation resource. 

The link is embedded a comment added by a bot to our gitlab merge-request threads. 

For our monorepo this integration therefore guides people to run npx or yarn but doesn't guide them to use the package manager `pnpm` that is in use within our monorepo.