### PR TITLE
Remove unused `@babel/runtime` dependency

### DIFF
--- a/.changeset/selfish-flowers-work.md
+++ b/.changeset/selfish-flowers-work.md
@@ -1,0 +1,14 @@
+---
+"@changesets/assemble-release-plan": patch
+"@changesets/get-dependents-graph": patch
+"@changesets/should-skip-package": patch
+"@changesets/apply-release-plan": patch
+"@changesets/get-release-plan": patch
+"@changesets/write": patch
+"@changesets/read": patch
+"@changesets/cli": patch
+"@changesets/git": patch
+"@changesets/pre": patch
+---
+
+Remove unused `@babel/runtime` dependency

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
-    "@babel/runtime": "^7.20.1",
     "@manypkg/cli": "^0.19.1",
     "@preconstruct/cli": "^2.8.1",
     "@types/fs-extra": "^5.1.0",

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/apply-release-plan",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/config": "^3.0.2",
     "@changesets/get-version-range-type": "^0.4.0",
     "@changesets/git": "^3.0.0",

--- a/packages/assemble-release-plan/package.json
+++ b/packages/assemble-release-plan/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/assemble-release-plan",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/errors": "^0.2.0",
     "@changesets/get-dependents-graph": "^2.1.1",
     "@changesets/should-skip-package": "^0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/apply-release-plan": "^7.0.4",
     "@changesets/assemble-release-plan": "^6.0.3",
     "@changesets/changelog-git": "^0.2.0",
@@ -89,7 +88,6 @@
     "enquirer": "^2.3.0",
     "external-editor": "^3.1.0",
     "fs-extra": "^7.0.1",
-    "human-id": "^1.0.2",
     "mri": "^1.2.0",
     "outdent": "^0.5.0",
     "p-limit": "^2.2.0",
@@ -102,6 +100,7 @@
   "devDependencies": {
     "@changesets/parse": "*",
     "@changesets/test-utils": "*",
+    "human-id": "^1.0.2",
     "strip-ansi": "^5.2.0"
   }
 }

--- a/packages/get-dependents-graph/package.json
+++ b/packages/get-dependents-graph/package.json
@@ -22,7 +22,6 @@
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^2.1.0",
-    "fs-extra": "^7.0.1",
     "semver": "^7.5.3"
   },
   "devDependencies": {

--- a/packages/get-release-plan/package.json
+++ b/packages/get-release-plan/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/get-release-plan",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/assemble-release-plan": "^6.0.3",
     "@changesets/config": "^3.0.2",
     "@changesets/pre": "^2.0.0",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -19,9 +19,7 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/git",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/errors": "^0.2.0",
-    "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
     "is-subdir": "^1.1.1",
     "micromatch": "^4.0.2",

--- a/packages/pre/package.json
+++ b/packages/pre/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/pre",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/errors": "^0.2.0",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",

--- a/packages/read/package.json
+++ b/packages/read/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/read",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/git": "^3.0.0",
     "@changesets/logger": "^0.1.0",
     "@changesets/parse": "^0.4.0",

--- a/packages/should-skip-package/package.json
+++ b/packages/should-skip-package/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/should-skip-package",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3"
   },

--- a/packages/write/package.json
+++ b/packages/write/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/changesets/changesets/tree/main/packages/write",
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
     "@changesets/types": "^6.0.0",
     "fs-extra": "^7.0.1",
     "human-id": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,13 +1184,6 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-transform-typescript" "^7.18.6"
 
-"@babel/runtime@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
-  integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
-  dependencies:
-    regenerator-runtime "^0.13.10"
-
 "@babel/runtime@^7.5.5":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
@@ -6133,11 +6126,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.13.10:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.3"


### PR DESCRIPTION
I might be doing something silly, but after checking the files, it doesn't look like `@babel/runtime` is used anywhere and in `dist`, so I think we can remove it.

I also:
- moved `human-id` as dev dep in `cli`
- removed `fs-extra` in `get-dependents-graph`
- removed `@changesets/types` in `git`

They don't seem to be used in the published code. Even though these deps are used elsewhere in transitive deps in practice, I think it's nice to keep them concise if unused.
