### PR TITLE
Remove is-subdir dependency

### DIFF
--- a/.changeset/old-paths-bake.md
+++ b/.changeset/old-paths-bake.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": patch
+---
+
+Remove `is-subdir` dependency

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@changesets/errors": "^0.2.0",
     "@manypkg/get-packages": "^1.1.3",
-    "is-subdir": "^1.1.1",
     "micromatch": "^4.0.8",
     "spawndamnit": "^3.0.1"
   },

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "path";
 import { getPackages, type Package } from "@manypkg/get-packages";
 import { GitError } from "@changesets/errors";
-import isSubdir from "is-subdir";
 import micromatch from "micromatch";
 
 export async function add(pathToFile: string, cwd: string) {
@@ -271,8 +270,8 @@ export async function getChangedPackagesSinceRef({
 
         for (let i = changedFiles.length - 1; i >= 0; i--) {
           const file = changedFiles[i];
-
-          if (isSubdir(pkg.dir, file)) {
+          const isFileInPkg = !path.relative(pkg.dir, file).startsWith("..");
+          if (isFileInPkg) {
             changedFiles.splice(i, 1);
             const relativeFile = file.slice(pkg.dir.length + 1);
             changedPackageFiles.push(relativeFile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,13 +2201,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-better-path-resolve@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/better-path-resolve/-/better-path-resolve-1.0.0.tgz#13a35a1104cdd48a7b74bf8758f96a1ee613f99d"
-  integrity sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==
-  dependencies:
-    is-windows "^1.0.0"
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -3931,13 +3924,6 @@ is-string@^1.1.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-subdir@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-subdir/-/is-subdir-1.1.1.tgz#423e66902f9c5f159b9cc4826c820df083059538"
-  integrity sha512-VYpq0S7gPBVkkmfwkvGnx1EL9UVIo87NQyNcgMiNUdQCws3CJm5wj2nB+XPL7zigvjxhuZgp3bl2yBcKkSIj1w==
-  dependencies:
-    better-path-resolve "1.0.0"
-
 is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -3992,11 +3978,6 @@ is-whitespace-character@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
   integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
-
-is-windows@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
-  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
 is-word-character@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
Using normal `path` APIs should also yield the same result as it also normalizes the paths beforehand.

The dependency was added in https://github.com/changesets/changesets/pull/336 as the code before was using plain string `startsWith` instead of the `path` API.