### PR TITLE
fix: git diff no-relative

### DIFF
--- a/.changeset/famous-loops-repair.md
+++ b/.changeset/famous-loops-repair.md
@@ -1,0 +1,7 @@
+---
+"@changesets/cli": patch
+---
+
+author: @Netail
+
+Correctly fetch new changesets with since if the git option diff.relative has been set to true

--- a/.changeset/khaki-peaches-refuse.md
+++ b/.changeset/khaki-peaches-refuse.md
@@ -1,0 +1,7 @@
+---
+"@changesets/git": patch
+---
+
+author: @Netail
+
+Make sure that git diff always returns the paths relative to the git root in case diff.relative has been set to true in the git config

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -195,7 +195,11 @@ export async function getChangedFilesSince({
 }): Promise<Array<string>> {
   const divergedAt = await getDivergedCommit(cwd, ref);
   // Now we can find which files we added
-  const cmd = await spawn("git", ["diff", "--name-only", divergedAt], { cwd });
+  const cmd = await spawn(
+    "git",
+    ["diff", "--name-only", "--no-relative", divergedAt],
+    { cwd }
+  );
   if (cmd.code !== 0) {
     throw new Error(
       `Failed to diff against ${divergedAt}. Is ${divergedAt} a valid ref?`
@@ -226,7 +230,7 @@ export async function getChangedChangesetFilesSinceRef({
     // Now we can find which files we added
     const cmd = await spawn(
       "git",
-      ["diff", "--name-only", "--diff-filter=d", divergedAt],
+      ["diff", "--name-only", "--diff-filter=d", "--no-relative", divergedAt],
       {
         cwd,
       }


### PR DESCRIPTION
If diff.relative in the git config has (accidentally) been set to true (In our case by GitHub actions/workflows), the new changesets are not correctly resolved. (as it won't include `.changeset/` in the path, thus not passing the filter) This should fix it.

RE: https://github.com/changesets/changesets/issues/700#issuecomment-2741593490

Friendly pings; @Andarist @bluwy :)