### PR TITLE
Fix publish with yarn

### DIFF
--- a/.changeset/late-ways-confess.md
+++ b/.changeset/late-ways-confess.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Fix publish with yarn

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -43,9 +43,12 @@ function getCorrectRegistry(packageJson?: PackageJSON): string {
 
 async function getPublishTool(
   cwd: string
-): Promise<{ name: "npm" } | { name: "pnpm"; shouldAddNoGitChecks: boolean }> {
+): Promise<
+  { name: "npm" | "yarn" } | { name: "pnpm"; shouldAddNoGitChecks: boolean }
+> {
   const pm = await detect({ cwd });
-  if (!pm || pm.name !== "pnpm") return { name: "npm" };
+  if (!pm) return { name: "npm" };
+  if (pm.name === "yarn") return { name: "yarn" };
   try {
     let result = await spawn("pnpm", ["--version"], { cwd });
     let version = result.stdout.toString().trim();
@@ -185,6 +188,11 @@ async function internalPublish(
   let { code, stdout, stderr } =
     publishTool.name === "pnpm"
       ? await spawn("pnpm", ["publish", "--json", ...publishFlags], {
+          env: Object.assign({}, process.env, envOverride),
+          cwd: opts.cwd,
+        })
+      : publishTool.name === "yarn"
+      ? await spawn("yarn", ["npm", "publish", ...publishFlags], {
           env: Object.assign({}, process.env, envOverride),
           cwd: opts.cwd,
         })


### PR DESCRIPTION
* Add support for yarn to `getPublishTool`.
* Use yarn for publishing when it is the used package manager.

Fixes:
* https://github.com/changesets/changesets/issues/1411

<img width="445" alt="Screenshot 2024-08-30 at 15 28 48" src="https://github.com/user-attachments/assets/4e294e73-6ba3-4af7-a1cb-696fb12b4791">
