### PR TITLE
fix: prevent crash when trying to version the root of the monorepo

### DIFF
--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -53,6 +53,11 @@ export default async function add(
       releases: [],
       summary: ``,
     };
+  } else if (versionablePackages.length === 0) {
+    warn("This workspace does not contain any packages that can be versioned");
+    warn(`If you intend to version the root package, add ${pc.green('"."')} to the list of workspaces`);
+    warn(`See ${pc.blue('https://github.com/changesets/changesets/issues/1137')} for more details`);
+    newChangeset = { confirmed: false };
   } else {
     const changedPackagesNames = (
       await getVersionableChangedPackages(config, {


### PR DESCRIPTION
Hey! Trying to address the bug I encountered in a monorepo where only the root package is published to npm

Before:

```
🦋  error TypeError: Cannot read properties of undefined (reading 'packageJson')
🦋  error     at createChangeset (.../dist/changesets-cli.cjs.js:417:75)
🦋  error     at add (.../dist/changesets-cli.cjs.js:514:26)
🦋  error     at async run (.../dist/changesets-cli.cjs.js:1347:5)
```

After:

```
🦋  warn This workspace does not contain any packages that can be versioned
🦋  warn If you intend to version the root project, add "." to the list of workspaces
🦋  warn See https://github.com/changesets/changesets/issues/1137 for more details
```

Related: #1137