### PR TITLE
Remove term-size dependency

### DIFF
--- a/.changeset/thick-emus-refuse.md
+++ b/.changeset/thick-emus-refuse.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Remove `term-size` dependency

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,8 +67,7 @@
     "package-manager-detector": "^0.2.0",
     "picocolors": "^1.1.0",
     "semver": "^7.5.3",
-    "spawndamnit": "^3.0.1",
-    "term-size": "^2.1.0"
+    "spawndamnit": "^3.0.1"
   },
   "devDependencies": {
     "@changesets/parse": "*",

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -1,5 +1,4 @@
 // @ts-ignore it's not worth writing a TS declaration file in this repo for a tiny module we use once like this
-import termSize from "term-size";
 import { error, prefix, success } from "@changesets/logger";
 import enuirer from "enquirer";
 import { edit } from "external-editor";
@@ -41,7 +40,7 @@ const serialId: () => number = (function () {
   return () => id++;
 })();
 
-const limit = Math.max(termSize().rows - 5, 10);
+const limit = Math.max(process.stdout.rows - 5, 10);
 
 let cancelFlow = () => {
   success("Cancelled... 👋 ");

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -1,4 +1,3 @@
-// @ts-ignore it's not worth writing a TS declaration file in this repo for a tiny module we use once like this
 import { error, prefix, success } from "@changesets/logger";
 import enuirer from "enquirer";
 import { edit } from "external-editor";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,11 +5453,6 @@ tempy@^0.2.1:
     temp-dir "^1.0.0"
     unique-string "^1.0.0"
 
-term-size@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.0.tgz#3aec444c07a7cf936e157c1dc224b590c3c7eef2"
-  integrity sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==
-
 terser@^5.16.8:
   version "5.18.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.18.2.tgz#ff3072a0faf21ffd38f99acc9a0ddf7b5f07b948"


### PR DESCRIPTION
The package is [deprecated](https://www.npmjs.com/package/term-size) but we can also replace with a simple `process.stdout.rows` check