### PR TITLE
upgrade node to v18 for csb

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "node": "14"
+  "node": "18"
 }


### PR DESCRIPTION
This PR upgrades the version of `node` for CodeSandbox to v18 LTS.

Needed for #1436 