### PR TITLE
chore(deps): replace resolve-from package with native Node API

### DIFF
--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -30,7 +30,6 @@
     "lodash.startcase": "^4.4.0",
     "outdent": "^0.5.0",
     "prettier": "^2.7.1",
-    "resolve-from": "^5.0.0",
     "semver": "^7.5.3"
   },
   "devDependencies": {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -13,13 +13,12 @@ import detectIndent from "detect-indent";
 import fs from "fs-extra";
 import path from "path";
 import prettier from "prettier";
-import resolveFrom from "resolve-from";
 import getChangelogEntry from "./get-changelog-entry";
 import versionPackage from "./version-package";
 
 function getPrettierInstance(cwd: string): typeof prettier {
   try {
-    return require(require.resolve("prettier", { paths: [cwd] }));
+    return require(require.resolve("prettier", { paths: [path.resolve(cwd)] }));
   } catch (err) {
     if (!err || (err as any).code !== "MODULE_NOT_FOUND") {
       throw err;
@@ -207,8 +206,8 @@ async function getNewChangelogEntry(
 
   const changelogOpts = config.changelog[1];
   let changesetPath = path.join(cwd, ".changeset");
-  let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
-
+  let changelogPath = require.resolve(config.changelog[0], { paths: [path.resolve(changesetPath)] });
+  
   let possibleChangelogFunc = require(changelogPath);
   if (possibleChangelogFunc.default) {
     possibleChangelogFunc = possibleChangelogFunc.default;

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -206,8 +206,10 @@ async function getNewChangelogEntry(
 
   const changelogOpts = config.changelog[1];
   let changesetPath = path.join(cwd, ".changeset");
-  let changelogPath = require.resolve(config.changelog[0], { paths: [path.resolve(changesetPath)] });
-  
+  let changelogPath = require.resolve(config.changelog[0], {
+    paths: [path.resolve(changesetPath)],
+  });
+
   let possibleChangelogFunc = require(changelogPath);
   if (possibleChangelogFunc.default) {
     possibleChangelogFunc = possibleChangelogFunc.default;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -90,7 +90,6 @@
     "p-limit": "^2.2.0",
     "package-manager-detector": "^0.2.0",
     "picocolors": "^1.1.0",
-    "resolve-from": "^5.0.0",
     "semver": "^7.5.3",
     "spawndamnit": "^2.0.0",
     "term-size": "^2.1.0"

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -1,6 +1,5 @@
 import { CommitFunctions } from "@changesets/types";
 import path from "path";
-import resolveFrom from "resolve-from";
 
 export function getCommitFunctions(
   commit: false | readonly [string, any],
@@ -12,7 +11,7 @@ export function getCommitFunctions(
   }
   let commitOpts: any = commit[1];
   let changesetPath = path.join(cwd, ".changeset");
-  let commitPath = resolveFrom(changesetPath, commit[0]);
+  let commitPath = require.resolve(commit[0], { paths: [path.resolve(changesetPath)] });
 
   let possibleCommitFunc = require(commitPath);
   if (possibleCommitFunc.default) {

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -11,7 +11,9 @@ export function getCommitFunctions(
   }
   let commitOpts: any = commit[1];
   let changesetPath = path.join(cwd, ".changeset");
-  let commitPath = require.resolve(commit[0], { paths: [path.resolve(changesetPath)] });
+  let commitPath = require.resolve(commit[0], {
+    paths: [path.resolve(changesetPath)],
+  });
 
   let possibleCommitFunc = require(commitPath);
   if (possibleCommitFunc.default) {


### PR DESCRIPTION
## Overview

This pull request replaces `resolve-from` with native Node implementation of `require.resolve`.

The main difference is only the error message as `resolve-from` provides friendlier message compared to native.

> [!NOTE]
> `resolve-from` itself doesn't require any dependencies, maybe we shouldn't remove it?