### PR TITLE
fix(config): allow booleans as `prettier` values

### DIFF
--- a/.changeset/curly-ties-lead.md
+++ b/.changeset/curly-ties-lead.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Fix `prettier` config validation

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -380,6 +380,31 @@ let correctCases: Record<string, CorrectCase> = {
       ignore: ["pkg-a", "@pkg/a", "@pkg/b"],
     },
   },
+  prettierDefault: {
+    input: {},
+    output: {
+      ...defaults,
+      prettier: true,
+    },
+  },
+  prettierOn: {
+    input: {
+      prettier: true,
+    },
+    output: {
+      ...defaults,
+      prettier: true,
+    },
+  },
+  prettierOff: {
+    input: {
+      prettier: false,
+    },
+    output: {
+      ...defaults,
+      prettier: false,
+    },
+  },
   privatePackagesFalseDisablesAll: {
     input: {
       privatePackages: false,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -331,7 +331,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     }
   }
 
-  if (json.prettier !== undefined) {
+  if (["undefined", "boolean"].includes(typeof json.prettier) === false) {
     messages.push(
       `The \`prettier\` option is set as ${JSON.stringify(
         json.prettier,


### PR DESCRIPTION
This PR updates validation during config file parsing to allow passing `boolean` type values.

Fixes
- #1593 