### PR TITLE
Run CI on multiple node versions

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -1,12 +1,18 @@
 name: Setup CI
 
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: 20
+
 runs:
   using: composite
   steps:
-    - name: Setup Node.js 20.x
+    - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: ${{ inputs.node-version }}
         cache: yarn
 
     - name: Install dependencies

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -16,11 +16,5 @@ runs:
         cache: yarn
 
     - name: Install dependencies
-      if: inputs.node-version >= 14
       shell: bash
       run: yarn install --frozen-lockfile
-
-    - name: Install dependencies with --ignore-engines
-      if: inputs.node-version < 14
-      shell: bash
-      run: yarn install --frozen-lockfile --ignore-engines

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -16,5 +16,11 @@ runs:
         cache: yarn
 
     - name: Install dependencies
+      if: inputs.node-version >= 14
       shell: bash
       run: yarn install --frozen-lockfile
+
+    - name: Install dependencies with --ignore-engines
+      if: inputs.node-version < 14
+      shell: bash
+      run: yarn install --frozen-lockfile --ignore-engines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node_version: [8, 10, 12, 14, 16, 18, 20, 22]
+        # node 8, 10, 12 are not tested as jest doesn't support them
+        node_version: [14, 16, 18, 20, 22]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,18 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: 'Test: node-${{ matrix.node_version }}'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        node_version: [8, 10, 12, 14, 16, 18, 20, 22]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci-setup
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - name: Check Git version
         run: git --version
@@ -24,10 +30,16 @@ jobs:
         run: git config --global user.email "you@example.com" && git config --global user.name "Your Name"
 
       - name: Jest tests
+        if: matrix.node_version != 20
+        run: yarn jest --ci --color --runInBand --reporters=default --reporters=jest-junit
+        
+      - name: Jest tests with coverage
+        if: matrix.node_version == 20
         run: yarn jest --ci --color --runInBand --coverage --reporters=default --reporters=jest-junit
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        if: matrix.node_version == 20
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
From https://github.com/changesets/changesets/pull/1445, maybe it's useful to run the CI on multiple node versions to see how well older node versions are still supported and prevent breaking them.