### PR TITLE
fix: include missing peer depedency updates in release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Affected Packages
 
-<!-- Because monorepos, it's super helpful if you tell us which packages are affected, so it's easy to find the change points. Adding a tag pf `pkg:package-name` would be the best 🙏 -->
+<!-- Because monorepos, it's super helpful if you tell us which packages are affected, so it's easy to find the change points. Adding a tag of `pkg:package-name` would be the best 🙏 -->
 
 ## Problem
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -47,10 +47,6 @@ export default async function getChangelogEntry(
     patch: [],
   };
 
-  // console.group("RELEASE >>>", release);
-
-  console.log("RELEASE NAME >>>", release.name);
-
   // I sort of feel we can do better, as ComprehensiveReleases have an array
   // of the relevant changesets but since we need the version type for the
   // release in the changeset, I don't know if we can
@@ -68,15 +64,7 @@ export default async function getChangelogEntry(
     const peerDependencyVersionRange =
       release.packageJson.peerDependencies?.[rel.name];
 
-    console.log("rel.name >>>", rel.name);
-
-    // console.log("dependencyVersionRange >>>", dependencyVersionRange);
-    // console.log("peerDependencyVersionRange >>>", peerDependencyVersionRange);
-
     const versionRange = dependencyVersionRange || peerDependencyVersionRange;
-
-    // console.log("validRange(versionRange)", validRange(versionRange));
-
     const usesWorkspaceRange = versionRange?.startsWith("workspace:");
     return (
       versionRange &&
@@ -95,8 +83,6 @@ export default async function getChangelogEntry(
       )
     );
   });
-
-  console.log("dependentReleases >>>", dependentReleases);
 
   let relevantChangesetIds: Set<string> = new Set();
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -1,4 +1,8 @@
-import { ChangelogFunctions, NewChangesetWithCommit } from "@changesets/types";
+import {
+  ChangelogFunctions,
+  ExperimentalOptions,
+  NewChangesetWithCommit,
+} from "@changesets/types";
 
 import { ModCompWithPackage } from "@changesets/types";
 import startCase from "lodash.startcase";
@@ -35,8 +39,8 @@ export default async function getChangelogEntry(
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
     updateInternalDependencies: "patch" | "minor";
-    updateInternalDependents: "out-of-range" | "always";
-    onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+    updateInternalDependents: ExperimentalOptions["updateInternalDependents"];
+    onlyUpdatePeerDependentsWhenOutOfRange: ExperimentalOptions["onlyUpdatePeerDependentsWhenOutOfRange"];
   }
 ) {
   if (release.type === "none") return null;

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -31,9 +31,11 @@ export default async function getChangelogEntry(
   changelogOpts: any,
   {
     updateInternalDependencies,
+    updateInternalDependents,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
     updateInternalDependencies: "patch" | "minor";
+    updateInternalDependents: "out-of-range" | "always";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ) {
@@ -44,6 +46,10 @@ export default async function getChangelogEntry(
     minor: [],
     patch: [],
   };
+
+  // console.group("RELEASE >>>", release);
+
+  console.log("RELEASE NAME >>>", release.name);
 
   // I sort of feel we can do better, as ComprehensiveReleases have an array
   // of the relevant changesets but since we need the version type for the
@@ -62,7 +68,15 @@ export default async function getChangelogEntry(
     const peerDependencyVersionRange =
       release.packageJson.peerDependencies?.[rel.name];
 
+    console.log("rel.name >>>", rel.name);
+
+    // console.log("dependencyVersionRange >>>", dependencyVersionRange);
+    // console.log("peerDependencyVersionRange >>>", peerDependencyVersionRange);
+
     const versionRange = dependencyVersionRange || peerDependencyVersionRange;
+
+    // console.log("validRange(versionRange)", validRange(versionRange));
+
     const usesWorkspaceRange = versionRange?.startsWith("workspace:");
     return (
       versionRange &&
@@ -76,10 +90,13 @@ export default async function getChangelogEntry(
         {
           minReleaseType: updateInternalDependencies,
           onlyUpdatePeerDependentsWhenOutOfRange,
+          updateInternalDependents,
         }
       )
     );
   });
+
+  console.log("dependentReleases >>>", dependentReleases);
 
   let relevantChangesetIds: Set<string> = new Set();
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2736,7 +2736,7 @@ describe("apply release plan", () => {
       - Hey, let's have fun with testing!`);
     });
 
-    it("should add an updated peerDependencies line when peerDependencies have been updated and updateInternalDependents is `always`", async () => {
+    it("should add an updated dependencies line when peerDependencies have been updated and updateInternalDependents is `always`", async () => {
       let { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2833,20 +2833,12 @@ describe("apply release plan", () => {
         a.endsWith(`pkg-c${path.sep}CHANGELOG.md`)
       );
 
-      console.log("readmePath", readmePath);
-      console.log("readmePathB", readmePathB);
-      console.log("readmePathC", readmePathC);
-
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
 
       let readme = await fs.readFile(readmePath, "utf-8");
       let readmeB = await fs.readFile(readmePathB, "utf-8");
       let readmeC = await fs.readFile(readmePathC, "utf-8");
-
-      console.log("readme", readme.trim());
-      console.log("readmeB", readmeB.trim());
-      console.log("readmeC", readmeC.trim());
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2196,7 +2196,7 @@ describe("apply release plan", () => {
       expect(pkgAChangelogPath).toBeUndefined();
     });
 
-    test("should list multi-line same-type summaries correctly", async () => {
+    it("should list multi-line same-type summaries correctly", async () => {
       const releasePlan = new FakeReleasePlan([
         {
           id: "some-id-1",
@@ -2734,6 +2734,145 @@ describe("apply release plan", () => {
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);
+    });
+
+    it("should add an updated peerDependencies line when peerDependencies have been updated and updateInternalDependents is `always`", async () => {
+      let { changedFiles } = await testSetup(
+        {
+          "package.json": JSON.stringify({
+            private: true,
+            workspaces: ["packages/*"],
+          }),
+          "packages/pkg-a/package.json": JSON.stringify({
+            name: "pkg-a",
+            version: "1.0.3",
+            devDependencies: {
+              "pkg-b": "*",
+            },
+            peerDependencies: {
+              "pkg-b": "*",
+            },
+          }),
+          "packages/pkg-b/package.json": JSON.stringify({
+            name: "pkg-b",
+            version: "1.2.0",
+          }),
+          "packages/pkg-c/package.json": JSON.stringify({
+            name: "pkg-c",
+            version: "2.0.0",
+            dependencies: {
+              "pkg-b": "*",
+            },
+          }),
+        },
+        {
+          changesets: [
+            {
+              id: "quick-lions-devour",
+              summary: "Hey, let's have fun with testing!",
+              releases: [{ name: "pkg-b", type: "patch" }],
+            },
+          ],
+          releases: [
+            {
+              name: "pkg-a",
+              type: "patch",
+              oldVersion: "1.0.3",
+              newVersion: "1.0.4",
+              changesets: [],
+            },
+            {
+              name: "pkg-b",
+              type: "patch",
+              oldVersion: "1.2.0",
+              newVersion: "1.2.1",
+              changesets: ["quick-lions-devour"],
+            },
+            {
+              name: "pkg-c",
+              type: "patch",
+              oldVersion: "2.0.0",
+              newVersion: "2.0.1",
+              changesets: [],
+            },
+          ],
+          preState: undefined,
+        },
+        {
+          changelog: [
+            path.resolve(__dirname, "test-utils/simple-get-changelog-entry"),
+            null,
+          ],
+          commit: false,
+          fixed: [],
+          linked: [],
+          access: "restricted",
+          changedFilePatterns: ["**"],
+          baseBranch: "main",
+          updateInternalDependencies: "patch",
+          ignore: [],
+          privatePackages: { version: true, tag: false },
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            onlyUpdatePeerDependentsWhenOutOfRange: true,
+            updateInternalDependents: "always",
+          },
+          snapshot: {
+            useCalculatedVersion: false,
+            prereleaseTemplate: null,
+          },
+        }
+      );
+
+      let readmePath = changedFiles.find((a) =>
+        a.endsWith(`pkg-a${path.sep}CHANGELOG.md`)
+      );
+      let readmePathB = changedFiles.find((a) =>
+        a.endsWith(`pkg-b${path.sep}CHANGELOG.md`)
+      );
+      let readmePathC = changedFiles.find((a) =>
+        a.endsWith(`pkg-c${path.sep}CHANGELOG.md`)
+      );
+
+      console.log("readmePath", readmePath);
+      console.log("readmePathB", readmePathB);
+      console.log("readmePathC", readmePathC);
+
+      if (!readmePath || !readmePathB || !readmePathC)
+        throw new Error(`could not find an updated changelog`);
+
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readmeC = await fs.readFile(readmePathC, "utf-8");
+
+      console.log("readme", readme.trim());
+      console.log("readmeB", readmeB.trim());
+      console.log("readmeC", readmeC.trim());
+
+      expect(readme.trim()).toEqual(outdent`# pkg-a
+
+      ## 1.0.4
+
+      ### Patch Changes
+
+      - Updated dependencies
+        - pkg-b@1.2.1`);
+
+      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+
+      ## 1.2.1
+
+      ### Patch Changes
+
+      - Hey, let's have fun with testing!`);
+
+      expect(readmeC.trim()).toEqual(outdent`# pkg-c
+
+      ## 2.0.1
+
+      ### Patch Changes
+
+      - Updated dependencies
+        - pkg-b@1.2.1`);
     });
   });
   describe("should error and not write if", () => {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -231,6 +231,8 @@ async function getNewChangelogEntry(
     commit: commits[i],
   }));
 
+  console.log("releasesWithPackage >>>", releasesWithPackage);
+
   return Promise.all(
     releasesWithPackage.map(async (release) => {
       let changelog = await getChangelogEntry(
@@ -244,8 +246,13 @@ async function getNewChangelogEntry(
           onlyUpdatePeerDependentsWhenOutOfRange:
             config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange,
+          updateInternalDependents:
+            config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+              .updateInternalDependents,
         }
       );
+
+      console.log("CHANGELOG >>>", changelog);
 
       return {
         ...release,

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -231,8 +231,6 @@ async function getNewChangelogEntry(
     commit: commits[i],
   }));
 
-  console.log("releasesWithPackage >>>", releasesWithPackage);
-
   return Promise.all(
     releasesWithPackage.map(async (release) => {
       let changelog = await getChangelogEntry(
@@ -251,8 +249,6 @@ async function getNewChangelogEntry(
               .updateInternalDependents,
         }
       );
-
-      console.log("CHANGELOG >>>", changelog);
 
       return {
         ...release,

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -2,7 +2,11 @@
  * Shared utility functions and business logic
  */
 import semverSatisfies from "semver/functions/satisfies";
-import { VersionType } from "@changesets/types";
+import {
+  DependencyType,
+  ExperimentalOptions,
+  VersionType,
+} from "@changesets/types";
 
 const bumpTypes = ["none", "patch", "minor", "major"];
 
@@ -22,11 +26,7 @@ export function shouldUpdateDependencyBasedOnConfig(
     depType,
   }: {
     depVersionRange: string;
-    depType:
-      | "dependencies"
-      | "devDependencies"
-      | "peerDependencies"
-      | "optionalDependencies";
+    depType: DependencyType;
   },
   {
     minReleaseType,
@@ -34,8 +34,8 @@ export function shouldUpdateDependencyBasedOnConfig(
     updateInternalDependents,
   }: {
     minReleaseType: "patch" | "minor";
-    onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-    updateInternalDependents: "out-of-range" | "always";
+    onlyUpdatePeerDependentsWhenOutOfRange: ExperimentalOptions["onlyUpdatePeerDependentsWhenOutOfRange"];
+    updateInternalDependents?: ExperimentalOptions["updateInternalDependents"];
   }
 ): boolean {
   if (!semverSatisfies(release.version, depVersionRange)) {

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -31,9 +31,11 @@ export function shouldUpdateDependencyBasedOnConfig(
   {
     minReleaseType,
     onlyUpdatePeerDependentsWhenOutOfRange,
+    updateInternalDependents,
   }: {
     minReleaseType: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+    updateInternalDependents: "out-of-range" | "always";
   }
 ): boolean {
   if (!semverSatisfies(release.version, depVersionRange)) {
@@ -45,7 +47,9 @@ export function shouldUpdateDependencyBasedOnConfig(
   let shouldUpdate = getBumpLevel(release.type) >= minLevel;
 
   if (depType === "peerDependencies") {
-    shouldUpdate = !onlyUpdatePeerDependentsWhenOutOfRange;
+    shouldUpdate =
+      !onlyUpdatePeerDependentsWhenOutOfRange ||
+      updateInternalDependents === "always";
   }
   return shouldUpdate;
 }


### PR DESCRIPTION
- Fixes #1459
- Minor rename of `test` to `it` in test suite, to match others.
- Minor typo fix in issue template.