### PR TITLE
chore: move `@types/semver` to `devDependencies`

### DIFF
--- a/.changeset/red-walls-poke.md
+++ b/.changeset/red-walls-poke.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+chore: move @types/semver to devDependencies

--- a/.changeset/red-walls-poke.md
+++ b/.changeset/red-walls-poke.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-chore: move @types/semver to devDependencies
+Moved `@types/semver` to `devDependencies`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,7 +81,6 @@
     "@changesets/types": "^6.0.0",
     "@changesets/write": "^0.3.2",
     "@manypkg/get-packages": "^1.1.3",
-    "@types/semver": "^7.5.0",
     "ansi-colors": "^4.1.3",
     "ci-info": "^3.7.0",
     "enquirer": "^2.3.0",
@@ -100,6 +99,7 @@
   "devDependencies": {
     "@changesets/parse": "*",
     "@changesets/test-utils": "*",
+    "@types/semver": "^7.5.0",
     "human-id": "^1.0.2",
     "strip-ansi": "^5.2.0"
   }


### PR DESCRIPTION
This is not used in the distributed types of `changesets`, so doesn't need to be listed in `dependencies`