### PR TITLE
Add an error message for when a changeset references a nonexistent package

### DIFF
--- a/.changeset/sharp-impalas-jog.md
+++ b/.changeset/sharp-impalas-jog.md
@@ -1,0 +1,5 @@
+---
+"@changesets/assemble-release-plan": patch
+---
+
+Add error-reporting for when a changeset references a non-existent package

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -560,6 +560,26 @@ Mixed changesets that contain both ignored and not ignored packages are not allo
     expect(releases[1].newVersion).toEqual("1.0.0");
   });
 
+  it("should throw an error when a changeset contains a package that is not in the workspace", () => {
+    setup.addChangeset({
+      id: "big-cats-delight",
+      releases: [{ name: "pkg-a", type: "major" }],
+    });
+    setup.addChangeset({
+      id: "small-dogs-sad",
+      releases: [{ name: "pkg-z", type: "minor" }],
+    });
+
+    expect(() =>
+      assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        defaultConfig,
+        undefined
+      )
+    ).toThrow("Found changeset small-dogs-sad for package pkg-z which is not in the workspace");
+  });
+
   describe("fixed packages", () => {
     it("should assemble release plan for fixed packages", () => {
       setup.addChangeset({

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -577,7 +577,9 @@ Mixed changesets that contain both ignored and not ignored packages are not allo
         defaultConfig,
         undefined
       )
-    ).toThrow("Found changeset small-dogs-sad for package pkg-z which is not in the workspace");
+    ).toThrow(
+      "Found changeset small-dogs-sad for package pkg-z which is not in the workspace"
+    );
   });
 
   describe("fixed packages", () => {

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -279,7 +279,9 @@ function getRelevantChangesets(
       const packageByName = packagesByName.get(release.name);
 
       if (!packageByName) {
-        throw new Error(`Changeset ${changeset.id} references non-existent package ${release.name}`);
+        throw new Error(
+          `Changeset ${changeset.id} references non-existent package ${release.name}`
+        );
       }
 
       if (

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -280,7 +280,7 @@ function getRelevantChangesets(
 
       if (!packageByName) {
         throw new Error(
-          `Changeset ${changeset.id} references non-existent package ${release.name}`
+          `Found changeset ${changeset.id} for package ${release.name} which is not in the workspace`
         );
       }
 

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -276,8 +276,14 @@ function getRelevantChangesets(
     const skippedPackages = [];
     const notSkippedPackages = [];
     for (const release of changeset.releases) {
+      const packageByName = packagesByName.get(release.name);
+
+      if (!packageByName) {
+        throw new Error(`Changeset ${changeset.id} references non-existent package ${release.name}`);
+      }
+
       if (
-        shouldSkipPackage(packagesByName.get(release.name)!, {
+        shouldSkipPackage(packageByName, {
           ignore: config.ignore,
           allowPrivatePackages: config.privatePackages.version,
         })


### PR DESCRIPTION
This can occur when a package with pending changesets is deleted.

I added this error because we ran into this issue in my workplace, and we had to do `console.log` commands inside the Changeset project to figure out exactly what the problem was. This change should make it easier for anyone else who made the same mistake to get useful feedback explaining what the issue was.