### PR TITLE
Remove `fs-extra`

### DIFF
--- a/.changeset/afraid-radios-fetch.md
+++ b/.changeset/afraid-radios-fetch.md
@@ -1,0 +1,13 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/release-utils": patch
+"@changesets/test-utils": patch
+"@changesets/config": patch
+"@changesets/write": patch
+"@changesets/read": patch
+"@changesets/cli": patch
+"@changesets/git": patch
+"@changesets/pre": patch
+---
+
+Replace `fs-extra` usage with `node:fs`

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-typescript": "^7.18.6",
     "@manypkg/cli": "^0.19.1",
     "@preconstruct/cli": "^2.8.1",
-    "@types/fs-extra": "^5.1.0",
     "@types/jest": "^24.0.12",
     "@types/jest-in-case": "^1.0.6",
     "@types/js-yaml": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jest-in-case": "^1.0.6",
     "@types/js-yaml": "^3.12.1",
     "@types/lodash": "^4.14.136",
+    "@types/node": "^22.7.4",
     "@types/prettier": "^2.7.1",
     "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -26,7 +26,6 @@
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
     "detect-indent": "^6.0.0",
-    "fs-extra": "^7.0.1",
     "lodash.startcase": "^4.4.0",
     "outdent": "^0.5.0",
     "prettier": "^2.7.1",

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -5,7 +5,7 @@ import {
   ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
-import { readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import outdent from "outdent";
 import spawn from "spawndamnit";
@@ -131,7 +131,7 @@ async function testSetup(
 }
 
 async function readJson(path: string) {
-  return JSON.parse(await readFile(path, "utf8"));
+  return JSON.parse(await fsp.readFile(path, "utf8"));
 }
 
 describe("apply release plan", () => {
@@ -155,7 +155,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -184,7 +184,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
 \t"name": "pkg-a",
@@ -206,7 +206,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -229,7 +229,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -2043,7 +2043,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2104,8 +2104,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
-      let readmeB = await readFile(readmePathB, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readmeB = await fsp.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2243,7 +2243,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
       expect(readme.trim()).toEqual(
         [
           "# pkg-a\n",
@@ -2343,8 +2343,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
-      let readmeB = await readFile(readmePathB, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readmeB = await fsp.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2452,8 +2452,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
-      let readmeB = await readFile(readmePathB, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readmeB = await fsp.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2576,9 +2576,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
-      let readmeB = await readFile(readmePathB, "utf-8");
-      let readmeC = await readFile(readmePathC, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readmeB = await fsp.readFile(readmePathB, "utf-8");
+      let readmeC = await fsp.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2711,9 +2711,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await readFile(readmePath, "utf-8");
-      let readmeB = await readFile(readmePathB, "utf-8");
-      let readmeC = await readFile(readmePathC, "utf-8");
+      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readmeB = await fsp.readFile(readmePathB, "utf-8");
+      let readmeC = await fsp.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -3155,7 +3155,7 @@ describe("apply release plan", () => {
     let lastCommit = commits[commits.length - 1].substring(0, 7);
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(tempDir, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -5,7 +5,7 @@ import {
   ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import outdent from "outdent";
 import spawn from "spawndamnit";
@@ -131,7 +131,7 @@ async function testSetup(
 }
 
 async function readJson(path: string) {
-  return JSON.parse(await fsp.readFile(path, "utf8"));
+  return JSON.parse(await fs.readFile(path, "utf8"));
 }
 
 describe("apply release plan", () => {
@@ -155,7 +155,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -184,7 +184,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
 \t"name": "pkg-a",
@@ -206,7 +206,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -229,7 +229,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fsp.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -2043,7 +2043,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2104,8 +2104,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
-      let readmeB = await fsp.readFile(readmePathB, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2243,7 +2243,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
       expect(readme.trim()).toEqual(
         [
           "# pkg-a\n",
@@ -2343,8 +2343,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
-      let readmeB = await fsp.readFile(readmePathB, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2452,8 +2452,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
-      let readmeB = await fsp.readFile(readmePathB, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2576,9 +2576,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
-      let readmeB = await fsp.readFile(readmePathB, "utf-8");
-      let readmeC = await fsp.readFile(readmePathC, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readmeC = await fs.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2711,9 +2711,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fsp.readFile(readmePath, "utf-8");
-      let readmeB = await fsp.readFile(readmePathB, "utf-8");
-      let readmeC = await fsp.readFile(readmePathC, "utf-8");
+      let readme = await fs.readFile(readmePath, "utf-8");
+      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readmeC = await fs.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -3155,7 +3155,7 @@ describe("apply release plan", () => {
     let lastCommit = commits[commits.length - 1].substring(0, 7);
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(tempDir, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -5,7 +5,7 @@ import {
   ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
-import fs from "fs-extra";
+import { access, mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import outdent from "outdent";
 import spawn from "spawndamnit";
@@ -128,6 +128,19 @@ async function testSetup(
   };
 }
 
+async function readJson(path: string) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function outputFile(
+  filePath: string,
+  content: string,
+  encoding = "utf8" as const
+) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, encoding);
+}
+
 describe("apply release plan", () => {
   describe("versioning", () => {
     describe("formatting", () => {
@@ -149,7 +162,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -178,7 +191,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
 \t"name": "pkg-a",
@@ -200,7 +213,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -223,7 +236,7 @@ describe("apply release plan", () => {
         let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        let pkgJSON = await readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -253,7 +266,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await fs.readJSON(pkgPath);
+      let pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toMatchObject({
         name: "pkg-a",
@@ -305,7 +318,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await fs.readJSON(pkgPath);
+      let pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -360,7 +373,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await fs.readJSON(pkgPath);
+      let pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -449,7 +462,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await fs.readJSON(pkgPath);
+      let pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -526,7 +539,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgAPath) throw new Error(`could not find an updated package json`);
-      let pkgAJSON = await fs.readJSON(pkgAPath);
+      let pkgAJSON = await readJson(pkgAPath);
 
       expect(pkgAJSON).toEqual({
         name: "pkg-a",
@@ -541,7 +554,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgCPath) throw new Error(`could not find an updated package json`);
-      let pkgCJSON = await fs.readJSON(pkgCPath);
+      let pkgCJSON = await readJson(pkgCPath);
 
       expect(pkgCJSON).toEqual({
         name: "pkg-c",
@@ -596,8 +609,8 @@ describe("apply release plan", () => {
       if (!pkgPathA || !pkgPathB) {
         throw new Error(`could not find an updated package json`);
       }
-      let pkgJSONA = await fs.readJSON(pkgPathA);
-      let pkgJSONB = await fs.readJSON(pkgPathB);
+      let pkgJSONA = await readJson(pkgPathA);
+      let pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONA).toMatchObject({
         name: "pkg-a",
@@ -687,8 +700,8 @@ describe("apply release plan", () => {
       if (!pkgPathA || !pkgPathB) {
         throw new Error(`could not find an updated package json`);
       }
-      let pkgJSONA = await fs.readJSON(pkgPathA);
-      let pkgJSONB = await fs.readJSON(pkgPathB);
+      let pkgJSONA = await readJson(pkgPathA);
+      let pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONA).toMatchObject({
         name: "pkg-a",
@@ -754,7 +767,7 @@ describe("apply release plan", () => {
         }
       );
 
-      let pkgJSON = await fs.readJSON(path.join(tempDir, "package.json"));
+      let pkgJSON = await readJson(path.join(tempDir, "package.json"));
 
       expect(pkgJSON).toMatchObject({
         name: "self-referenced",
@@ -814,7 +827,7 @@ describe("apply release plan", () => {
       expect(pkgPathA).toBeUndefined();
       if (!pkgPathB) throw new Error(`could not find an updated package json`);
 
-      let pkgJSONB = await fs.readJSON(pkgPathB);
+      let pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONB).toMatchObject({
         name: "pkg-b",
@@ -871,7 +884,7 @@ describe("apply release plan", () => {
       expect(pkgPathA).toBeUndefined();
       if (!pkgPathB) throw new Error(`could not find an updated package json`);
 
-      let pkgJSONB = await fs.readJSON(pkgPathB);
+      let pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONB).toMatchObject({
         name: "pkg-b",
@@ -925,7 +938,7 @@ describe("apply release plan", () => {
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await fs.readJSON(pkgPath);
+      let pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toMatchObject({
         name: "pkg-a",
@@ -1021,8 +1034,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1137,8 +1150,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1238,8 +1251,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1338,8 +1351,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1438,8 +1451,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1541,8 +1554,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1657,8 +1670,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1766,8 +1779,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1866,8 +1879,8 @@ describe("apply release plan", () => {
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await fs.readJSON(pkgPathA);
-          let pkgJSONB = await fs.readJSON(pkgPathB);
+          let pkgJSONA = await readJson(pkgPathA);
+          let pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1967,8 +1980,8 @@ describe("apply release plan", () => {
         if (!pkgPathDependent || !pkgPathDepended) {
           throw new Error(`could not find an updated package json`);
         }
-        let pkgJSONDependent = await fs.readJSON(pkgPathDependent);
-        let pkgJSONDepended = await fs.readJSON(pkgPathDepended);
+        let pkgJSONDependent = await readJson(pkgPathDependent);
+        let pkgJSONDepended = await readJson(pkgPathDepended);
 
         expect(pkgJSONDependent).toMatchObject({
           name: "has-peer-dep",
@@ -2037,7 +2050,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2098,8 +2111,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
+      let readmeB = await readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2237,7 +2250,7 @@ describe("apply release plan", () => {
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
       expect(readme.trim()).toEqual(
         [
           "# pkg-a\n",
@@ -2337,8 +2350,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
+      let readmeB = await readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2446,8 +2459,8 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
+      let readmeB = await readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2570,9 +2583,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
-      let readmeC = await fs.readFile(readmePathC, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
+      let readmeB = await readFile(readmePathB, "utf-8");
+      let readmeC = await readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2705,9 +2718,9 @@ describe("apply release plan", () => {
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
-      let readmeC = await fs.readFile(readmePathC, "utf-8");
+      let readme = await readFile(readmePath, "utf-8");
+      let readmeB = await readFile(readmePathB, "utf-8");
+      let readmeC = await readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2928,7 +2941,7 @@ describe("apply release plan", () => {
             const thisPath = path.resolve(tempDir, ".changeset", `${id}.md`);
             changesetPath = thisPath;
             const content = `---\n---\n${summary}`;
-            return fs.outputFile(thisPath, content);
+            return outputFile(thisPath, content);
           })
         );
 
@@ -2950,7 +2963,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await fs.pathExists(changesetPath);
+      let pathExists = await access(changesetPath)
+        .then(() => true)
+        .catch(() => false);
       expect(pathExists).toEqual(false);
     });
     it("should NOT delete changesets for ignored packages", async () => {
@@ -2964,7 +2979,7 @@ describe("apply release plan", () => {
             const thisPath = path.resolve(tempDir, ".changeset", `${id}.md`);
             changesetPath = thisPath;
             const content = `---\n---\n${summary}`;
-            return fs.outputFile(thisPath, content);
+            return outputFile(thisPath, content);
           })
         );
 
@@ -2986,7 +3001,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await fs.pathExists(changesetPath);
+      let pathExists = await access(changesetPath)
+        .then(() => true)
+        .catch(() => false);
       expect(pathExists).toEqual(true);
     });
     it("should NOT delete changesets for private unversioned packages", async () => {
@@ -3000,7 +3017,7 @@ describe("apply release plan", () => {
             const thisPath = path.resolve(tempDir, ".changeset", `${id}.md`);
             changesetPath = thisPath;
             const content = `---\n---\n${summary}`;
-            return fs.outputFile(thisPath, content);
+            return outputFile(thisPath, content);
           })
         );
 
@@ -3026,7 +3043,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await fs.pathExists(changesetPath);
+      let pathExists = await access(changesetPath)
+        .then(() => true)
+        .catch(() => false);
       expect(pathExists).toEqual(true);
     });
     it("should delete an old format changeset if it is applied", async () => {
@@ -3052,8 +3071,8 @@ describe("apply release plan", () => {
                 id,
                 `changes.json`
               );
-              await fs.outputFile(changesetMDPath, summary);
-              await fs.outputFile(
+              await outputFile(changesetMDPath, summary);
+              await outputFile(
                 changesetJSONPath,
                 JSON.stringify({ id, summary })
               );
@@ -3078,9 +3097,13 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let mdPathExists = await fs.pathExists(changesetMDPath);
+      let mdPathExists = await access(changesetMDPath)
+        .then(() => true)
+        .catch(() => false);
       // @ts-ignore this is possibly bad
-      let JSONPathExists = await fs.pathExists(changesetMDPath);
+      let JSONPathExists = await access(changesetMDPath)
+        .then(() => true)
+        .catch(() => false);
 
       expect(mdPathExists).toEqual(false);
       expect(JSONPathExists).toEqual(false);
@@ -3108,11 +3131,8 @@ describe("apply release plan", () => {
             id,
             `changes.json`
           );
-          await fs.outputFile(changesetMDPath, summary);
-          await fs.outputFile(
-            changesetJSONPath,
-            JSON.stringify({ id, summary })
-          );
+          await outputFile(changesetMDPath, summary);
+          await outputFile(changesetJSONPath, JSON.stringify({ id, summary }));
         })
       );
 
@@ -3152,7 +3172,7 @@ describe("apply release plan", () => {
     let lastCommit = commits[commits.length - 1].substring(0, 7);
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(tempDir, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )
@@ -3224,7 +3244,7 @@ describe("apply release plan", () => {
             const thisPath = path.resolve(tempDir, ".changeset", `${id}.md`);
             changesetPath = thisPath;
             const content = `---\n---\n${summary}`;
-            return fs.outputFile(thisPath, content);
+            return outputFile(thisPath, content);
           })
         );
 
@@ -3259,7 +3279,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await fs.pathExists(changesetPath);
+      let pathExists = await access(changesetPath)
+        .then(() => true)
+        .catch(() => false);
 
       expect(pathExists).toEqual(false);
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -5,8 +5,7 @@ import {
   ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
-import { ObjectEncodingOptions } from "fs";
-import { access, mkdir, readFile, writeFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import outdent from "outdent";
 import spawn from "spawndamnit";
@@ -18,6 +17,8 @@ import {
   temporarilySilenceLogs,
   testdir,
   Fixture,
+  outputFile,
+  pathExists,
 } from "@changesets/test-utils";
 
 class FakeReleasePlan {
@@ -131,15 +132,6 @@ async function testSetup(
 
 async function readJson(path: string) {
   return JSON.parse(await readFile(path, "utf8"));
-}
-
-async function outputFile(
-  filePath: string,
-  content: string,
-  encoding = "utf8" as ObjectEncodingOptions
-) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, encoding);
 }
 
 describe("apply release plan", () => {
@@ -2964,10 +2956,8 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await access(changesetPath)
-        .then(() => true)
-        .catch(() => false);
-      expect(pathExists).toEqual(false);
+      let changesetExists = await pathExists(changesetPath);
+      expect(changesetExists).toEqual(false);
     });
     it("should NOT delete changesets for ignored packages", async () => {
       const releasePlan = new FakeReleasePlan();
@@ -3002,10 +2992,8 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await access(changesetPath)
-        .then(() => true)
-        .catch(() => false);
-      expect(pathExists).toEqual(true);
+      let changesetExists = await pathExists(changesetPath);
+      expect(changesetExists).toEqual(true);
     });
     it("should NOT delete changesets for private unversioned packages", async () => {
       const releasePlan = new FakeReleasePlan();
@@ -3044,10 +3032,8 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await access(changesetPath)
-        .then(() => true)
-        .catch(() => false);
-      expect(pathExists).toEqual(true);
+      let changesetExists = await pathExists(changesetPath);
+      expect(changesetExists).toEqual(true);
     });
     it("should delete an old format changeset if it is applied", async () => {
       const releasePlan = new FakeReleasePlan();
@@ -3098,13 +3084,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let mdPathExists = await access(changesetMDPath)
-        .then(() => true)
-        .catch(() => false);
+      let mdPathExists = await pathExists(changesetMDPath);
       // @ts-ignore this is possibly bad
-      let JSONPathExists = await access(changesetMDPath)
-        .then(() => true)
-        .catch(() => false);
+      let JSONPathExists = await pathExists(changesetJSONPath);
 
       expect(mdPathExists).toEqual(false);
       expect(JSONPathExists).toEqual(false);
@@ -3280,11 +3262,9 @@ describe("apply release plan", () => {
       );
 
       // @ts-ignore this is possibly bad
-      let pathExists = await access(changesetPath)
-        .then(() => true)
-        .catch(() => false);
+      let changesetExists = await pathExists(changesetPath);
 
-      expect(pathExists).toEqual(false);
+      expect(changesetExists).toEqual(false);
 
       let gitCmd = await spawn("git", ["status"], { cwd: tempDir });
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   ComprehensiveRelease,
 } from "@changesets/types";
 import * as git from "@changesets/git";
+import { ObjectEncodingOptions } from "fs";
 import { access, mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import outdent from "outdent";
@@ -135,7 +136,7 @@ async function readJson(path: string) {
 async function outputFile(
   filePath: string,
   content: string,
-  encoding = "utf8" as const
+  encoding = "utf8" as ObjectEncodingOptions
 ) {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, content, encoding);

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -301,7 +301,7 @@ async function updateChangelog(
 
   // if the file exists but doesn't have the header, we'll add it in
   if (!fileData) {
-    const completelyNewChangelog = `# ${name}${fileData}`;
+    const completelyNewChangelog = `# ${name}${templateString}`;
     await writeFormattedMarkdownFile(
       changelogPath,
       completelyNewChangelog,
@@ -310,7 +310,7 @@ async function updateChangelog(
     return;
   }
 
-  const newChangelog = fileData.replace("\n", fileData);
+  const newChangelog = fileData.replace("\n", templateString);
 
   await writeFormattedMarkdownFile(
     changelogPath,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -85,7 +85,6 @@
     "ci-info": "^3.7.0",
     "enquirer": "^2.3.0",
     "external-editor": "^3.1.0",
-    "fs-extra": "^7.0.1",
     "mri": "^1.2.0",
     "p-limit": "^2.2.0",
     "package-manager-detector": "^0.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,7 +83,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "ansi-colors": "^4.1.3",
     "ci-info": "^3.7.0",
-    "enquirer": "^2.3.0",
+    "enquirer": "^2.3.6",
     "external-editor": "^3.1.0",
     "mri": "^1.2.0",
     "p-limit": "^2.2.0",

--- a/packages/cli/src/commands/init/__tests__/command.ts
+++ b/packages/cli/src/commands/init/__tests__/command.ts
@@ -1,8 +1,11 @@
-import fs from "fs";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import { defaultWrittenConfig } from "@changesets/config";
-import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
+import {
+  pathExists,
+  silenceLogsInBlock,
+  testdir,
+} from "@changesets/test-utils";
 
 import initializeCommand from "..";
 
@@ -17,11 +20,11 @@ describe("init", () => {
     const cwd = await testdir({});
     const { readmePath, configPath } = getPaths(cwd);
 
-    expect(fs.existsSync(readmePath)).toBe(false);
-    expect(fs.existsSync(configPath)).toBe(false);
+    expect(await pathExists(readmePath)).toBe(false);
+    expect(await pathExists(configPath)).toBe(false);
     await initializeCommand(cwd);
-    expect(fs.existsSync(readmePath)).toBe(true);
-    expect(fs.existsSync(configPath)).toBe(true);
+    expect(await pathExists(readmePath)).toBe(true);
+    expect(await pathExists(configPath)).toBe(true);
   });
   it("should write the default config if it doesn't exist", async () => {
     const cwd = await testdir({
@@ -34,7 +37,7 @@ describe("init", () => {
     await initializeCommand(cwd);
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
       )
     ).toEqual({ ...defaultWrittenConfig, baseBranch: "main" });
   });
@@ -49,7 +52,7 @@ describe("init", () => {
     await initializeCommand(cwd);
 
     const configPath = path.join(cwd, ".changeset/config.json");
-    const config = (await fsp.readFile(configPath)).toString();
+    const config = (await fs.readFile(configPath)).toString();
     const lastCharacter = config.slice(-1);
 
     expect(lastCharacter).toBe("\n");
@@ -68,7 +71,7 @@ describe("init", () => {
     await initializeCommand(cwd);
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
       )
     ).toEqual({
       changelog: false,

--- a/packages/cli/src/commands/init/__tests__/command.ts
+++ b/packages/cli/src/commands/init/__tests__/command.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "fs";
-import { readFile } from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 import { defaultWrittenConfig } from "@changesets/config";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
@@ -17,11 +17,11 @@ describe("init", () => {
     const cwd = await testdir({});
     const { readmePath, configPath } = getPaths(cwd);
 
-    expect(existsSync(readmePath)).toBe(false);
-    expect(existsSync(configPath)).toBe(false);
+    expect(fs.existsSync(readmePath)).toBe(false);
+    expect(fs.existsSync(configPath)).toBe(false);
     await initializeCommand(cwd);
-    expect(existsSync(readmePath)).toBe(true);
-    expect(existsSync(configPath)).toBe(true);
+    expect(fs.existsSync(readmePath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
   });
   it("should write the default config if it doesn't exist", async () => {
     const cwd = await testdir({
@@ -34,7 +34,7 @@ describe("init", () => {
     await initializeCommand(cwd);
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
       )
     ).toEqual({ ...defaultWrittenConfig, baseBranch: "main" });
   });
@@ -49,7 +49,7 @@ describe("init", () => {
     await initializeCommand(cwd);
 
     const configPath = path.join(cwd, ".changeset/config.json");
-    const config = (await readFile(configPath)).toString();
+    const config = (await fsp.readFile(configPath)).toString();
     const lastCharacter = config.slice(-1);
 
     expect(lastCharacter).toBe("\n");
@@ -68,7 +68,7 @@ describe("init", () => {
     await initializeCommand(cwd);
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset/config.json"), "utf8")
       )
     ).toEqual({
       changelog: false,

--- a/packages/cli/src/commands/init/__tests__/command.ts
+++ b/packages/cli/src/commands/init/__tests__/command.ts
@@ -1,4 +1,5 @@
-import fs from "fs-extra";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
 import path from "path";
 import { defaultWrittenConfig } from "@changesets/config";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
@@ -16,11 +17,11 @@ describe("init", () => {
     const cwd = await testdir({});
     const { readmePath, configPath } = getPaths(cwd);
 
-    expect(fs.pathExistsSync(readmePath)).toBe(false);
-    expect(fs.pathExistsSync(configPath)).toBe(false);
+    expect(existsSync(readmePath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
     await initializeCommand(cwd);
-    expect(fs.pathExistsSync(readmePath)).toBe(true);
-    expect(fs.pathExistsSync(configPath)).toBe(true);
+    expect(existsSync(readmePath)).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
   });
   it("should write the default config if it doesn't exist", async () => {
     const cwd = await testdir({
@@ -31,9 +32,11 @@ describe("init", () => {
     });
 
     await initializeCommand(cwd);
-    expect(await fs.readJson(path.join(cwd, ".changeset/config.json"))).toEqual(
-      { ...defaultWrittenConfig, baseBranch: "main" }
-    );
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+      )
+    ).toEqual({ ...defaultWrittenConfig, baseBranch: "main" });
   });
   it("should add newline at the end of config", async () => {
     const cwd = await testdir({
@@ -46,7 +49,7 @@ describe("init", () => {
     await initializeCommand(cwd);
 
     const configPath = path.join(cwd, ".changeset/config.json");
-    const config = (await fs.promises.readFile(configPath)).toString();
+    const config = (await readFile(configPath)).toString();
     const lastCharacter = config.slice(-1);
 
     expect(lastCharacter).toBe("\n");
@@ -63,10 +66,12 @@ describe("init", () => {
     });
 
     await initializeCommand(cwd);
-    expect(await fs.readJson(path.join(cwd, ".changeset/config.json"))).toEqual(
-      {
-        changelog: false,
-      }
-    );
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset/config.json"), "utf8")
+      )
+    ).toEqual({
+      changelog: false,
+    });
   });
 });

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "fs";
+import { cp, writeFile } from "fs/promises";
 import path from "path";
-import fs from "fs-extra";
 import pc from "picocolors";
 
 import { defaultWrittenConfig } from "@changesets/config";
@@ -18,9 +19,9 @@ const defaultConfig = `${JSON.stringify(
 export default async function init(cwd: string) {
   const changesetBase = path.resolve(cwd, ".changeset");
 
-  if (fs.existsSync(changesetBase)) {
-    if (!fs.existsSync(path.join(changesetBase, "config.json"))) {
-      if (fs.existsSync(path.join(changesetBase, "config.js"))) {
+  if (existsSync(changesetBase)) {
+    if (!existsSync(path.join(changesetBase, "config.json"))) {
+      if (existsSync(path.join(changesetBase, "config.js"))) {
         error(
           "It looks like you're using the version 1 `.changeset/config.js` file"
         );
@@ -39,7 +40,7 @@ export default async function init(cwd: string) {
           "The default config file will be written at `.changeset/config.json`"
         );
       }
-      await fs.writeFile(
+      await writeFile(
         path.resolve(changesetBase, "config.json"),
         defaultConfig
       );
@@ -49,11 +50,10 @@ export default async function init(cwd: string) {
       );
     }
   } else {
-    await fs.copy(path.resolve(pkgPath, "./default-files"), changesetBase);
-    await fs.writeFile(
-      path.resolve(changesetBase, "config.json"),
-      defaultConfig
-    );
+    await cp(path.resolve(pkgPath, "./default-files"), changesetBase, {
+      recursive: true,
+    });
+    await writeFile(path.resolve(changesetBase, "config.json"), defaultConfig);
 
     log(
       `Thanks for choosing ${pc.green(

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "fs";
-import { cp, writeFile } from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 import pc from "picocolors";
 
@@ -19,9 +19,9 @@ const defaultConfig = `${JSON.stringify(
 export default async function init(cwd: string) {
   const changesetBase = path.resolve(cwd, ".changeset");
 
-  if (existsSync(changesetBase)) {
-    if (!existsSync(path.join(changesetBase, "config.json"))) {
-      if (existsSync(path.join(changesetBase, "config.js"))) {
+  if (fs.existsSync(changesetBase)) {
+    if (!fs.existsSync(path.join(changesetBase, "config.json"))) {
+      if (fs.existsSync(path.join(changesetBase, "config.js"))) {
         error(
           "It looks like you're using the version 1 `.changeset/config.js` file"
         );
@@ -40,7 +40,7 @@ export default async function init(cwd: string) {
           "The default config file will be written at `.changeset/config.json`"
         );
       }
-      await writeFile(
+      await fsp.writeFile(
         path.resolve(changesetBase, "config.json"),
         defaultConfig
       );
@@ -50,10 +50,13 @@ export default async function init(cwd: string) {
       );
     }
   } else {
-    await cp(path.resolve(pkgPath, "./default-files"), changesetBase, {
+    await fsp.cp(path.resolve(pkgPath, "./default-files"), changesetBase, {
       recursive: true,
     });
-    await writeFile(path.resolve(changesetBase, "config.json"), defaultConfig);
+    await fsp.writeFile(
+      path.resolve(changesetBase, "config.json"),
+      defaultConfig
+    );
 
     log(
       `Thanks for choosing ${pc.green(

--- a/packages/cli/src/commands/pre/index.test.ts
+++ b/packages/cli/src/commands/pre/index.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import pc from "picocolors";
 import * as logger from "@changesets/logger";
@@ -23,7 +23,7 @@ describe("enterPre", () => {
 
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchObject({
       changesets: [],
@@ -76,7 +76,7 @@ describe("enterPre", () => {
     await pre(cwd, { command: "enter", tag: "next" });
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toEqual({
       changesets: [],
@@ -108,7 +108,7 @@ describe("exitPre", () => {
 
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toEqual({
       changesets: [],

--- a/packages/cli/src/commands/pre/index.test.ts
+++ b/packages/cli/src/commands/pre/index.test.ts
@@ -1,4 +1,4 @@
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import pc from "picocolors";
 import * as logger from "@changesets/logger";
@@ -23,7 +23,7 @@ describe("enterPre", () => {
 
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchObject({
       changesets: [],
@@ -76,7 +76,7 @@ describe("enterPre", () => {
     await pre(cwd, { command: "enter", tag: "next" });
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toEqual({
       changesets: [],
@@ -108,7 +108,7 @@ describe("exitPre", () => {
 
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toEqual({
       changesets: [],

--- a/packages/cli/src/commands/pre/index.test.ts
+++ b/packages/cli/src/commands/pre/index.test.ts
@@ -1,6 +1,6 @@
+import { readFile } from "fs/promises";
 import path from "path";
 import pc from "picocolors";
-import * as fs from "fs-extra";
 import * as logger from "@changesets/logger";
 import { ExitError } from "@changesets/errors";
 import { testdir } from "@changesets/test-utils";
@@ -22,7 +22,9 @@ describe("enterPre", () => {
     await pre(cwd, { command: "enter", tag: "next" });
 
     expect(
-      await fs.readJson(path.join(cwd, ".changeset", "pre.json"))
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
     ).toMatchObject({
       changesets: [],
       initialVersions: {},
@@ -72,14 +74,16 @@ describe("enterPre", () => {
     });
 
     await pre(cwd, { command: "enter", tag: "next" });
-    expect(await fs.readJson(path.join(cwd, ".changeset", "pre.json"))).toEqual(
-      {
-        changesets: [],
-        initialVersions: {},
-        mode: "pre",
-        tag: "next",
-      }
-    );
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
+    ).toEqual({
+      changesets: [],
+      initialVersions: {},
+      mode: "pre",
+      tag: "next",
+    });
     expect(mockedLogger.success).toBeCalledWith(
       `Entered pre mode with tag ${pc.cyan("next")}`
     );
@@ -102,14 +106,16 @@ describe("exitPre", () => {
     });
     await pre(cwd, { command: "exit" });
 
-    expect(await fs.readJson(path.join(cwd, ".changeset", "pre.json"))).toEqual(
-      {
-        changesets: [],
-        initialVersions: {},
-        mode: "exit",
-        tag: "next",
-      }
-    );
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
+    ).toEqual({
+      changesets: [],
+      initialVersions: {},
+      mode: "exit",
+      tag: "next",
+    });
   });
   it("should throw if not in pre", async () => {
     const cwd = await testdir({

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -4,7 +4,7 @@ import { gitdir, silenceLogsInBlock } from "@changesets/test-utils";
 import { ReleasePlan } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
-import fs from "fs-extra";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import status from "..";
@@ -40,6 +40,15 @@ function replaceHumanIds(releaseObj: ReleasePlan | undefined) {
   };
 }
 
+async function outputFile(
+  filePath: string,
+  content: string,
+  encoding = "utf8" as const
+) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, encoding);
+}
+
 describe("status", () => {
   silenceLogsInBlock();
 
@@ -62,7 +71,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -128,7 +137,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -195,7 +204,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -258,7 +267,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -295,7 +304,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -319,7 +328,7 @@ describe("status", () => {
       await readConfig(cwd)
     );
 
-    const releaseObj = await fs.readFile(path.join(cwd, output), "utf-8");
+    const releaseObj = await readFile(path.join(cwd, output), "utf8");
 
     expect(probsUndefined).toEqual(undefined);
     expect(replaceHumanIds(JSON.parse(releaseObj))).toMatchInlineSnapshot(`
@@ -371,7 +380,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/unrelated.json"),
       JSON.stringify({})
     );
@@ -414,7 +423,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/src/a.js"),
       'export default "updated a"'
     );
@@ -445,7 +454,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-a/a.js"),
       'export default "updated a"'
     );
@@ -520,7 +529,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-b/b.js"),
       'export default "updated b"'
     );
@@ -570,7 +579,7 @@ describe("status", () => {
 
     await spawn("git", ["checkout", "-b", "new-branch"], { cwd });
 
-    await fs.outputFile(
+    await outputFile(
       path.join(cwd, "packages/pkg-b/b.js"),
       'export default "updated b"'
     );

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -1,11 +1,10 @@
 import { read } from "@changesets/config";
 import * as git from "@changesets/git";
-import { gitdir, silenceLogsInBlock } from "@changesets/test-utils";
+import { gitdir, outputFile, silenceLogsInBlock } from "@changesets/test-utils";
 import { ReleasePlan } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
-import { ObjectEncodingOptions } from "fs";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import status from "..";
@@ -39,15 +38,6 @@ function replaceHumanIds(releaseObj: ReleasePlan | undefined) {
       changesets: release.changesets.map((id) => changesetNames.get(id) || id),
     })),
   };
-}
-
-async function outputFile(
-  filePath: string,
-  content: string,
-  encoding = "utf8" as ObjectEncodingOptions
-) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, encoding);
 }
 
 describe("status", () => {

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -4,6 +4,7 @@ import { gitdir, silenceLogsInBlock } from "@changesets/test-utils";
 import { ReleasePlan } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
+import { ObjectEncodingOptions } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
@@ -43,7 +44,7 @@ function replaceHumanIds(releaseObj: ReleasePlan | undefined) {
 async function outputFile(
   filePath: string,
   content: string,
-  encoding = "utf8" as const
+  encoding = "utf8" as ObjectEncodingOptions
 ) {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, content, encoding);

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -4,7 +4,7 @@ import { gitdir, outputFile, silenceLogsInBlock } from "@changesets/test-utils";
 import { ReleasePlan } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
-import { readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import status from "..";
@@ -319,7 +319,7 @@ describe("status", () => {
       await readConfig(cwd)
     );
 
-    const releaseObj = await readFile(path.join(cwd, output), "utf8");
+    const releaseObj = await fsp.readFile(path.join(cwd, output), "utf8");
 
     expect(probsUndefined).toEqual(undefined);
     expect(replaceHumanIds(JSON.parse(releaseObj))).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -4,7 +4,7 @@ import { gitdir, outputFile, silenceLogsInBlock } from "@changesets/test-utils";
 import { ReleasePlan } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import status from "..";
@@ -319,7 +319,7 @@ describe("status", () => {
       await readConfig(cwd)
     );
 
-    const releaseObj = await fsp.readFile(path.join(cwd, output), "utf8");
+    const releaseObj = await fs.readFile(path.join(cwd, output), "utf8");
 
     expect(probsUndefined).toEqual(undefined);
     expect(replaceHumanIds(JSON.parse(releaseObj))).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import { writeFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import getReleasePlan from "@changesets/get-release-plan";
 import { error, info, log, warn } from "@changesets/logger";
@@ -52,7 +52,7 @@ export default async function status(
   }
 
   if (output) {
-    await writeFile(
+    await fsp.writeFile(
       path.join(cwd, output),
       JSON.stringify(releasePlan, undefined, 2)
     );

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import fs from "fs-extra";
+import { writeFile } from "fs/promises";
 import path from "path";
 import getReleasePlan from "@changesets/get-release-plan";
 import { error, info, log, warn } from "@changesets/logger";
@@ -52,7 +52,7 @@ export default async function status(
   }
 
   if (output) {
-    await fs.writeFile(
+    await writeFile(
       path.join(cwd, output),
       JSON.stringify(releasePlan, undefined, 2)
     );

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import getReleasePlan from "@changesets/get-release-plan";
 import { error, info, log, warn } from "@changesets/logger";
@@ -52,7 +52,7 @@ export default async function status(
   }
 
   if (output) {
-    await fsp.writeFile(
+    await fs.writeFile(
       path.join(cwd, output),
       JSON.stringify(releasePlan, undefined, 2)
     );

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -7,7 +7,7 @@ import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
 import humanId from "human-id";
 import assert from "node:assert/strict";
-import fs from "node:fs/promises";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import pre from "../pre";
 import version from "./index";
@@ -91,7 +91,7 @@ const getFilePath = async (pkgName: string, fileName: string, cwd: string) => {
 };
 
 const getFile = async (pkgName: string, fileName: string, cwd: string) => {
-  return fs.readFile(await getFilePath(pkgName, fileName, cwd), "utf8");
+  return fsp.readFile(await getFilePath(pkgName, fileName, cwd), "utf8");
 };
 
 const getPkgJSON = async (pkgName: string, cwd: string) => {
@@ -457,7 +457,7 @@ Awesome feature, hidden behind a feature flag
       },
     ]);
 
-    const changesetDir = await fs.readdir(path.join(cwd, ".changeset"));
+    const changesetDir = await fsp.readdir(path.join(cwd, ".changeset"));
     // should still contain the ignored changeset
     expect(changesetDir).toContain(".ignored-temporarily.md");
   });
@@ -642,12 +642,12 @@ Awesome feature, hidden behind a feature flag
         ],
         cwd
       );
-      expect((await fs.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
+      expect((await fsp.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
         3
       );
 
       await version(cwd, defaultOptions, modifiedDefaultConfig);
-      expect((await fs.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
+      expect((await fsp.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
         1
       );
     });
@@ -1420,7 +1420,7 @@ describe("snapshot release", () => {
         ],
         cwd
       );
-      jest.spyOn(fs, "writeFile");
+      jest.spyOn(fsp, "writeFile");
 
       expect(
         version(
@@ -1470,7 +1470,7 @@ describe("snapshot release", () => {
         ],
         cwd
       );
-      jest.spyOn(fs, "writeFile");
+      jest.spyOn(fsp, "writeFile");
 
       expect(
         version(
@@ -1887,10 +1887,10 @@ describe("updateInternalDependents: always", () => {
     // pkg-b and - pkg-c are not being released so changelogs should not be
     // generated for them
     expect(
-      fs.access(await getFilePath("pkg-b", "CHANGELOG.md", cwd))
+      fsp.access(await getFilePath("pkg-b", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
     expect(
-      fs.access(await getFilePath("pkg-c", "CHANGELOG.md", cwd))
+      fsp.access(await getFilePath("pkg-c", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
   });
 
@@ -1944,7 +1944,7 @@ describe("updateInternalDependents: always", () => {
 
     // shouldn't be created
     expect(
-      fs.access(await getFilePath("pkg-a", "CHANGELOG.md", cwd))
+      fsp.access(await getFilePath("pkg-a", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
 
     expect(await getChangelog("pkg-b", cwd)).toMatchInlineSnapshot(`
@@ -2164,7 +2164,7 @@ describe("pre", () => {
       },
     ]);
     expect(
-      await fs.readFile(
+      await fsp.readFile(
         path.join(packages.packages[0].dir, "CHANGELOG.md"),
         "utf8"
       )
@@ -2211,7 +2211,7 @@ describe("pre", () => {
       "
     `);
     expect(
-      await fs.readFile(
+      await fsp.readFile(
         path.join(packages.packages[1].dir, "CHANGELOG.md"),
         "utf8"
       )
@@ -2274,8 +2274,8 @@ describe("pre", () => {
         version: "1.0.1-next.0",
       },
     ]);
-    await fs.mkdir(path.join(cwd, "packages", "pkg-c"), { recursive: true });
-    await fs.writeFile(
+    await fsp.mkdir(path.join(cwd, "packages", "pkg-c"), { recursive: true });
+    await fsp.writeFile(
       path.join(cwd, "packages", "pkg-c", "package.json"),
       JSON.stringify(
         {

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -7,7 +7,7 @@ import writeChangeset from "@changesets/write";
 import { getPackages } from "@manypkg/get-packages";
 import humanId from "human-id";
 import assert from "node:assert/strict";
-import fsp from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import pre from "../pre";
 import version from "./index";
@@ -91,7 +91,7 @@ const getFilePath = async (pkgName: string, fileName: string, cwd: string) => {
 };
 
 const getFile = async (pkgName: string, fileName: string, cwd: string) => {
-  return fsp.readFile(await getFilePath(pkgName, fileName, cwd), "utf8");
+  return fs.readFile(await getFilePath(pkgName, fileName, cwd), "utf8");
 };
 
 const getPkgJSON = async (pkgName: string, cwd: string) => {
@@ -457,7 +457,7 @@ Awesome feature, hidden behind a feature flag
       },
     ]);
 
-    const changesetDir = await fsp.readdir(path.join(cwd, ".changeset"));
+    const changesetDir = await fs.readdir(path.join(cwd, ".changeset"));
     // should still contain the ignored changeset
     expect(changesetDir).toContain(".ignored-temporarily.md");
   });
@@ -642,12 +642,12 @@ Awesome feature, hidden behind a feature flag
         ],
         cwd
       );
-      expect((await fsp.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
+      expect((await fs.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
         3
       );
 
       await version(cwd, defaultOptions, modifiedDefaultConfig);
-      expect((await fsp.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
+      expect((await fs.readdir(path.resolve(cwd, ".changeset"))).length).toBe(
         1
       );
     });
@@ -1420,7 +1420,6 @@ describe("snapshot release", () => {
         ],
         cwd
       );
-      jest.spyOn(fsp, "writeFile");
 
       expect(
         version(
@@ -1470,7 +1469,6 @@ describe("snapshot release", () => {
         ],
         cwd
       );
-      jest.spyOn(fsp, "writeFile");
 
       expect(
         version(
@@ -1887,10 +1885,10 @@ describe("updateInternalDependents: always", () => {
     // pkg-b and - pkg-c are not being released so changelogs should not be
     // generated for them
     expect(
-      fsp.access(await getFilePath("pkg-b", "CHANGELOG.md", cwd))
+      fs.access(await getFilePath("pkg-b", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
     expect(
-      fsp.access(await getFilePath("pkg-c", "CHANGELOG.md", cwd))
+      fs.access(await getFilePath("pkg-c", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
   });
 
@@ -1944,7 +1942,7 @@ describe("updateInternalDependents: always", () => {
 
     // shouldn't be created
     expect(
-      fsp.access(await getFilePath("pkg-a", "CHANGELOG.md", cwd))
+      fs.access(await getFilePath("pkg-a", "CHANGELOG.md", cwd))
     ).rejects.toThrow();
 
     expect(await getChangelog("pkg-b", cwd)).toMatchInlineSnapshot(`
@@ -2164,7 +2162,7 @@ describe("pre", () => {
       },
     ]);
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(packages.packages[0].dir, "CHANGELOG.md"),
         "utf8"
       )
@@ -2211,7 +2209,7 @@ describe("pre", () => {
       "
     `);
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(packages.packages[1].dir, "CHANGELOG.md"),
         "utf8"
       )
@@ -2274,8 +2272,8 @@ describe("pre", () => {
         version: "1.0.1-next.0",
       },
     ]);
-    await fsp.mkdir(path.join(cwd, "packages", "pkg-c"), { recursive: true });
-    await fsp.writeFile(
+    await fs.mkdir(path.join(cwd, "packages", "pkg-c"), { recursive: true });
+    await fs.writeFile(
       path.join(cwd, "packages", "pkg-c", "package.json"),
       JSON.stringify(
         {

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs/promises";
 import path from "path";
 import * as git from "@changesets/git";
 import { warn } from "@changesets/logger";
@@ -113,6 +113,7 @@ beforeEach(() => {
 
 afterEach(() => {
   console.error = consoleError;
+  jest.restoreAllMocks();
 });
 
 describe("running version in a simple project", () => {
@@ -219,7 +220,7 @@ describe("running version in a simple project", () => {
       ignore: ["pkg-a"],
     });
 
-    const bumpedPackageA = !!spy.mock.calls.find((call: string[]) =>
+    const bumpedPackageA = !!spy.mock.calls.find((call: any) =>
       call[0].endsWith(`pkg-a${path.sep}package.json`)
     );
 
@@ -2271,11 +2272,18 @@ describe("pre", () => {
         version: "1.0.1-next.0",
       },
     ]);
-    await fs.mkdir(path.join(cwd, "packages", "pkg-c"));
-    await fs.writeJson(path.join(cwd, "packages", "pkg-c", "package.json"), {
-      name: "pkg-c",
-      version: "0.0.0",
-    });
+    await fs.mkdir(path.join(cwd, "packages", "pkg-c"), { recursive: true });
+    await fs.writeFile(
+      path.join(cwd, "packages", "pkg-c", "package.json"),
+      JSON.stringify(
+        {
+          name: "pkg-c",
+          version: "0.0.0",
+        },
+        null,
+        2
+      ) + "\n"
+    );
     await writeChangeset(
       {
         releases: [

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -5,8 +5,8 @@ import { error } from "@changesets/logger";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { Config } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
-import { existsSync } from "fs";
-import { access } from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 import add from "./commands/add";
 import init from "./commands/init";
@@ -27,7 +27,7 @@ export async function run(
     return;
   }
 
-  if (!existsSync(path.resolve(cwd, ".changeset"))) {
+  if (!fs.existsSync(path.resolve(cwd, ".changeset"))) {
     error("There is no .changeset folder. ");
     error(
       "If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up."
@@ -44,9 +44,8 @@ export async function run(
   try {
     config = await read(cwd, packages);
   } catch (e) {
-    let oldConfigExists = await access(
-      path.resolve(cwd, ".changeset/config.js")
-    )
+    let oldConfigExists = await fsp
+      .access(path.resolve(cwd, ".changeset/config.js"))
       .then(() => true)
       .catch(() => false);
     if (oldConfigExists) {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -5,7 +5,8 @@ import { error } from "@changesets/logger";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { Config } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
-import fs from "fs-extra";
+import { existsSync } from "fs";
+import { access } from "fs/promises";
 import path from "path";
 import add from "./commands/add";
 import init from "./commands/init";
@@ -26,7 +27,7 @@ export async function run(
     return;
   }
 
-  if (!fs.existsSync(path.resolve(cwd, ".changeset"))) {
+  if (!existsSync(path.resolve(cwd, ".changeset"))) {
     error("There is no .changeset folder. ");
     error(
       "If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up."
@@ -43,9 +44,11 @@ export async function run(
   try {
     config = await read(cwd, packages);
   } catch (e) {
-    let oldConfigExists = await fs.pathExists(
+    let oldConfigExists = await access(
       path.resolve(cwd, ".changeset/config.js")
-    );
+    )
+      .then(() => true)
+      .catch(() => false);
     if (oldConfigExists) {
       error(
         "It looks like you're using the version 1 `.changeset/config.js` file"

--- a/packages/cli/src/utils/v1-legacy/removeFolders.ts
+++ b/packages/cli/src/utils/v1-legacy/removeFolders.ts
@@ -1,18 +1,19 @@
+import { readdirSync } from "fs";
+import { readdir, rmdir } from "fs/promises";
 import path from "path";
-import fs from "fs-extra";
 
 // This helper is designed to operate on the .changeset
 // folder, and tidy up the subfolders
 // THIS SHOULD BE REMOVED WHEN SUPPORT FOR CHANGESETS FROM V1 IS DROPPED
 
 const removeEmptyFolders = async (folderPath: string) => {
-  const dirContents = fs.readdirSync(folderPath);
+  const dirContents = readdirSync(folderPath);
   return Promise.all(
     dirContents.map(async (contentPath) => {
       const singleChangesetPath = path.resolve(folderPath, contentPath);
       try {
-        if ((await fs.readdir(singleChangesetPath)).length < 1) {
-          await fs.rmdir(singleChangesetPath);
+        if ((await readdir(singleChangesetPath)).length < 1) {
+          await rmdir(singleChangesetPath);
         }
       } catch (err) {
         if ((err as any).code !== "ENOTDIR") {

--- a/packages/cli/src/utils/v1-legacy/removeFolders.ts
+++ b/packages/cli/src/utils/v1-legacy/removeFolders.ts
@@ -1,5 +1,5 @@
-import { readdirSync } from "fs";
-import { readdir, rmdir } from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 
 // This helper is designed to operate on the .changeset
@@ -7,13 +7,13 @@ import path from "path";
 // THIS SHOULD BE REMOVED WHEN SUPPORT FOR CHANGESETS FROM V1 IS DROPPED
 
 const removeEmptyFolders = async (folderPath: string) => {
-  const dirContents = readdirSync(folderPath);
+  const dirContents = fs.readdirSync(folderPath);
   return Promise.all(
     dirContents.map(async (contentPath) => {
       const singleChangesetPath = path.resolve(folderPath, contentPath);
       try {
-        if ((await readdir(singleChangesetPath)).length < 1) {
-          await rmdir(singleChangesetPath);
+        if ((await fsp.readdir(singleChangesetPath)).length < 1) {
+          await fsp.rmdir(singleChangesetPath);
         }
       } catch (err) {
         if ((err as any).code !== "ENOTDIR") {

--- a/packages/cli/src/utils/v1-legacy/removeFolders.ts
+++ b/packages/cli/src/utils/v1-legacy/removeFolders.ts
@@ -1,5 +1,4 @@
-import fs from "fs";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 
 // This helper is designed to operate on the .changeset
@@ -7,13 +6,13 @@ import path from "path";
 // THIS SHOULD BE REMOVED WHEN SUPPORT FOR CHANGESETS FROM V1 IS DROPPED
 
 const removeEmptyFolders = async (folderPath: string) => {
-  const dirContents = fs.readdirSync(folderPath);
+  const dirContents = await fs.readdir(folderPath);
   return Promise.all(
     dirContents.map(async (contentPath) => {
       const singleChangesetPath = path.resolve(folderPath, contentPath);
       try {
-        if ((await fsp.readdir(singleChangesetPath)).length < 1) {
-          await fsp.rmdir(singleChangesetPath);
+        if ((await fs.readdir(singleChangesetPath)).length < 1) {
+          await fs.rmdir(singleChangesetPath);
         }
       } catch (err) {
         if ((err as any).code !== "ENOTDIR") {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,7 +28,6 @@
     "@changesets/logger": "^0.1.1",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
-    "fs-extra": "^7.0.1",
     "micromatch": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,4 @@
+import fsp from "fs/promises";
 import path from "path";
 import micromatch from "micromatch";
 import { ValidationError } from "@changesets/errors";
@@ -12,7 +13,6 @@ import {
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
-import { readFile } from "fs/promises";
 
 export let defaultWrittenConfig = {
   $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
@@ -93,7 +93,7 @@ function isArray<T>(
 
 export let read = async (cwd: string, packages: Packages) => {
   let json = JSON.parse(
-    await readFile(path.join(cwd, ".changeset", "config.json"), "utf8")
+    await fsp.readFile(path.join(cwd, ".changeset", "config.json"), "utf8")
   );
   return parse(json, packages);
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import micromatch from "micromatch";
 import { ValidationError } from "@changesets/errors";
@@ -93,7 +93,7 @@ function isArray<T>(
 
 export let read = async (cwd: string, packages: Packages) => {
   let json = JSON.parse(
-    await fsp.readFile(path.join(cwd, ".changeset", "config.json"), "utf8")
+    await fs.readFile(path.join(cwd, ".changeset", "config.json"), "utf8")
   );
   return parse(json, packages);
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs-extra";
 import path from "path";
 import micromatch from "micromatch";
 import { ValidationError } from "@changesets/errors";
@@ -13,6 +12,7 @@ import {
 } from "@changesets/types";
 import packageJson from "../package.json";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
+import { readFile } from "fs/promises";
 
 export let defaultWrittenConfig = {
   $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
@@ -92,7 +92,9 @@ function isArray<T>(
 }
 
 export let read = async (cwd: string, packages: Packages) => {
-  let json = await fs.readJSON(path.join(cwd, ".changeset", "config.json"));
+  let json = JSON.parse(
+    await readFile(path.join(cwd, ".changeset", "config.json"), "utf8")
+  );
   return parse(json, packages);
 };
 

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@changesets/test-utils": "*",
     "@changesets/write": "*",
-    "file-url": "^3.0.0",
-    "fs-extra": "^7.0.1"
+    "file-url": "^3.0.0"
   }
 }

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -1,8 +1,7 @@
-import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import fileUrl from "file-url";
-import { gitdir, tempdir } from "@changesets/test-utils";
+import { gitdir, outputFile, tempdir } from "@changesets/test-utils";
 import writeChangeset from "@changesets/write";
 
 import {
@@ -18,20 +17,10 @@ import {
   tagExists,
   getCurrentCommitId,
 } from "./";
-import { ObjectEncodingOptions } from "fs";
 
 async function getCommitCount(cwd: string) {
   const cmd = await spawn("git", ["rev-list", "--count", "HEAD"], { cwd });
   return parseInt(cmd.stdout.toString(), 10);
-}
-
-async function outputFile(
-  filePath: string,
-  content: string,
-  encoding = "utf8" as ObjectEncodingOptions
-) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, encoding);
 }
 
 describe("git", () => {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1,5 +1,5 @@
 import spawn from "spawndamnit";
-import fs from "fs";
+import fs from "node:fs/promises";
 import path from "path";
 import { getPackages, Package } from "@manypkg/get-packages";
 import { GitError } from "@changesets/errors";
@@ -159,7 +159,12 @@ export async function isRepoShallow({ cwd }: { cwd: string }) {
     const fullGitDir = path.resolve(cwd, gitDir);
 
     // Check for the existence of <gitDir>/shallow
-    return fs.existsSync(path.join(fullGitDir, "shallow"));
+    try {
+      await fs.access(path.join(fullGitDir, "shallow"));
+      return true;
+    } catch {
+      return false;
+    }
   } else {
     // We have a newer Git which supports `rev-parse --is-shallow-repository`. We'll use
     // the output of that instead of messing with .git/shallow in case that changes in the future.

--- a/packages/pre/package.json
+++ b/packages/pre/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@changesets/errors": "^0.2.0",
     "@changesets/types": "^6.0.0",
-    "@manypkg/get-packages": "^1.1.3",
-    "fs-extra": "^7.0.1"
+    "@manypkg/get-packages": "^1.1.3"
   },
   "devDependencies": {
     "@changesets/test-utils": "*"

--- a/packages/pre/src/index.test.ts
+++ b/packages/pre/src/index.test.ts
@@ -1,5 +1,5 @@
 import { enterPre, exitPre, readPreState } from "./index";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import {
   PreEnterButInPreModeError,
@@ -30,7 +30,7 @@ describe("enterPre", () => {
 
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {
@@ -105,7 +105,7 @@ describe("enterPre", () => {
     await enterPre(cwd, "next");
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {
@@ -155,7 +155,7 @@ describe("exitPre", () => {
 
     expect(
       JSON.parse(
-        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {

--- a/packages/pre/src/index.test.ts
+++ b/packages/pre/src/index.test.ts
@@ -1,5 +1,5 @@
 import { enterPre, exitPre, readPreState } from "./index";
-import * as fs from "fs-extra";
+import { readFile } from "fs/promises";
 import path from "path";
 import {
   PreEnterButInPreModeError,
@@ -28,8 +28,11 @@ describe("enterPre", () => {
     });
     await enterPre(cwd, "next");
 
-    expect(await fs.readJson(path.join(cwd, ".changeset", "pre.json")))
-      .toMatchInlineSnapshot(`
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
+    ).toMatchInlineSnapshot(`
       {
         "changesets": [],
         "initialVersions": {
@@ -100,8 +103,11 @@ describe("enterPre", () => {
       }),
     });
     await enterPre(cwd, "next");
-    expect(await fs.readJson(path.join(cwd, ".changeset", "pre.json")))
-      .toMatchInlineSnapshot(`
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
+    ).toMatchInlineSnapshot(`
       {
         "changesets": [
           "slimy-dingos-whisper",
@@ -147,8 +153,11 @@ describe("exitPre", () => {
     });
     await exitPre(cwd);
 
-    expect(await fs.readJson(path.join(cwd, ".changeset", "pre.json")))
-      .toMatchInlineSnapshot(`
+    expect(
+      JSON.parse(
+        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+      )
+    ).toMatchInlineSnapshot(`
       {
         "changesets": [],
         "initialVersions": {

--- a/packages/pre/src/index.test.ts
+++ b/packages/pre/src/index.test.ts
@@ -1,5 +1,5 @@
 import { enterPre, exitPre, readPreState } from "./index";
-import { readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import {
   PreEnterButInPreModeError,
@@ -30,7 +30,7 @@ describe("enterPre", () => {
 
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {
@@ -105,7 +105,7 @@ describe("enterPre", () => {
     await enterPre(cwd, "next");
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {
@@ -155,7 +155,7 @@ describe("exitPre", () => {
 
     expect(
       JSON.parse(
-        await readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
+        await fsp.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8")
       )
     ).toMatchInlineSnapshot(`
       {

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -1,5 +1,4 @@
-import fs from "fs";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import { PreState } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
@@ -8,13 +7,9 @@ import {
   PreEnterButInPreModeError,
 } from "@changesets/errors";
 
-async function outputFile(
-  filePath: string,
-  content: string,
-  encoding = "utf8" as fs.ObjectEncodingOptions
-) {
-  await fsp.mkdir(path.dirname(filePath), { recursive: true });
-  await fsp.writeFile(filePath, content, encoding);
+async function outputFile(filePath: string, content: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
 }
 
 export async function readPreState(cwd: string): Promise<PreState | undefined> {
@@ -22,7 +17,7 @@ export async function readPreState(cwd: string): Promise<PreState | undefined> {
   // TODO: verify that the pre state isn't broken
   let preState: PreState | undefined;
   try {
-    let contents = await fsp.readFile(preStatePath, "utf8");
+    let contents = await fs.readFile(preStatePath, "utf8");
     try {
       preState = JSON.parse(contents);
     } catch (err) {

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -1,5 +1,5 @@
-import { ObjectEncodingOptions } from "fs";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 import { PreState } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
@@ -11,10 +11,10 @@ import {
 async function outputFile(
   filePath: string,
   content: string,
-  encoding = "utf8" as ObjectEncodingOptions
+  encoding = "utf8" as fs.ObjectEncodingOptions
 ) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, encoding);
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, content, encoding);
 }
 
 export async function readPreState(cwd: string): Promise<PreState | undefined> {
@@ -22,7 +22,7 @@ export async function readPreState(cwd: string): Promise<PreState | undefined> {
   // TODO: verify that the pre state isn't broken
   let preState: PreState | undefined;
   try {
-    let contents = await readFile(preStatePath, "utf8");
+    let contents = await fsp.readFile(preStatePath, "utf8");
     try {
       preState = JSON.parse(contents);
     } catch (err) {

--- a/packages/read/package.json
+++ b/packages/read/package.json
@@ -23,7 +23,6 @@
     "@changesets/logger": "^0.1.1",
     "@changesets/parse": "^0.4.0",
     "@changesets/types": "^6.0.0",
-    "fs-extra": "^7.0.1",
     "p-filter": "^2.1.0",
     "picocolors": "^1.1.0"
   },

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -3,7 +3,7 @@ import outdent from "outdent";
 
 import read from "./";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
-import { mkdir } from "fs/promises";
+import fsp from "fs/promises";
 
 silenceLogsInBlock();
 
@@ -98,7 +98,7 @@ I'm amazed we needed to update the best package, because it was already the best
   });
   it("should return an empty array when no changesets are found", async () => {
     const cwd = await testdir({});
-    await mkdir(path.join(cwd, ".changeset"), { recursive: true });
+    await fsp.mkdir(path.join(cwd, ".changeset"), { recursive: true });
 
     const changesets = await read(cwd);
     expect(changesets).toEqual([]);

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -3,7 +3,7 @@ import outdent from "outdent";
 
 import read from "./";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 
 silenceLogsInBlock();
 
@@ -98,7 +98,7 @@ I'm amazed we needed to update the best package, because it was already the best
   });
   it("should return an empty array when no changesets are found", async () => {
     const cwd = await testdir({});
-    await fsp.mkdir(path.join(cwd, ".changeset"), { recursive: true });
+    await fs.mkdir(path.join(cwd, ".changeset"), { recursive: true });
 
     const changesets = await read(cwd);
     expect(changesets).toEqual([]);

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -1,9 +1,9 @@
-import fs from "fs-extra";
 import path from "path";
 import outdent from "outdent";
 
 import read from "./";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
+import { mkdir } from "fs/promises";
 
 silenceLogsInBlock();
 
@@ -98,7 +98,7 @@ I'm amazed we needed to update the best package, because it was already the best
   });
   it("should return an empty array when no changesets are found", async () => {
     const cwd = await testdir({});
-    await fs.mkdir(path.join(cwd, ".changeset"));
+    await mkdir(path.join(cwd, ".changeset"), { recursive: true });
 
     const changesets = await read(cwd);
     expect(changesets).toEqual([]);

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -50,10 +50,7 @@ export default async function getChangesets(
   );
 
   const changesetContents = changesets.map(async (file) => {
-    const changeset = await fs.readFile(
-      path.join(changesetBase, file),
-      "utf8"
-    );
+    const changeset = await fs.readFile(path.join(changesetBase, file), "utf8");
 
     return { ...parse(changeset), id: file.replace(".md", "") };
   });

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -1,4 +1,4 @@
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import parse from "@changesets/parse";
 import { NewChangeset } from "@changesets/types";
@@ -26,7 +26,7 @@ export default async function getChangesets(
   let changesetBase = path.join(cwd, ".changeset");
   let contents: string[];
   try {
-    contents = await fsp.readdir(changesetBase);
+    contents = await fs.readdir(changesetBase);
   } catch (err) {
     if ((err as any).code === "ENOENT") {
       throw new Error("There is no .changeset directory in this project");
@@ -50,7 +50,7 @@ export default async function getChangesets(
   );
 
   const changesetContents = changesets.map(async (file) => {
-    const changeset = await fsp.readFile(
+    const changeset = await fs.readFile(
       path.join(changesetBase, file),
       "utf8"
     );

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -1,9 +1,9 @@
-import fs from "fs-extra";
 import path from "path";
 import parse from "@changesets/parse";
 import { NewChangeset } from "@changesets/types";
 import * as git from "@changesets/git";
 import getOldChangesetsAndWarn from "./legacy";
+import { readdir, readFile } from "fs/promises";
 
 async function filterChangesetsSinceRef(
   changesets: Array<string>,
@@ -26,7 +26,7 @@ export default async function getChangesets(
   let changesetBase = path.join(cwd, ".changeset");
   let contents: string[];
   try {
-    contents = await fs.readdir(changesetBase);
+    contents = await readdir(changesetBase);
   } catch (err) {
     if ((err as any).code === "ENOENT") {
       throw new Error("There is no .changeset directory in this project");
@@ -50,10 +50,7 @@ export default async function getChangesets(
   );
 
   const changesetContents = changesets.map(async (file) => {
-    const changeset = await fs.readFile(
-      path.join(changesetBase, file),
-      "utf-8"
-    );
+    const changeset = await readFile(path.join(changesetBase, file), "utf8");
 
     return { ...parse(changeset), id: file.replace(".md", "") };
   });

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -1,9 +1,9 @@
+import fsp from "fs/promises";
 import path from "path";
 import parse from "@changesets/parse";
 import { NewChangeset } from "@changesets/types";
 import * as git from "@changesets/git";
 import getOldChangesetsAndWarn from "./legacy";
-import { readdir, readFile } from "fs/promises";
 
 async function filterChangesetsSinceRef(
   changesets: Array<string>,
@@ -26,7 +26,7 @@ export default async function getChangesets(
   let changesetBase = path.join(cwd, ".changeset");
   let contents: string[];
   try {
-    contents = await readdir(changesetBase);
+    contents = await fsp.readdir(changesetBase);
   } catch (err) {
     if ((err as any).code === "ENOENT") {
       throw new Error("There is no .changeset directory in this project");
@@ -50,7 +50,10 @@ export default async function getChangesets(
   );
 
   const changesetContents = changesets.map(async (file) => {
-    const changeset = await readFile(path.join(changesetBase, file), "utf8");
+    const changeset = await fsp.readFile(
+      path.join(changesetBase, file),
+      "utf8"
+    );
 
     return { ...parse(changeset), id: file.replace(".md", "") };
   });

--- a/packages/read/src/legacy.ts
+++ b/packages/read/src/legacy.ts
@@ -1,4 +1,4 @@
-import { lstat, readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import pc from "picocolors";
 import { NewChangeset } from "@changesets/types";
@@ -21,15 +21,18 @@ async function getOldChangesets(
 ): Promise<Array<NewChangeset>> {
   // this needs to support just not dealing with dirs that aren't set up properly
   let changesets = await pFilter(dirs, async (dir) =>
-    (await lstat(path.join(changesetBase, dir))).isDirectory()
+    (await fsp.lstat(path.join(changesetBase, dir))).isDirectory()
   );
 
   const changesetContents = changesets.map(async (changesetDir) => {
     const jsonPath = path.join(changesetBase, changesetDir, "changes.json");
 
     const [summary, rawJson] = await Promise.all([
-      readFile(path.join(changesetBase, changesetDir, "changes.md"), "utf8"),
-      readFile(jsonPath, "utf8"),
+      fsp.readFile(
+        path.join(changesetBase, changesetDir, "changes.md"),
+        "utf8"
+      ),
+      fsp.readFile(jsonPath, "utf8"),
     ]);
     const json = JSON.parse(rawJson);
 

--- a/packages/read/src/legacy.ts
+++ b/packages/read/src/legacy.ts
@@ -1,4 +1,4 @@
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import pc from "picocolors";
 import { NewChangeset } from "@changesets/types";
@@ -21,18 +21,15 @@ async function getOldChangesets(
 ): Promise<Array<NewChangeset>> {
   // this needs to support just not dealing with dirs that aren't set up properly
   let changesets = await pFilter(dirs, async (dir) =>
-    (await fsp.lstat(path.join(changesetBase, dir))).isDirectory()
+    (await fs.lstat(path.join(changesetBase, dir))).isDirectory()
   );
 
   const changesetContents = changesets.map(async (changesetDir) => {
     const jsonPath = path.join(changesetBase, changesetDir, "changes.json");
 
     const [summary, rawJson] = await Promise.all([
-      fsp.readFile(
-        path.join(changesetBase, changesetDir, "changes.md"),
-        "utf8"
-      ),
-      fsp.readFile(jsonPath, "utf8"),
+      fs.readFile(path.join(changesetBase, changesetDir, "changes.md"), "utf8"),
+      fs.readFile(jsonPath, "utf8"),
     ]);
     const json = JSON.parse(rawJson);
 

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -20,7 +20,6 @@
     "@changesets/read": "^0.6.1",
     "@changesets/types": "^6.0.0",
     "@manypkg/get-packages": "^1.1.3",
-    "fs-extra": "^7.0.1",
     "mdast-util-to-string": "^1.0.6",
     "remark-parse": "^7.0.1",
     "remark-stringify": "^7.0.3",

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -3,14 +3,14 @@ import { silenceLogsInBlock, tempdir, testdir } from "@changesets/test-utils";
 import { Changeset } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import fileUrl from "file-url";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import { getCurrentBranch } from "./gitUtils";
 import { runPublish, runVersion } from "./run";
 
 const linkNodeModules = async (cwd: string) => {
-  await fsp.symlink(
+  await fs.symlink(
     path.join(__dirname, "..", "..", "..", "node_modules"),
     path.join(cwd, "node_modules")
   );
@@ -101,7 +101,7 @@ describe("version", () => {
     });
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8"
       )
@@ -116,7 +116,7 @@ describe("version", () => {
     `);
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
         "utf8"
       )
@@ -127,7 +127,7 @@ describe("version", () => {
       }"
     `);
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )
@@ -141,7 +141,7 @@ describe("version", () => {
 `)
     );
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"),
         "utf8"
       )
@@ -224,7 +224,7 @@ describe("version", () => {
     });
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8"
       )
@@ -239,7 +239,7 @@ describe("version", () => {
     `);
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
         "utf8"
       )
@@ -251,7 +251,7 @@ describe("version", () => {
     `);
 
     expect(
-      await fsp.readFile(
+      await fs.readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )
@@ -265,7 +265,7 @@ describe("version", () => {
 `)
     );
     await expect(
-      fsp.readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf8")
+      fs.readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
     expect(changedPackages).toEqual([
       {

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -3,14 +3,14 @@ import { silenceLogsInBlock, tempdir, testdir } from "@changesets/test-utils";
 import { Changeset } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import fileUrl from "file-url";
-import { readFile, symlink } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import { getCurrentBranch } from "./gitUtils";
 import { runPublish, runVersion } from "./run";
 
 const linkNodeModules = async (cwd: string) => {
-  await symlink(
+  await fsp.symlink(
     path.join(__dirname, "..", "..", "..", "node_modules"),
     path.join(cwd, "node_modules")
   );
@@ -101,7 +101,7 @@ describe("version", () => {
     });
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8"
       )
@@ -116,7 +116,7 @@ describe("version", () => {
     `);
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
         "utf8"
       )
@@ -127,7 +127,7 @@ describe("version", () => {
       }"
     `);
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )
@@ -141,7 +141,7 @@ describe("version", () => {
 `)
     );
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"),
         "utf8"
       )
@@ -224,7 +224,7 @@ describe("version", () => {
     });
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8"
       )
@@ -239,7 +239,7 @@ describe("version", () => {
     `);
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
         "utf8"
       )
@@ -251,7 +251,7 @@ describe("version", () => {
     `);
 
     expect(
-      await readFile(
+      await fsp.readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
         "utf8"
       )
@@ -265,7 +265,7 @@ describe("version", () => {
 `)
     );
     await expect(
-      readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf8")
+      fsp.readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
     expect(changedPackages).toEqual([
       {

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -3,14 +3,14 @@ import { silenceLogsInBlock, tempdir, testdir } from "@changesets/test-utils";
 import { Changeset } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import fileUrl from "file-url";
-import fs from "fs-extra";
+import { readFile, symlink } from "fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
 import { getCurrentBranch } from "./gitUtils";
 import { runPublish, runVersion } from "./run";
 
 const linkNodeModules = async (cwd: string) => {
-  await fs.symlink(
+  await symlink(
     path.join(__dirname, "..", "..", "..", "node_modules"),
     path.join(cwd, "node_modules")
   );
@@ -101,9 +101,9 @@ describe("version", () => {
     });
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
-        "utf-8"
+        "utf8"
       )
     ).toMatchInlineSnapshot(`
       "{
@@ -116,9 +116,9 @@ describe("version", () => {
     `);
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
-        "utf-8"
+        "utf8"
       )
     ).toMatchInlineSnapshot(`
       "{
@@ -127,9 +127,9 @@ describe("version", () => {
       }"
     `);
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
-        "utf-8"
+        "utf8"
       )
     ).toEqual(
       expect.stringContaining(`# pkg-a
@@ -141,9 +141,9 @@ describe("version", () => {
 `)
     );
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"),
-        "utf-8"
+        "utf8"
       )
     ).toEqual(
       expect.stringContaining(`# pkg-b
@@ -224,9 +224,9 @@ describe("version", () => {
     });
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-a", "package.json"),
-        "utf-8"
+        "utf8"
       )
     ).toMatchInlineSnapshot(`
       "{
@@ -239,9 +239,9 @@ describe("version", () => {
     `);
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
-        "utf-8"
+        "utf8"
       )
     ).toMatchInlineSnapshot(`
       "{
@@ -251,9 +251,9 @@ describe("version", () => {
     `);
 
     expect(
-      await fs.readFile(
+      await readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
-        "utf-8"
+        "utf8"
       )
     ).toEqual(
       expect.stringContaining(`# pkg-a
@@ -265,7 +265,7 @@ describe("version", () => {
 `)
     );
     await expect(
-      fs.readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf-8")
+      readFile(path.join(cwd, "packages", "pkg-b", "CHANGELOG.md"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
     expect(changedPackages).toEqual([
       {

--- a/packages/write/package.json
+++ b/packages/write/package.json
@@ -20,7 +20,6 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/write",
   "dependencies": {
     "@changesets/types": "^6.0.0",
-    "fs-extra": "^7.0.1",
     "human-id": "^4.1.1",
     "prettier": "^2.7.1"
   },

--- a/packages/write/src/index.test.ts
+++ b/packages/write/src/index.test.ts
@@ -1,4 +1,4 @@
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import path from "path";
 import parse from "@changesets/parse";
 import writeChangeset from "./";
@@ -34,7 +34,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await fsp.readFile(mdPath, "utf8");
+    const mdContent = await fs.readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "This is a summary",
@@ -66,7 +66,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await fsp.readFile(mdPath, "utf8");
+    const mdContent = await fs.readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "",

--- a/packages/write/src/index.test.ts
+++ b/packages/write/src/index.test.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import { readFile } from "fs/promises";
 import path from "path";
 import parse from "@changesets/parse";
 import writeChangeset from "./";
@@ -34,7 +34,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await fs.readFile(mdPath, "utf-8");
+    const mdContent = await readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "This is a summary",
@@ -66,7 +66,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await fs.readFile(mdPath, "utf-8");
+    const mdContent = await readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "",

--- a/packages/write/src/index.test.ts
+++ b/packages/write/src/index.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import fsp from "fs/promises";
 import path from "path";
 import parse from "@changesets/parse";
 import writeChangeset from "./";
@@ -34,7 +34,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await readFile(mdPath, "utf8");
+    const mdContent = await fsp.readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "This is a summary",
@@ -66,7 +66,7 @@ describe("simple project", () => {
     );
 
     const mdPath = path.join(cwd, ".changeset", `${changesetID}.md`);
-    const mdContent = await readFile(mdPath, "utf8");
+    const mdContent = await fsp.readFile(mdPath, "utf8");
 
     expect(parse(mdContent)).toEqual({
       summary: "",

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,5 +1,5 @@
 import { Changeset } from "@changesets/types";
-import fsp from "fs/promises";
+import fs from "node:fs/promises";
 import humanId from "human-id";
 import path from "path";
 import prettier from "prettier";
@@ -43,8 +43,8 @@ ${releases.map((release) => `"${release.name}": ${release.type}`).join("\n")}
 ${summary}
   `;
 
-  await fsp.mkdir(path.dirname(newChangesetPath), { recursive: true });
-  await fsp.writeFile(
+  await fs.mkdir(path.dirname(newChangesetPath), { recursive: true });
+  await fs.writeFile(
     newChangesetPath,
     // Prettier v3 returns a promise
     await prettierInstance.format(changesetContents, {

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,5 +1,5 @@
 import { Changeset } from "@changesets/types";
-import fs from "fs/promises";
+import fsp from "fs/promises";
 import humanId from "human-id";
 import path from "path";
 import prettier from "prettier";
@@ -43,8 +43,8 @@ ${releases.map((release) => `"${release.name}": ${release.type}`).join("\n")}
 ${summary}
   `;
 
-  await fs.mkdir(path.dirname(newChangesetPath), { recursive: true });
-  await fs.writeFile(
+  await fsp.mkdir(path.dirname(newChangesetPath), { recursive: true });
+  await fsp.writeFile(
     newChangesetPath,
     // Prettier v3 returns a promise
     await prettierInstance.format(changesetContents, {

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -1,5 +1,5 @@
 import { Changeset } from "@changesets/types";
-import fs from "fs-extra";
+import fs from "fs/promises";
 import humanId from "human-id";
 import path from "path";
 import prettier from "prettier";
@@ -43,7 +43,8 @@ ${releases.map((release) => `"${release.name}": ${release.type}`).join("\n")}
 ${summary}
   `;
 
-  await fs.outputFile(
+  await fs.mkdir(path.dirname(newChangesetPath), { recursive: true });
+  await fs.writeFile(
     newChangesetPath,
     // Prettier v3 returns a promise
     await prettierInstance.format(changesetContents, {

--- a/scripts/test-utils/package.json
+++ b/scripts/test-utils/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@changesets/logger": "^0.1.1",
     "fixturez": "^1.1.0",
-    "fs-extra": "^7.0.1",
     "spawndamnit": "^2.0.0"
   }
 }

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -147,8 +147,8 @@ export async function outputFile(
 
 // `fs.exists` is deprecated, and Node recommends this for asynchronous existence checks.
 export async function pathExists(p: string) {
-  return fsp
-    .access(p)
-    .then(() => true)
-    .catch(() => false);
+  return fsp.access(p).then(
+    () => true,
+    () => false
+  );
 }

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -1,7 +1,7 @@
 import fixturez from "fixturez";
 import spawn from "spawndamnit";
-import { ObjectEncodingOptions } from "fs";
-import fs from "fs/promises";
+import fs from "fs";
+import fsp from "fs/promises";
 import path from "path";
 
 /**
@@ -97,8 +97,8 @@ export async function testdir(dir: Fixture) {
   await Promise.all(
     Object.keys(dir).map(async (filename) => {
       const fullPath = path.join(temp, filename);
-      await fs.mkdir(path.dirname(fullPath), { recursive: true });
-      await fs.writeFile(fullPath, dir[filename]);
+      await fsp.mkdir(path.dirname(fullPath), { recursive: true });
+      await fsp.writeFile(fullPath, dir[filename]);
     })
   );
   return temp;
@@ -139,15 +139,15 @@ export async function gitdir(dir: Fixture) {
 export async function outputFile(
   filePath: string,
   content: string,
-  encoding = "utf8" as ObjectEncodingOptions
+  encoding = "utf8" as fs.ObjectEncodingOptions
 ) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, content, encoding);
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, content, encoding);
 }
 
 // `fs.exists` is deprecated, and Node recommends this for asynchronous existence checks.
 export async function pathExists(p: string) {
-  return fs
+  return fsp
     .access(p)
     .then(() => true)
     .catch(() => false);

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -1,5 +1,6 @@
 import fixturez from "fixturez";
 import spawn from "spawndamnit";
+import { ObjectEncodingOptions } from "fs";
 import fs from "fs/promises";
 import path from "path";
 
@@ -133,4 +134,21 @@ export async function gitdir(dir: Fixture) {
   });
 
   return cwd;
+}
+
+export async function outputFile(
+  filePath: string,
+  content: string,
+  encoding = "utf8" as ObjectEncodingOptions
+) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, encoding);
+}
+
+// `fs.exists` is deprecated, and Node recommends this for asynchronous existence checks.
+export async function pathExists(p: string) {
+  return fs
+    .access(p)
+    .then(() => true)
+    .catch(() => false);
 }

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -1,7 +1,7 @@
 import fixturez from "fixturez";
 import spawn from "spawndamnit";
+import fs from "fs/promises";
 import path from "path";
-import fs from "fs-extra";
 
 /**
  * Reason for eslint disable import/no-commonjs
@@ -96,7 +96,8 @@ export async function testdir(dir: Fixture) {
   await Promise.all(
     Object.keys(dir).map(async (filename) => {
       const fullPath = path.join(temp, filename);
-      await fs.outputFile(fullPath, dir[filename]);
+      await fs.mkdir(path.dirname(fullPath), { recursive: true });
+      await fs.writeFile(fullPath, dir[filename]);
     })
   );
   return temp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,11 +2185,6 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-colors@^3.2.1:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
-  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
-
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -3100,13 +3095,6 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
-
-enquirer@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.2.tgz#1c30284907cadff5ed2404bd8396036dd3da070e"
-  integrity sha512-PLhTMPUXlnaIv9D3Cq3/Zr1xb7soeDDgunobyCmYLUG19n24dvC8i+ZZgm2DekGpDnx7JvFSHV7lxfM58PMtbA==
-  dependencies:
-    ansi-colors "^3.2.1"
 
 enquirer@^2.3.6:
   version "2.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,13 +1909,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/fs-extra@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
-  integrity sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.5.tgz#66103d2eddc543d44a04394abb7be52506d7f290"
   integrity sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==
 
+"@types/node@^22.7.4":
+  version "22.7.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.4.tgz#e35d6f48dca3255ce44256ddc05dee1c23353fcc"
+  integrity sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==
+  dependencies:
+    undici-types "~6.19.2"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -7003,6 +7010,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
Part of the v3 cleanup: https://github.com/changesets/changesets/discussions/1473. `fs-extra` is effectively unnecessary in modern Node versions, and can be replaced with the native functionality.