### PR TITLE
fix(assemble-release-plan): throw when package is not found

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -276,6 +276,9 @@ function getRelevantChangesets(
     const skippedPackages = [];
     const notSkippedPackages = [];
     for (const release of changeset.releases) {
+      if (!packagesByName.get(release.name)) {
+        throw new Error(`Could not get package JSON for ${release.name}`);
+      }
       if (
         shouldSkipPackage(packagesByName.get(release.name)!, {
           ignore: config.ignore,


### PR DESCRIPTION
I got this error when trying to release.

```
🦋  error TypeError: Cannot destructure property 'packageJson' of 'undefined' as it is undefined.
🦋  error     at Object.shouldSkipPackage (/home/bennyp/Developer/patternfly/patternfly-elements/node_modules/@changesets/should-skip-package/dist/changesets-should-skip-package.cjs.js:6:3)
🦋  error     at getRelevantChangesets (/home/bennyp/Developer/patternfly/patternfly-elements/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:561:29)
🦋  error     at Object.assembleReleasePlan [as default] (/home/bennyp/Developer/patternfly/patternfly-elements/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:488:30)
🦋  error     at version (/home/bennyp/Developer/patternfly/patternfly-elements/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1231:60)
🦋  error     at async run (/home/bennyp/Developer/patternfly/patternfly-elements/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1413:11)

```

The problem was that one of my changesets had a bad package name.

This wee PR throws the package name if the package JSON is not found.