### PR TITLE
Support lowercase changelog file

### DIFF
--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -140,7 +140,13 @@ export default async function applyReleasePlan(
     touchedFiles.push(pkgJSONPath);
 
     if (changelog && changelog.length > 0) {
-      const changelogPath = path.resolve(dir, "CHANGELOG.md");
+      const changelogPathUppercase = path.resolve(dir, "CHANGELOG.md");
+      const changelogPathLowercase = path.resolve(dir, "changelog.md");
+      let changelogPath = changelogPathUppercase;
+      if (fs.existsSync(changelogPathLowercase)) {
+        changelogPath = changelogPathLowercase;
+      }
+
       await updateChangelog(changelogPath, changelog, name, prettierInstance);
       touchedFiles.push(changelogPath);
     }


### PR DESCRIPTION
Closes #277

Finally got around to this. :) The code stood the test of time.

Unsure about testing this as the current tests fail for me locally:
```
    Cannot find module '/home/siilwyn/codeground/a-forks/changesets/packages/apply-release-plan/src/test-utils/simple-get-changelog-entry'
    Require stack:

      214 |   const changelogOpts = config.changelog[1];
      215 |   let changesetPath = path.join(cwd, ".changeset");
    > 216 |   let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
          |                                  ^
      217 |
      218 |   let possibleChangelogFunc = require(changelogPath);
      219 |   if (possibleChangelogFunc.default) {

      at resolveFileName (node_modules/resolve-from/index.js:29:39)
      at resolveFrom (node_modules/resolve-from/index.js:43:9)

```

However I figured this is quite a simple change so it might not be needed.
