### PR TITLE
Update changelog badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <br/>
 
-[![npm package](https://img.shields.io/npm/v/@changesets/cli.svg)](https://npmjs.com/package/@changesets/cli)
+[![npm package](https://img.shields.io/npm/v/@changesets/cli?label=%40changesets%2Fcli)](https://npmjs.com/package/@changesets/cli)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./packages/cli/CHANGELOG.md)
 
 The `changesets` workflow is designed to help when people are making changes, all the way through to publishing. It lets contributors declare how their changes should be released, then we automate updating package versions, and changelogs, and publishing new versions of packages based on the provided information.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 </p>
 <br/>
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/cli)
+[![npm package](https://img.shields.io/npm/v/@changesets/cli.svg)](https://npmjs.com/package/@changesets/cli)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./packages/cli/CHANGELOG.md)
 
 The `changesets` workflow is designed to help when people are making changes, all the way through to publishing. It lets contributors declare how their changes should be released, then we automate updating package versions, and changelogs, and publishing new versions of packages based on the provided information.
 

--- a/packages/apply-release-plan/README.md
+++ b/packages/apply-release-plan/README.md
@@ -1,6 +1,6 @@
 # Apply Release Plan
 
-[![npm package](https://img.shields.io/npm/v/@changesets/apply-release-plan.svg)](https://npmjs.com/package/@changesets/apply-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/apply-release-plan)](https://npmjs.com/package/@changesets/apply-release-plan)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 This takes a `releasePlan` object for changesets and applies the expected changes from that

--- a/packages/apply-release-plan/README.md
+++ b/packages/apply-release-plan/README.md
@@ -1,6 +1,7 @@
 # Apply Release Plan
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/apply-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/apply-release-plan.svg)](https://npmjs.com/package/@changesets/apply-release-plan)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 This takes a `releasePlan` object for changesets and applies the expected changes from that
 release. This includes updating package versions, and updating changelogs.

--- a/packages/assemble-release-plan/README.md
+++ b/packages/assemble-release-plan/README.md
@@ -1,6 +1,6 @@
 # Assemble Release Plan
 
-[![npm package](https://img.shields.io/npm/v/@changesets/assemble-release-plan.svg)](https://npmjs.com/package/@changesets/assemble-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/assemble-release-plan)](https://npmjs.com/package/@changesets/assemble-release-plan)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Assemble a release plan for changesets from data about a repository.

--- a/packages/assemble-release-plan/README.md
+++ b/packages/assemble-release-plan/README.md
@@ -1,6 +1,7 @@
 # Assemble Release Plan
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/assemble-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/assemble-release-plan.svg)](https://npmjs.com/package/@changesets/assemble-release-plan)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Assemble a release plan for changesets from data about a repository.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 ## @changesets/cli 🦋
 
-[![npm package](https://img.shields.io/npm/v/@changesets/cli.svg)](https://npmjs.com/package/@changesets/cli)
+[![npm package](https://img.shields.io/npm/v/@changesets/cli)](https://npmjs.com/package/@changesets/cli)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 The primary implementation of [changesets](https://github.com/Noviny/changesets). Helps you manage the versioning

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,7 @@
 ## @changesets/cli 🦋
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/cli)
+[![npm package](https://img.shields.io/npm/v/@changesets/cli.svg)](https://npmjs.com/package/@changesets/cli)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 The primary implementation of [changesets](https://github.com/Noviny/changesets). Helps you manage the versioning
 and changelog entries for your packages, with a focus on versioning within a mono-repository (though we support

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 > Utilities for reading and parsing Changeset's config
 
-[![npm package](https://img.shields.io/npm/v/@changesets/config.svg)](https://npmjs.com/package/@changesets/config)
+[![npm package](https://img.shields.io/npm/v/@changesets/config)](https://npmjs.com/package/@changesets/config)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 ```tsx

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,8 @@
 
 > Utilities for reading and parsing Changeset's config
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/config)
+[![npm package](https://img.shields.io/npm/v/@changesets/config.svg)](https://npmjs.com/package/@changesets/config)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 ```tsx
 import { parse, read, ValidationError } from "@changesets/config";

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,5 +1,6 @@
 # @changesets/errors
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/errors)
+[![npm package](https://img.shields.io/npm/v/@changesets/errors.svg)](https://npmjs.com/package/@changesets/errors)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Error classes for Changesets.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,6 +1,6 @@
 # @changesets/errors
 
-[![npm package](https://img.shields.io/npm/v/@changesets/errors.svg)](https://npmjs.com/package/@changesets/errors)
+[![npm package](https://img.shields.io/npm/v/@changesets/errors)](https://npmjs.com/package/@changesets/errors)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Error classes for Changesets.

--- a/packages/get-dependents-graph/README.md
+++ b/packages/get-dependents-graph/README.md
@@ -1,6 +1,7 @@
 # Get Dependents Graph
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/get-dependents-graph)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-dependents-graph.svg)](https://npmjs.com/package/@changesets/get-dependents-graph)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Small helper utility extracted from bolt to get a graph of relationships between packages.
 

--- a/packages/get-dependents-graph/README.md
+++ b/packages/get-dependents-graph/README.md
@@ -1,6 +1,6 @@
 # Get Dependents Graph
 
-[![npm package](https://img.shields.io/npm/v/@changesets/get-dependents-graph.svg)](https://npmjs.com/package/@changesets/get-dependents-graph)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-dependents-graph)](https://npmjs.com/package/@changesets/get-dependents-graph)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Small helper utility extracted from bolt to get a graph of relationships between packages.

--- a/packages/get-github-info/README.md
+++ b/packages/get-github-info/README.md
@@ -1,6 +1,7 @@
 # @changesets/get-github-info
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/get-github-info)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-github-info.svg)](https://npmjs.com/package/@changesets/get-github-info)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 > Get the GitHub username and PR number from a commit. Intended for use with changesets.
 

--- a/packages/get-github-info/README.md
+++ b/packages/get-github-info/README.md
@@ -1,6 +1,6 @@
 # @changesets/get-github-info
 
-[![npm package](https://img.shields.io/npm/v/@changesets/get-github-info.svg)](https://npmjs.com/package/@changesets/get-github-info)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-github-info)](https://npmjs.com/package/@changesets/get-github-info)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 > Get the GitHub username and PR number from a commit. Intended for use with changesets.

--- a/packages/get-release-plan/README.md
+++ b/packages/get-release-plan/README.md
@@ -1,6 +1,7 @@
 # @changesets/get-release-plan
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/get-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-release-plan.svg)](https://npmjs.com/package/@changesets/get-release-plan)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A function that reads information about the current repository
 

--- a/packages/get-release-plan/README.md
+++ b/packages/get-release-plan/README.md
@@ -1,6 +1,6 @@
 # @changesets/get-release-plan
 
-[![npm package](https://img.shields.io/npm/v/@changesets/get-release-plan.svg)](https://npmjs.com/package/@changesets/get-release-plan)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-release-plan)](https://npmjs.com/package/@changesets/get-release-plan)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A function that reads information about the current repository

--- a/packages/get-version-range-type/README.md
+++ b/packages/get-version-range-type/README.md
@@ -1,6 +1,7 @@
 # @changesets/get-version-range-type
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/get-version-range-type)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-version-range-type.svg)](https://npmjs.com/package/@changesets/get-version-range-type)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Simple function that takes in a string which is a version range (ie `^1.0.0`, `~3.5.1`, `2.0.0`)
 and returns the range definition.

--- a/packages/get-version-range-type/README.md
+++ b/packages/get-version-range-type/README.md
@@ -1,6 +1,6 @@
 # @changesets/get-version-range-type
 
-[![npm package](https://img.shields.io/npm/v/@changesets/get-version-range-type.svg)](https://npmjs.com/package/@changesets/get-version-range-type)
+[![npm package](https://img.shields.io/npm/v/@changesets/get-version-range-type)](https://npmjs.com/package/@changesets/get-version-range-type)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Simple function that takes in a string which is a version range (ie `^1.0.0`, `~3.5.1`, `2.0.0`)

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -1,6 +1,6 @@
 # @changesets/git
 
-[![npm package](https://img.shields.io/npm/v/@changesets/git.svg)](https://npmjs.com/package/@changesets/git)
+[![npm package](https://img.shields.io/npm/v/@changesets/git)](https://npmjs.com/package/@changesets/git)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A collection of helper functions used internally in changesets to make git operations easier.

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -1,6 +1,7 @@
 # @changesets/git
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/git)
+[![npm package](https://img.shields.io/npm/v/@changesets/git.svg)](https://npmjs.com/package/@changesets/git)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A collection of helper functions used internally in changesets to make git operations easier.
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,6 +1,6 @@
 ## @changesets/logger
 
-[![npm package](https://img.shields.io/npm/v/@changesets/logger.svg)](https://npmjs.com/package/@changesets/logger)
+[![npm package](https://img.shields.io/npm/v/@changesets/logger)](https://npmjs.com/package/@changesets/logger)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 ### Usage

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,6 +1,7 @@
 ## @changesets/logger
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/logger)
+[![npm package](https://img.shields.io/npm/v/@changesets/logger.svg)](https://npmjs.com/package/@changesets/logger)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 ### Usage
 

--- a/packages/parse/README.md
+++ b/packages/parse/README.md
@@ -1,6 +1,6 @@
 # @changesets/parse
 
-[![npm package](https://img.shields.io/npm/v/@changesets/parse.svg)](https://npmjs.com/package/@changesets/parse)
+[![npm package](https://img.shields.io/npm/v/@changesets/parse)](https://npmjs.com/package/@changesets/parse)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Parses a changeset from its written format to a data object.

--- a/packages/parse/README.md
+++ b/packages/parse/README.md
@@ -1,6 +1,7 @@
 # @changesets/parse
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/parse)
+[![npm package](https://img.shields.io/npm/v/@changesets/parse.svg)](https://npmjs.com/package/@changesets/parse)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Parses a changeset from its written format to a data object.
 

--- a/packages/pre/README.md
+++ b/packages/pre/README.md
@@ -1,6 +1,7 @@
 # @changesets/pre
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/pre)
+[![npm package](https://img.shields.io/npm/v/@changesets/pre.svg)](https://npmjs.com/package/@changesets/pre)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Enter and exit pre mode in a Changesets repo.
 

--- a/packages/pre/README.md
+++ b/packages/pre/README.md
@@ -1,6 +1,6 @@
 # @changesets/pre
 
-[![npm package](https://img.shields.io/npm/v/@changesets/pre.svg)](https://npmjs.com/package/@changesets/pre)
+[![npm package](https://img.shields.io/npm/v/@changesets/pre)](https://npmjs.com/package/@changesets/pre)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Enter and exit pre mode in a Changesets repo.

--- a/packages/read/README.md
+++ b/packages/read/README.md
@@ -1,6 +1,7 @@
 # @changesets/read
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/read)
+[![npm package](https://img.shields.io/npm/v/@changesets/read.svg)](https://npmjs.com/package/@changesets/read)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Read in all changesets from a repository.
 

--- a/packages/read/README.md
+++ b/packages/read/README.md
@@ -1,6 +1,6 @@
 # @changesets/read
 
-[![npm package](https://img.shields.io/npm/v/@changesets/read.svg)](https://npmjs.com/package/@changesets/read)
+[![npm package](https://img.shields.io/npm/v/@changesets/read)](https://npmjs.com/package/@changesets/read)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 Read in all changesets from a repository.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,6 @@
 # @changesets/types
 
-[![npm package](https://img.shields.io/npm/v/@changesets/types.svg)](https://npmjs.com/package/@changesets/types)
+[![npm package](https://img.shields.io/npm/v/@changesets/types)](https://npmjs.com/package/@changesets/types)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A package of types for use in changesets, or projects wishing to extend them.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,7 @@
 # @changesets/types
 
-[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@changesets/types)
+[![npm package](https://img.shields.io/npm/v/@changesets/types.svg)](https://npmjs.com/package/@changesets/types)
+[![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
 A package of types for use in changesets, or projects wishing to extend them.
 


### PR DESCRIPTION
close https://github.com/changesets/changesets/pull/1309

changelogs.xyz doesn't seem to properly show the changelog anymore, so I updated the badge and link it to the `CHANGELOG.md` file directly.

I also added an npm badge to quickly go to the npm page. Let me know if you don't want that, I'm fine either ways 😄 