### PR TITLE
feat: add message when releases have no changes

### DIFF
--- a/.changeset/smart-bees-cover.md
+++ b/.changeset/smart-bees-cover.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+Include changelog message for empty releases

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -101,6 +101,20 @@ export default async function getChangelogEntry(
     )
   );
 
+  if (
+    !(
+      await Promise.all([
+        ...changelogLines.patch,
+        ...changelogLines.minor,
+        ...changelogLines.major,
+      ])
+    ).some(Boolean)
+  ) {
+    return [`## ${release.newVersion}`, "No changes in this release."]
+      .filter((line) => line)
+      .join("\n");
+  }
+
   return [
     `## ${release.newVersion}`,
     await generateChangesForVersionTypeMarkdown(changelogLines, "major"),

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2129,7 +2129,9 @@ describe("apply release plan", () => {
 
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
-      ## 2.0.0`);
+      ## 2.0.0
+
+      No changes in this release.`);
     });
     it("should not update the changelog if only devDeps changed", async () => {
       let { changedFiles } = await testSetup(

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -818,6 +818,8 @@ describe("fixed", () => {
       "# pkg-b
 
       ## 1.1.0
+
+      No changes in this release.
       "
     `);
 
@@ -867,7 +869,11 @@ describe("fixed", () => {
 
       ## 1.2.0
 
+      No changes in this release.
+
       ## 1.1.0
+
+      No changes in this release.
       "
     `);
   });


### PR DESCRIPTION
Fixes https://github.com/changesets/changesets/issues/992

This adds a message for empty releases caused by using fixed packages to make it more clear that the release was intentional and not a bug in changelog generation.