### PR TITLE
Fix logging --version flag

### DIFF
--- a/.changeset/hungry-trains-sneeze.md
+++ b/.changeset/hungry-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Fix logging `--version` flag

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,6 +64,13 @@ if (parsed.help && args.length === 1) {
   process.exit(0);
 }
 
+// Version should only be shown if it's the only argument passed
+if (parsed.version && args.length === 1) {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  console.log(require("@changesets/cli/package.json").version);
+  process.exit(0);
+}
+
 const cwd = process.cwd();
 
 run(parsed._, parsed, cwd).catch((err) => {


### PR DESCRIPTION
Fixes #1418

I didn't realize that `meow` would [read the nearest package.json](https://github.com/sindresorhus/meow/blob/87d1bc394d9a1d73b76a81d4874db4f1190259ef/source/options.js#L67-L70) and auto support the `--version` flag, so this PR adds that support manually.