### PR TITLE
fix: Allow changesets to be read from a nested folder that is not the monorepo root

### DIFF
--- a/.changeset/eager-squids-feel.md
+++ b/.changeset/eager-squids-feel.md
@@ -1,0 +1,5 @@
+---
+"@changesets/read": patch
+---
+
+Allow changesets to be read from a nested folder that is not the monorepo root

--- a/packages/read/README.md
+++ b/packages/read/README.md
@@ -6,7 +6,7 @@
 Read in all changesets from a repository.
 
 ```js
-import read from "@changesets/read";
+import getChangesets from "@changesets/read";
 
 let changesets = await getChangesets(cwd);
 ```

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -26,6 +26,25 @@ Nice simple summary`,
       },
     ]);
   });
+  it("should read a changeset from a nested directory", async () => {
+    const nestedFolderPath = "some/nested/folder/";
+    const repositoryRoot = await testdir({
+      [`${nestedFolderPath}/.changeset/nested-folders-rock.md`]: `---
+"amazing-package": minor
+---
+
+Amazing summary`,
+    });
+    const cwd = path.resolve(repositoryRoot, nestedFolderPath);
+    const changesets = await read(cwd);
+    expect(changesets).toEqual([
+      {
+        releases: [{ name: "amazing-package", type: "minor" }],
+        summary: "Amazing summary",
+        id: "nested-folders-rock",
+      },
+    ]);
+  });
   it("should ignore a readme file", async () => {
     const cwd = await testdir({
       ".changeset/README.md": `Changesets are great for monorepos`,

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -14,7 +14,7 @@ async function filterChangesetsSinceRef(
     cwd: changesetBase,
     ref: sinceRef,
   });
-  const newHashes = newChangesets.map((c) => c.split("/")[1]);
+  const newHashes = newChangesets.map((c) => c.split("/").at(-1));
 
   return changesets.filter((dir) => newHashes.includes(dir));
 }


### PR DESCRIPTION
Fixes #1433 