### PR TITLE
Run CI on node 18, 20, and 22

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -1,14 +1,18 @@
 name: Setup CI
 
+inputs:
+  node-version:
+    description: "Node.js version"
+    required: false
+    default: 20
+
 runs:
   using: composite
   steps:
-    - name: Setup Node.js 20.x
+    - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: ${{ inputs.node-version }}
         cache: yarn
 
     - name: Install dependencies
-      shell: bash
-      run: yarn install --frozen-lockfile

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -16,3 +16,5 @@ runs:
         cache: yarn
 
     - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,27 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - next
 
 permissions:
   contents: read
 
 jobs:
   test:
-    name: Test
+    name: "Test: node-${{ matrix.node_version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        node_version: [18, 20, 22]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci-setup
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - name: Check Git version
         run: git --version
@@ -24,10 +32,17 @@ jobs:
         run: git config --global user.email "you@example.com" && git config --global user.name "Your Name"
 
       - name: Jest tests
+        if: matrix.node_version != 20
+        run: yarn jest --ci --color --runInBand --reporters=default --reporters=jest-junit
+
+      # Run coverage only once on node 20 to avoid duplicate codecov uploads
+      - name: Jest tests with coverage
+        if: matrix.node_version == 20
         run: yarn jest --ci --color --runInBand --coverage --reporters=default --reporters=jest-junit
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        if: matrix.node_version == 20
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    name: "Test: node-${{ matrix.node_version }}"
+    name: "Test using Node ${{ matrix.node_version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       # Run coverage only once on node 20 to avoid duplicate codecov uploads
       - name: Jest tests with coverage
         if: matrix.node_version == 20
-        run: yarn jest --ci --color --runInBand --coverage --reporters=default --reporters=jest-junit
+        run: yarn jest --ci --color --runInBand --reporters=default --reporters=jest-junit --coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
This is the same thing as https://github.com/changesets/changesets/pull/1465 but for the `next` branch. Maybe we should do this only for the `next` branch for now.