### PR TITLE
Remove deprecated CLI flag warnings

### DIFF
--- a/.changeset/whole-aliens-notice.md
+++ b/.changeset/whole-aliens-notice.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Remove deprecated flag warnings, including `--updateChangelog`, `--isPublic`, `--skipCI`, and `--commit`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,10 +28,6 @@ const parsed = mri(args, {
     "since-master": "sinceMaster",
     "git-tag": "gitTag",
     "snapshot-prerelease-template": "snapshotPrereleaseTemplate",
-    // Deprecated flags
-    "update-changelog": "updateChangelog",
-    "is-public": "isPublic",
-    "skip-c-i": "skipCI",
   },
   default: {
     gitTag: true,

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -91,19 +91,6 @@ export async function run(
       open,
       gitTag,
     }: CliOptions = flags;
-    const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
-
-    deadFlags.forEach((flag) => {
-      if (flags[flag]) {
-        error(
-          `the flag ${flag} has been removed from changesets for version 2`
-        );
-        error(`Please encode the desired value into your config`);
-        error(`See our changelog for more details`);
-        throw new ExitError(1);
-      }
-    });
-
     // Command line options need to be undefined, otherwise their
     // default value overrides the user's provided config in their
     // config file. For this reason, we only assign them to this


### PR DESCRIPTION
Should no longer be relevant in the next major.