### PR TITLE
Enable releases from next branch

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Updates the `changesets-version` workflow in `main` to allow it to creation versioning PRs from the `next` branch