### PR TITLE
Add Custom Tag Format Support to Changeset Configuration

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -9,6 +9,7 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
   "linked": [],
   "access": "restricted",
   "baseBranch": "master",
+  "tagFormat": "${name}@${version}",
   "ignore": [],
   "changelog": "@changesets/cli/changelog"
 }
@@ -56,6 +57,20 @@ If you want to prevent a package from being published to npm, set `private: true
 The branch to which changesets will make comparisons. A number of internal changesets features use git to compare present changesets against another branch. This defaults what branch will be used for these comparisons. This should generally set to the major branch you merge changes into. Commands that use this information accept a `--since` option which can be used to override this.
 
 > To help make coding a more inclusive experience, we recommend changing the name of your `master` branch to `main`.
+
+## `tagFormat` (git tag format)
+
+The tagFormat configuration item allows you to customize the format of the tags created by the tool. It uses placeholders that are replaced with the actual package name and version when the tag is generated. This feature provides flexibility in defining how your version tags should look, making it easier to adhere to specific naming conventions or integrate with other tools and workflows.
+
+To use the tagFormat configuration item, add it to your .changeset/config.json file with the desired format. The available placeholders are ${name} for the package name and ${version} for the package version. For example:
+
+```json
+{
+  "tagFormat": "${name}/v${version}"
+}
+```
+
+This configuration would result in tags like `package-name/v1.0.0`. You can customize this format to match your project's needs, such as using a different separator, including additional static text, or formatting the version differently.
 
 ## `ignore` (array of packages)
 

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -18,12 +18,15 @@ export default async function tag(cwd: string, config: Config) {
       })
   );
 
+  const tagFormat = config.tagFormat || "${name}@${version}";
   for (const { name, newVersion } of await getUntaggedPackages(
     taggablePackages,
     cwd,
     tool
   )) {
-    const tag = tool !== "root" ? `${name}@${newVersion}` : `v${newVersion}`;
+    const tag = tool == "root"
+      ? `v${newVersion}`
+      : tagFormat.replace("${name}", name).replace("${version}", newVersion);
 
     if (allExistingTags.has(tag)) {
       log("Skipping tag (already exists): ", tag);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -73,6 +73,7 @@ export type Config = {
   linked: Linked;
   access: AccessType;
   baseBranch: string;
+  tagFormat: string;
   changedFilePatterns: readonly string[];
   /** Features enabled for Private packages */
   privatePackages: PrivatePackages;
@@ -98,6 +99,7 @@ export type WrittenConfig = {
   linked?: Linked;
   access?: AccessType;
   baseBranch?: string;
+  tagFormat?: string;
   changedFilePatterns?: readonly string[];
   /** Opt in to tracking non-npm / private packages */
   privatePackages?:


### PR DESCRIPTION
This PR introduces the ability to customize the format of version tags generated by the Changeset tool. By adding a new configuration item, tagFormat, users can now specify the structure of the tag names according to their project's conventions or requirements.

**Key Changes**:
- Added tagFormat to the `.changeset/config.json` schema, allowing for dynamic tag names based on the package name and version.
- Implemented string replacement functionality in the tagging process to substitute ${name} and ${version} placeholders with their respective values.

**Usage**: To utilize this feature, users should add the tagFormat item to their `.changeset/config.json` file, like so:
```json
{
  "tagFormat": "${name}@${version}"
}
```

This configuration enables the creation of tags that follow the specified format, providing flexibility in tag naming conventions.

**Benefits**:

- Customization: Users can tailor tag names to match their versioning guidelines or integrate seamlessly with other tools that expect a specific tag format.
- Consistency: Ensures uniform tag naming across all packages within a monorepo, improving readability and manageability.