### PR TITLE
Added support for major to updateInternalDependencies config option

### DIFF
--- a/.changeset/sour-bottles-judge.md
+++ b/.changeset/sour-bottles-judge.md
@@ -1,0 +1,7 @@
+---
+"@changesets/apply-release-plan": minor
+"@changesets/config": minor
+"@changesets/types": minor
+---
+
+Added `major` to the list of acceptable values for the `updateInternalDependencies` config file option

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -128,7 +128,9 @@ pkg-b @ version 1.0.1
   depends on pkg-a at range `^1.0.0
 ```
 
-Using `minor` allows consumers to more actively control their own deduplication of packages, and will allow them to install fewer versions if you have many interconnected packages. Using `patch` will mean consumers will more often be using more updated code, but may cause problems with deduplication.
+Similarly, if the option is set to `major`, it will only update the dependency when there is a major change.
+
+Using `minor` or `major` allows consumers to more actively control their own deduplication of packages, and will allow them to install fewer versions if you have many interconnected packages. Using `patch` will mean consumers will more often be using more updated code, but may cause problems with deduplication.
 
 Changesets will always update the dependency if it would leave the old semver range.
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -33,7 +33,7 @@ export default async function getChangelogEntry(
     updateInternalDependencies,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
-    updateInternalDependencies: "patch" | "minor";
+    updateInternalDependencies: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ) {

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -32,7 +32,7 @@ export function shouldUpdateDependencyBasedOnConfig(
     minReleaseType,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
-    minReleaseType: "patch" | "minor";
+    minReleaseType: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ): boolean {
@@ -47,5 +47,6 @@ export function shouldUpdateDependencyBasedOnConfig(
   if (depType === "peerDependencies") {
     shouldUpdate = !onlyUpdatePeerDependentsWhenOutOfRange;
   }
+
   return shouldUpdate;
 }

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -29,7 +29,7 @@ export default function versionPackage(
     bumpVersionsWithWorkspaceProtocolOnly,
     snapshot,
   }: {
-    updateInternalDependencies: "patch" | "minor";
+    updateInternalDependencies: "patch" | "minor" | "major";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
     snapshot?: string | boolean | undefined;

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -117,7 +117,7 @@
       "default": []
     },
     "updateInternalDependencies": {
-      "enum": ["patch", "minor"],
+      "enum": ["patch", "minor", "major"],
       "type": "string",
       "description": "The minimum bump type to trigger automatic update of internal dependencies that are part of the same release.",
       "default": "patch"

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -291,6 +291,15 @@ let correctCases: Record<string, CorrectCase> = {
       linked: [["pkg-a", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
     },
   },
+  "update internal dependencies major": {
+    input: {
+      updateInternalDependencies: "major",
+    },
+    output: {
+      ...defaults,
+      updateInternalDependencies: "major",
+    },
+  },
   "update internal dependencies minor": {
     input: {
       updateInternalDependencies: "minor",
@@ -590,12 +599,12 @@ describe("parser errors", () => {
       'The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".'
     );
   });
-  test("updateInternalDependencies not patch or minor", () => {
+  test("updateInternalDependencies not patch, minor or major", () => {
     expect(() => {
-      unsafeParse({ updateInternalDependencies: "major" }, defaultPackages);
+      unsafeParse({ updateInternalDependencies: "none" }, defaultPackages);
     }).toThrowErrorMatchingInlineSnapshot(`
       "Some errors occurred when validating the changesets config:
-      The \`updateInternalDependencies\` option is set as "major" but can only be 'patch' or 'minor'"
+      The \`updateInternalDependencies\` option is set as "none" but can only be 'patch', 'minor' or 'major'"
     `);
   });
   test("ignore non-array", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -283,14 +283,14 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
 
   if (
     json.updateInternalDependencies !== undefined &&
-    !["patch", "minor"].includes(json.updateInternalDependencies)
+    !["patch", "minor", "major"].includes(json.updateInternalDependencies)
   ) {
     messages.push(
       `The \`updateInternalDependencies\` option is set as ${JSON.stringify(
         json.updateInternalDependencies,
         null,
         2
-      )} but can only be 'patch' or 'minor'`
+      )} but can only be 'patch', 'minor' or 'major'`
     );
   }
   if (json.ignore) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,7 +77,7 @@ export type Config = {
   /** Features enabled for Private packages */
   privatePackages: PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
-  updateInternalDependencies: "patch" | "minor";
+  updateInternalDependencies: "patch" | "minor" | "major";
   ignore: ReadonlyArray<string>;
   /** This is supposed to be used with pnpm's `link-workspace-packages: false` and Berry's `enableTransparentWorkspaces: false` */
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
@@ -107,7 +107,7 @@ export type WrittenConfig = {
         tag?: boolean;
       };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
-  updateInternalDependencies?: "patch" | "minor";
+  updateInternalDependencies?: "patch" | "minor" | "major";
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   snapshot?: {


### PR DESCRIPTION
I'd like to propose adding support for `major` value for the `updateInternalDependencies` config file option (https://github.com/galargh/changesets/blob/8c38d904991e3ff2dc2f41d3cbe3dedbca98d5d3/docs/config-file-options.md#updateinternaldependencies).

The use-case I'm trying to cover is a monorepo with packages A and B, where A depends on B with `workspace:^vX.Y.Z` version range. I'd like the version range to only be automatically updated on major version bumps. Otherwise, the decision should be at the discretion of contributors and should be made explicitly.

I'm aware that the possibility of adding the `major` value to the list of options was mentioned in https://github.com/changesets/changesets/pull/358. However, I'd like to argue that it would be useful to have it to cover the workflows as described above. Especially since it doesn't add much complexity to the implementation.

I added a set of tests to cover internal dependencies update process when `updateInternalDependencies` is set to `major`. The new tests group I added was inspired by similar ones for `updateInternalDependencies=minor` and `updateInternalDependencies=patch`.

I verified the CI is 🟢 in https://github.com/galargh/changesets/pull/1

I added minor changesets to modified packages since this is a new functionality but should not pose a breaking change to the users, but I'd appreciate guidance on whether that's correct for the proposed change.