### PR TITLE
chore: switch from `preferred-pm` to `package-manager-detector`

### DIFF
--- a/.changeset/slow-avocados-promise.md
+++ b/.changeset/slow-avocados-promise.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+chore: switch from `preferred-pm` to `package-manager-detector`

--- a/.changeset/slow-avocados-promise.md
+++ b/.changeset/slow-avocados-promise.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-chore: switch from `preferred-pm` to `package-manager-detector`
+Switched from `preferred-pm` to `package-manager-detector` in order to reduce installation size

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "mri": "^1.2.0",
     "outdent": "^0.5.0",
     "p-limit": "^2.2.0",
-    "preferred-pm": "^3.0.0",
+    "package-manager-detector": "^0.2.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.5.3",
     "spawndamnit": "^2.0.0",

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -2,7 +2,7 @@ import { ExitError } from "@changesets/errors";
 import { error, info, warn } from "@changesets/logger";
 import { AccessType, PackageJSON } from "@changesets/types";
 import pLimit from "p-limit";
-import { detect } from "package-manager-detector/detect";
+import { detect } from "package-manager-detector";
 import chalk from "chalk";
 import spawn from "spawndamnit";
 import semverParse from "semver/functions/parse";

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -2,7 +2,7 @@ import { ExitError } from "@changesets/errors";
 import { error, info, warn } from "@changesets/logger";
 import { AccessType, PackageJSON } from "@changesets/types";
 import pLimit from "p-limit";
-import preferredPM from "preferred-pm";
+import { detect } from "package-manager-detector/detect";
 import chalk from "chalk";
 import spawn from "spawndamnit";
 import semverParse from "semver/functions/parse";
@@ -44,7 +44,7 @@ function getCorrectRegistry(packageJson?: PackageJSON): string {
 async function getPublishTool(
   cwd: string
 ): Promise<{ name: "npm" } | { name: "pnpm"; shouldAddNoGitChecks: boolean }> {
-  const pm = await preferredPM(cwd);
+  const pm = await detect({ cwd });
   if (!pm || pm.name !== "pnpm") return { name: "npm" };
   try {
     let result = await spawn("pnpm", ["--version"], { cwd });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3655,14 +3655,6 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-find-yarn-workspace-root2@^1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.11.tgz#b14a8be43503ec8c0cdf7f5923a3534860bdd92e"
-  integrity sha512-TkwH3kDD1Z8X9LnrU3gbyYw8KtLZZjsym6c2YIRFCDIMJD1JL9+Blkzpm07db+Q6ZVLISqrW9cN0CvXN4rr5ag==
-  dependencies:
-    micromatch "^4.0.2"
-    pkg-dir "^4.2.0"
-
 fixturez@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fixturez/-/fixturez-1.1.0.tgz#37d5ecc830c9513907d8fdafb774751acf74db1a"
@@ -5046,7 +5038,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
+js-yaml@^3.13.1, js-yaml@^3.6.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -5194,16 +5186,6 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
-
-load-yaml-file@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/load-yaml-file/-/load-yaml-file-0.2.0.tgz#af854edaf2bea89346c07549122753c07372f64d"
-  integrity sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==
-  dependencies:
-    graceful-fs "^4.1.5"
-    js-yaml "^3.13.0"
-    pify "^4.0.1"
-    strip-bom "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -5799,6 +5781,11 @@ package-json@^6.5.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
+package-manager-detector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-0.2.0.tgz#160395cd5809181f5a047222319262b8c2d8aaea"
+  integrity sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -5968,16 +5955,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
-
-preferred-pm@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.0.0.tgz#26cc7fbbfc1815e4cb8272d5fdde15dc96220fb8"
-  integrity sha512-NbN+2UuqjakJpyHamsuIWyeFdQcFUQHF9nkw16hpFE++z3px+/KDsj+AF1h0BlnsBJi1Z5U4EKBW7XnHriny8g==
-  dependencies:
-    find-up "^4.1.0"
-    find-yarn-workspace-root2 "^1.2.11"
-    path-exists "^4.0.0"
-    which-pm "2.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -7274,14 +7251,6 @@ which-boxed-primitive@^1.0.2:
     is-number-object "^1.0.4"
     is-string "^1.0.5"
     is-symbol "^1.0.3"
-
-which-pm@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-pm/-/which-pm-2.0.0.tgz#8245609ecfe64bf751d0eef2f376d83bf1ddb7ae"
-  integrity sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==
-  dependencies:
-    load-yaml-file "^0.2.0"
-    path-exists "^4.0.0"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
https://npmgraph.js.org/?q=preferred-pm@3.0.0 - 34 dependencies
https://npmgraph.js.org/?q=package-manager-detector - 0 dependencies

A dozen dependencies are in the changesets dependency tree elsewhere, so the real savings for now will be 21 dependencies (18% of the overall changesets total). Half of the dependencies that appear elsewhere in the dependency tree have been removed from the latest version of the `@manypkg` packages and so this change together with upgrading those packages will result in an even greater savings in the future.

The yarn lockfile is only a little smaller because various `devDependencies` are pulling in many the removed dependencies. E.g. `jest` ends up pulling in `pkg-dir`. However, I see a greater savings in my projects. E.g. I use `vitest` rather than `jest`, so it is a really large savings for many users even if they're not visible in yarn lockfile here.

`package-manager-detector` was recently refactored out from the widely used `@antfu/ni` and `@antfu/install-pkg` as a new package by the authors of those packages upon my request. While the package itself is fairly new, the logic in it has been used for a long time

Before this, I had taken another approach of contributing to reducing the size of `preferred-pm`. However, when I tried to upgrade changesets to use the latest, I realized that won't work because the latest versions of `preferred-pm` require Node 18 and changesets supports older versions of Node.