### PR TITLE
Setup initial tests for package manager publishing

### DIFF
--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,0 +1,89 @@
+import { initPackageManager, testdir } from "@changesets/test-utils";
+import { getPublishCommand, PublishOptions } from "../npm-utils";
+import { TwoFactorState } from "../../../utils/types";
+
+function callGetPublishCommand(
+  cwd: string,
+  publishOpts?: Partial<PublishOptions>,
+  twoFactorState?: TwoFactorState
+) {
+  return getPublishCommand(
+    {
+      cwd,
+      tag: "latest",
+      access: "public",
+      publishDir: ".",
+      ...publishOpts,
+    },
+    twoFactorState ?? { isRequired: Promise.resolve(false), token: null }
+  );
+}
+
+describe("npm utils", () => {
+  describe("getPublishCommand", () => {
+    it("returns npm command by default", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({ private: true }),
+      });
+      const { cmd, args } = await callGetPublishCommand(cwd);
+      expect(cmd).toBe("npm");
+      expect(args).toEqual([
+        "publish",
+        ".",
+        "--json",
+        "--access",
+        "public",
+        "--tag",
+        "latest",
+      ]);
+    });
+
+    it("returns npm command with correct tag, access, publishDir based on option", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+      });
+      const { cmd, args } = await callGetPublishCommand(cwd, {
+        tag: "next",
+        access: "restricted",
+        publishDir: "./packages/pkg-a",
+      });
+      expect(cmd).toBe("npm");
+      expect(args).toEqual([
+        "publish",
+        "./packages/pkg-a",
+        "--json",
+        "--access",
+        "restricted",
+        "--tag",
+        "next",
+      ]);
+    });
+
+    it("returns pnpm command in pnpm project", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({ private: true }),
+      });
+      await initPackageManager(cwd, "pnpm");
+      const { cmd, args } = await callGetPublishCommand(cwd);
+      expect(cmd).toBe("pnpm");
+      expect(args).toEqual([
+        [
+          "publish",
+          "--json",
+          "--access",
+          "public",
+          "--tag",
+          "latest",
+          "--no-git-checks",
+        ],
+      ]);
+    });
+  });
+});

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -108,25 +108,12 @@ export const tempdir = f.temp;
 
 export async function gitdir(dir: Fixture) {
   const cwd = await testdir(dir);
-  await spawn("git", ["init"], { cwd });
-  // so that this works regardless of what the default branch of git init is and for git versions that don't support --initial-branch(like our CI)
-  {
-    const { stdout } = await spawn(
-      "git",
-      ["rev-parse", "--abbrev-ref", "HEAD"],
-      { cwd }
-    );
-    if (stdout.toString("utf8").trim() !== "main") {
-      await spawn("git", ["checkout", "-b", "main"], { cwd });
-    }
-  }
+  await spawn("git", ["init", "--initial-branch", "main"], { cwd });
   await spawn("git", ["config", "user.email", "x@y.z"], { cwd });
   await spawn("git", ["config", "user.name", "xyz"], { cwd });
   await spawn("git", ["config", "commit.gpgSign", "false"], { cwd });
   await spawn("git", ["config", "tag.gpgSign", "false"], { cwd });
-  await spawn("git", ["config", "tag.forceSignAnnotated", "false"], {
-    cwd,
-  });
+  await spawn("git", ["config", "tag.forceSignAnnotated", "false"], { cwd });
 
   await spawn("git", ["add", "."], { cwd });
   await spawn("git", ["commit", "-m", "initial commit", "--allow-empty"], {
@@ -151,4 +138,23 @@ export async function pathExists(p: string) {
     () => true,
     () => false
   );
+}
+
+export async function initPackageManager(
+  cwd: string,
+  packageManager: "npm" | "yarn" | "pnpm"
+) {
+  switch (packageManager) {
+    case "npm":
+      await spawn("npm", ["install"], { cwd });
+      break;
+    case "pnpm":
+      await spawn("pnpm", ["install"], { cwd });
+      break;
+    case "yarn":
+      await spawn("yarn", [], { cwd });
+      break;
+    default:
+      throw new Error(`Unsupported package manager ${packageManager}`);
+  }
 }


### PR DESCRIPTION
Basing on https://github.com/changesets/changesets/pull/674 to setup some test infra for package manager publishing. I extracted a part of `internalPublish` where it builds the command and args so we can test it directly.

Still working on this halfway. I'm not sure if this is the testing setup you have in mind, but I notice many of the tests are unit tests with mocks rather than e2e-style tests, so trying to replicate that.

Need to probably mock some commands where it checks for certain pnpm version (or any version like in #674) so it doesn't require users to install the package manager for testing.