### PR TITLE
Add no commit flag to CLI

### DIFF
--- a/.changeset/vast-onions-behave.md
+++ b/.changeset/vast-onions-behave.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Add no commit option to "add"/default command. Use `--no-commit` or `-n` when instantiated and the changeset will not be committed.

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -236,6 +236,38 @@ describe("Add command", () => {
     expect(git.commit).toHaveBeenCalledTimes(1);
   });
 
+  it("should not commit when the `no-commit` flag is passed in", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          "pkg-b": "1.0.0",
+        },
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+    });
+
+    mockUserResponses({ releases: { "pkg-a": "patch" } });
+    await addChangeset(
+      cwd,
+      { empty: false, noCommit: true },
+      {
+        ...defaultConfig,
+        commit: [path.resolve(__dirname, "..", "..", "..", "commit"), null],
+      }
+    );
+    expect(git.add).toHaveBeenCalledTimes(0);
+    expect(git.commit).toHaveBeenCalledTimes(0);
+  });
+
   it("should create empty changeset when empty flag is passed in", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -18,7 +18,7 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open }: { empty?: boolean; open?: boolean },
+  { empty, open, noCommit }: { empty?: boolean; open?: boolean; noCommit?: boolean },
   config: Config
 ): Promise<void> {
   const packages = await getPackages(cwd);
@@ -90,7 +90,7 @@ export default async function add(
       config.commit,
       cwd
     );
-    if (getAddMessage) {
+    if (getAddMessage && !noCommit) {
       await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
       await git.commit(await getAddMessage(newChangeset, commitOpts), cwd);
       log(pc.green(`${empty ? "Empty " : ""}Changeset added and committed`));

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -18,7 +18,11 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open, noCommit }: { empty?: boolean; open?: boolean; noCommit?: boolean },
+  {
+    empty,
+    open,
+    noCommit,
+  }: { empty?: boolean; open?: boolean; noCommit?: boolean },
   config: Config
 ): Promise<void> {
   const packages = await getPackages(cwd);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,15 @@ import { run } from "./run";
 const args = process.argv.slice(2);
 
 const parsed = mri(args, {
-  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot", "noCommit"],
+  boolean: [
+    "sinceMaster",
+    "verbose",
+    "empty",
+    "open",
+    "gitTag",
+    "snapshot",
+    "noCommit",
+  ],
   string: [
     "output",
     "otp",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ import { run } from "./run";
 const args = process.argv.slice(2);
 
 const parsed = mri(args, {
-  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot"],
+  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot", "noCommit"],
   string: [
     "output",
     "otp",
@@ -21,6 +21,7 @@ const parsed = mri(args, {
     // Short flags
     v: "verbose",
     o: "output",
+    n: "noCommit",
     // Support kebab-case flags
     "since-master": "sinceMaster",
     "git-tag": "gitTag",
@@ -52,7 +53,7 @@ if (parsed.help && args.length === 1) {
     $ changeset [command]
   Commands
     init
-    add [--empty] [--open]
+    add [--empty] [--open] [--no-commit]
     version [--ignore] [--snapshot <?name>] [--snapshot-prerelease-template <template>]
     publish [--tag <name>] [--otp <code>] [--no-git-tag]
     status [--since <branch>] [--verbose] [--output JSON_FILE.json]

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -64,9 +64,9 @@ export async function run(
   }
 
   if (input.length < 1) {
-    const { empty, open }: CliOptions = flags;
+    const { empty, noCommit, open }: CliOptions = flags;
     // @ts-ignore if this is undefined, we have already exited
-    await add(cwd, { empty, open }, config);
+    await add(cwd, { empty, noCommit, open }, config);
   } else if (input[0] !== "pre" && input.length > 1) {
     error(
       "Too many arguments passed to changesets - we only accept the command name as an argument"

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -12,6 +12,7 @@ export type CliOptions = {
   tag?: string;
   gitTag?: boolean;
   open?: boolean;
+  noCommit?: boolean;
 };
 
 export type CommandOptions = CliOptions & {


### PR DESCRIPTION
Often, we have staged changes and then make a changeset. This rolls up the staged changes with the changeset and is quite annoying.

Adding this `--no-commit`/`-n` flag will allow a user to make a changeset and not commit the newly created changeset.