### PR TITLE
fix: correctly fetch changesets (nested changeset directory from git root)

### DIFF
--- a/.changeset/big-maps-say.md
+++ b/.changeset/big-maps-say.md
@@ -1,0 +1,9 @@
+---
+"@changesets/cli": patch
+"@changesets/read": patch
+"@changesets/git": patch
+---
+
+author: @Netail
+
+Correctly resolve new changesets with since option when changesets directory is not directly in the git root

--- a/.changeset/big-maps-say.md
+++ b/.changeset/big-maps-say.md
@@ -6,4 +6,4 @@
 
 author: @Netail
 
-Correctly resolve new changesets with since option when changesets directory is not directly in the git root
+Correctly resolve new changesets with `since` option when the changesets directory is not directly in the git root

--- a/.changeset/big-maps-say.md
+++ b/.changeset/big-maps-say.md
@@ -6,4 +6,4 @@
 
 author: @Netail
 
-Correctly resolve new changesets with `since` option when the changesets directory is not directly in the git root
+Correctly resolve new changesets with `since` option when the `.changeset` directory is not directly in the git root

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -349,13 +349,28 @@ describe("running version in a simple project", () => {
 
     expect(spy).toHaveBeenCalled();
 
-    expect(spy).toHaveBeenCalledWith("packages/pkg-a/package.json", cwd);
-    expect(spy).toHaveBeenCalledWith("packages/pkg-a/CHANGELOG.md", cwd);
+    expect(spy).toHaveBeenCalledWith(
+      path.join("packages", "pkg-a", "package.json"),
+      cwd
+    );
+    expect(spy).toHaveBeenCalledWith(
+      path.join("packages", "pkg-a", "CHANGELOG.md"),
+      cwd
+    );
 
-    expect(spy).toHaveBeenCalledWith("packages/pkg-b/package.json", cwd);
-    expect(spy).toHaveBeenCalledWith("packages/pkg-b/CHANGELOG.md", cwd);
+    expect(spy).toHaveBeenCalledWith(
+      path.join("packages", "pkg-b", "package.json"),
+      cwd
+    );
+    expect(spy).toHaveBeenCalledWith(
+      path.join("packages", "pkg-b", "CHANGELOG.md"),
+      cwd
+    );
 
-    expect(spy).toHaveBeenCalledWith(`.changeset/${ids[0]}.md`, cwd);
+    expect(spy).toHaveBeenCalledWith(
+      path.join(".changeset", `${ids[0]}.md`),
+      cwd
+    );
   });
 
   it("should commit the result if commit config is set", async () => {

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -812,5 +812,42 @@ describe("git", () => {
       });
       expect(files).toEqual([`.changeset/${changesetId}.md`]);
     });
+
+    it("should still get the relative path to the changeset file if git config relative has been set to true", async () => {
+      const cwd = await gitdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+        }),
+        ".changeset/config.json": JSON.stringify({}),
+      });
+
+      await spawn("git", ["config", "diff.relative", "true"], {
+        cwd,
+      });
+
+      const changesetId = await writeChangeset(
+        {
+          releases: [
+            {
+              name: "pkg-a",
+              type: "minor",
+            },
+          ],
+          summary: "Awesome summary",
+        },
+        cwd
+      );
+      await add(".changeset", cwd);
+
+      const files = await getChangedChangesetFilesSinceRef({
+        cwd: path.join(cwd, ".changeset"),
+        ref: "main",
+      });
+      expect(files).toEqual([`.changeset/${changesetId}.md`]);
+    });
   });
 });

--- a/packages/read/package.json
+++ b/packages/read/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@changesets/test-utils": "*",
+    "@changesets/write": "*",
     "outdent": "^0.5.0"
   }
 }

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -14,7 +14,7 @@ async function filterChangesetsSinceRef(
     cwd: changesetBase,
     ref: sinceRef,
   });
-  const newHashes = newChangesets.map((c) => c.split("/")[1]);
+  const newHashes = newChangesets.map((c) => c.split("/").pop());
 
   return changesets.filter((dir) => newHashes.includes(dir));
 }


### PR DESCRIPTION
Brought up by @Aubron in https://github.com/changesets/changesets/pull/1620#issuecomment-2807668248 (but seperate from the issue fixed in that PR)

When the `.changeset` directory is located lower than the git root it wrongly parses the changeset filenames from the changeset paths. It always tries to get the second item in the array, which is the case for repos where the `.changeset` dir is located in the git root, but not when nested. It's safer to pop off the last item, as it's a file name (Which is filtered by `getChangedChangesetFilesSinceRef` already)
