### PR TITLE
docs: adds spectrum css and spectrum web components

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To make releasing easier, you can use [this changesets github action](https://gi
 - [neverthrow](https://github.com/supermacro/neverthrow)
 - [Apollo Client](https://github.com/apollographql/apollo-client)
 - [Adobe Spectrum CSS](https://github.com/adobe/spectrum-css)
-- [Adobe Spectrum Web Components](https://github.com/adobe/spectrum-web-components/)
+- [Adobe Spectrum Web Components](https://github.com/adobe/spectrum-web-components)
 
 <!-- NOTE: we currently only accept new entries with at least 1000 GitHub stars -->
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ To make releasing easier, you can use [this changesets github action](https://gi
 - [Hey API](https://github.com/hey-api/openapi-ts)
 - [neverthrow](https://github.com/supermacro/neverthrow)
 - [Apollo Client](https://github.com/apollographql/apollo-client)
+- [Adobe Spectrum CSS](https://github.com/adobe/spectrum-css)
+- [Adobe Spectrum Web Components](https://github.com/adobe/spectrum-web-components/)
 
 <!-- NOTE: we currently only accept new entries with at least 1000 GitHub stars -->
 


### PR DESCRIPTION
This adds two links to the Cool Projects list: one for [Adobe's Spectrum CSS repo](https://github.com/adobe/spectrum-css) and one for [Adobe's Spectrum Web Components repo](https://github.com/adobe/spectrum-web-components/).

Thank you all so much for creating and maintaining this project. It's been a huge help for our workflow and it's made life so much easier for us and our contributors!