### PR TITLE
Include next steps when presented with "Which packages should have a [major|minor] bump" options

### DIFF
--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -122,7 +122,11 @@ export default async function createChangeset(
 
     let pkgsThatShouldBeMajorBumped = (
       await cli.askCheckboxPlus(
-        bold(`Which packages should have a ${red("major")} bump?`),
+        bold(
+          `Which packages should have a ${red(
+            "major"
+          )} bump? If none, please leave empty (it will ask for minor changes afterwards).`
+        ),
         [
           {
             name: "all packages",
@@ -168,7 +172,11 @@ export default async function createChangeset(
     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
       let pkgsThatShouldBeMinorBumped = (
         await cli.askCheckboxPlus(
-          bold(`Which packages should have a ${green("minor")} bump?`),
+          bold(
+            `Which packages should have a ${green(
+              "minor"
+            )} bump? If none, please leave empty (it will ask for patch changes afterwards).`
+          ),
           [
             {
               name: "all packages",


### PR DESCRIPTION
Hello everyone 👋

I was using this package while working on a bugfix for [Qwik](https://github.com/QwikDev/qwik) and I wasn't aware that I could've left unselected options when I got asked `Which packages should have a major bump?` by the `changesets` CLI. For that reason, I chose the first (and only) package option and then I noticed it wasn't really what I wanted, so I had to manually change generated file by myself.

To avoid confusion, I added a notice that users do not have to select any package for a fix that they created that is not in major or minor fix version (and that they will later have an option to select minor or patch versions, respectively, later on).

I hope the wording is OK and that it will be helpful for everyone using the `changesets` CLI.