### PR TITLE
fix(assemble-release-plan): errors caused by non-standard packages#835

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -322,8 +322,16 @@ function getHighestPreVersion(
 ): number {
   let highestPreVersion = 0;
   for (let pkg of packageGroup) {
+    let { version, name } = packagesByName.get(pkg)!.packageJson;
+
+    if (!version) {
+      throw new Error(
+        `Could not find version for package ${name} in the workspace`
+      );
+    }
+
     highestPreVersion = Math.max(
-      getPreVersion(packagesByName.get(pkg)!.packageJson.version),
+      getPreVersion(version),
       highestPreVersion
     );
   }
@@ -358,9 +366,15 @@ function getPreInfo(
   // preVersion is the map between package name and its next pre version number.
   let preVersions = new Map<string, number>();
   for (const [, pkg] of packagesByName) {
+    let { version, name } = pkg.packageJson;
+    if (!version) {
+      throw new Error(
+        `Could not find version for package ${name} in the workspace`
+      );
+    }
     preVersions.set(
       pkg.packageJson.name,
-      getPreVersion(pkg.packageJson.version)
+      getPreVersion(version)
     );
   }
   for (let fixedGroup of config.fixed) {


### PR DESCRIPTION
If some internal packages in the workspace lack version numbers, it will cause changesets to crash.

I strictly check the input and throw error messages to let users know where they can improve their code to avoid confusion.

BUG：https://github.com/changesets/changesets/issues/835