### PR TITLE
Move outdent as dev dependency

### DIFF
--- a/.changeset/petite-buttons-shake.md
+++ b/.changeset/petite-buttons-shake.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+Move `outdent` as a dev dependency

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -18,12 +18,12 @@
     "@manypkg/get-packages": "^1.1.3",
     "detect-indent": "^6.0.0",
     "import-meta-resolve": "^4.1.0",
-    "outdent": "^0.8.0",
     "prettier": "^2.7.1",
     "semver": "^7.5.3"
   },
   "devDependencies": {
     "@changesets/test-utils": "*",
+    "outdent": "^0.8.0",
     "spawndamnit": "^3.0.1"
   },
   "engines": {


### PR DESCRIPTION
Looks like it's only used in tests