### PR TITLE
feat: add `getCurrentRelease` to enable freely formatting the entire content

### DIFF
--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -101,8 +101,7 @@ export default async function getChangelogEntry(
       changelogOpts
     )
   );
-
-  return [
+  const currentReleaseMessage = [
     `## ${release.newVersion}`,
     await generateChangesForVersionTypeMarkdown(changelogLines, "major"),
     await generateChangesForVersionTypeMarkdown(changelogLines, "minor"),
@@ -110,4 +109,9 @@ export default async function getChangelogEntry(
   ]
     .filter((line) => line)
     .join("\n");
+
+  return await changelogFuncs.getCurrentRelease(
+    currentReleaseMessage,
+    changelogOpts
+  );
 }

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -224,6 +224,7 @@ async function getNewChangelogEntry(
   let getChangelogFuncs: ChangelogFunctions = {
     getReleaseLine: () => Promise.resolve(""),
     getDependencyReleaseLine: () => Promise.resolve(""),
+    getCurrentRelease: () => Promise.resolve(""),
   };
 
   const changelogOpts = config.changelog[1];
@@ -248,7 +249,8 @@ async function getNewChangelogEntry(
   }
   if (
     typeof possibleChangelogFunc.getReleaseLine === "function" &&
-    typeof possibleChangelogFunc.getDependencyReleaseLine === "function"
+    typeof possibleChangelogFunc.getDependencyReleaseLine === "function" &&
+    typeof possibleChangelogFunc.getCurrentRelease === "function"
   ) {
     getChangelogFuncs = possibleChangelogFunc;
   } else {

--- a/packages/apply-release-plan/src/test-utils/failing-functions.ts
+++ b/packages/apply-release-plan/src/test-utils/failing-functions.ts
@@ -5,4 +5,7 @@ export default {
   getDependencyReleaseLine: () => {
     throw new Error("no chance");
   },
+  getCurrentRelease: () => {
+    throw new Error("no chance");
+  },
 };

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -45,7 +45,7 @@ const getDependencyReleaseLine = async (
   return [...changesetLinks, ...updatedDependenciesList].join("\n");
 };
 
-const getCurrentRelease:GetCurrentRelease = async (changesets, _options) => {
+const getCurrentRelease:GetCurrentRelease = async (changesets: string, _changelogOpts: null | Record<string, any>) => {
   return changesets;
 };
 

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -3,6 +3,7 @@ import type {
   VersionType,
   ChangelogFunctions,
   ModCompWithPackage,
+  GetCurrentRelease,
 } from "@changesets/types";
 
 const getReleaseLine = async (
@@ -44,9 +45,14 @@ const getDependencyReleaseLine = async (
   return [...changesetLinks, ...updatedDependenciesList].join("\n");
 };
 
+const getCurrentRelease:GetCurrentRelease = async (changesets, _options) => {
+  return changesets;
+};
+
 const defaultChangelogFunctions: ChangelogFunctions = {
   getReleaseLine,
   getDependencyReleaseLine,
+  getCurrentRelease,
 };
 
 export default defaultChangelogFunctions;

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -119,6 +119,9 @@ const changelogFunctions: ChangelogFunctions = {
       .map((l) => `  ${l}`)
       .join("\n")}`;
   },
+  getCurrentRelease: async (changesets, _options) => {
+    return changesets;
+  },
 };
 
 export default changelogFunctions;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -147,7 +147,7 @@ export type GetDependencyReleaseLine = (
 ) => Promise<string>;
 
 export type GetCurrentRelease = (
-  changesets: String,
+  changesets: string,
   changelogOpts: null | Record<string, any>
 ) => Promise<string>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -146,9 +146,15 @@ export type GetDependencyReleaseLine = (
   changelogOpts: any
 ) => Promise<string>;
 
+export type GetCurrentRelease = (
+  changesets: String,
+  changelogOpts: null | Record<string, any>
+) => Promise<string>;
+
 export type ChangelogFunctions = {
   getReleaseLine: GetReleaseLine;
   getDependencyReleaseLine: GetDependencyReleaseLine;
+  getCurrentRelease: GetCurrentRelease;
 };
 
 export type GetAddMessage = (


### PR DESCRIPTION
I will try to develop for this requirement (#1596 ) first and try to promote the completion of this function.

I have a few issues that are holding me back and I don't know how to proceed：
- [ ] I don't know how to run this function in dev mode
- [ ] If the user customizes the formatting content, for example, will the first line cause errors in the version interception somewhere (my previous CHANGELOG.md was not written in a fixed format and all were sent to github release)
- [ ]  Will adding `getCurrentRelease` without making it optional be a big destructive update, but I might want to add it as an optional? Reduce destructive updates

---
- [ ] I need to do add tests after verifying the function