### PR TITLE
Allow @changesets/cli/changelog to be resolved even when homed in global node_modules

### DIFF
--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -207,7 +207,18 @@ async function getNewChangelogEntry(
 
   const changelogOpts = config.changelog[1];
   let changesetPath = path.join(cwd, ".changeset");
-  let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
+  let changelogPath;
+  try {
+    changelogPath = resolveFrom(changesetPath, config.changelog[0]);
+  } catch (error) {
+    const { execSync } = require("child_process");
+    const globalNodeModules = execSync("npm root -g", {
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    changelogPath = path.join(globalNodeModules, config.changelog[0]);
+  }
 
   let possibleChangelogFunc = require(changelogPath);
   if (possibleChangelogFunc.default) {


### PR DESCRIPTION
As described in the thread linked below, there is an edge case when using a `npm install -g` version of @changesets/cli because the bespoke resolution algorithm to resolve `@changesets/cli/changelog` breaks - it assumes the module must only exist relative to the changeset package root rather than the global node_modules.

This is impactful because changesets are among the things you want to calculate in a pipeline step without doing a full npm install (e.g. to reason about identities for docker images and what not). The difference in some cases could be minutes of performance.

Fixes https://github.com/changesets/changesets/issues/566