### PR TITLE
docs: privatePackages config

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -194,3 +194,30 @@ You can use the following placeholders for customizing the snapshot release vers
 **Default behavior**
 
 If you are not specifying `prereleaseTemplate`, the default behavior will fall back to using the following template: `{tag}-{datetime}`, and in cases where the tag is empty (`--snapshot` with no tag name), it will use `{datetime}` only.
+
+## `privatePackages` (object or false)
+
+This option is for setting how private packages should be handled. By default, Changesets will update the changelog and version for private packages, but will not create a tag. You can configure this option to change the default behavior.
+
+### `version` (optional boolean)
+
+Default value: `true`
+
+When `version` is set to `true`, Changesets will update the version for private packages. If set to `false`, Changesets will not update the version for private packages.
+
+### `tag` (optional boolean)
+
+Default value: `false`
+
+When `tag` is set to `true`, Changesets will create a tag for private packages. If set to `false`, Changesets will not create a tag for private packages.
+
+### Example
+
+```json
+{
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  }
+}
+```


### PR DESCRIPTION
Add documentation for `privatePackages` configuration option.

* **docs/config-file-options.md**
  - Add a new section for `privatePackages` configuration option.
  - Explain the purpose of `privatePackages`.
  - Provide an example of how to use `privatePackages`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/changesets/changesets?shareId=XXXX-XXXX-XXXX-XXXX).