### PR TITLE
Support prerelease range for dependency graph

### DIFF
--- a/.changeset/fancy-wings-slide.md
+++ b/.changeset/fancy-wings-slide.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-dependents-graph": patch
+---
+
+Support prerelease range for dependency graph

--- a/packages/get-dependents-graph/src/get-dependency-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.test.ts
@@ -115,4 +115,36 @@ describe("getting the dependency graph", function () {
       `);
     })
   );
+
+  it("should handle dependencies with prerelease versions", function () {
+    const { graph, valid } = getDependencyGraph({
+      root: {
+        dir: ".",
+        packageJson: { name: "root", version: "1.0.0" },
+      },
+      packages: [
+        {
+          dir: "foo",
+          packageJson: {
+            name: "foo",
+            version: "1.0.0",
+            dependencies: {
+              bar: "^1.0.0-beta.0",
+            },
+          },
+        },
+        {
+          dir: "bar",
+          packageJson: {
+            name: "bar",
+            version: "1.2.3-beta.1",
+          },
+        },
+      ],
+      tool: "pnpm",
+    });
+    expect((console.error as any).mock.calls).toMatchInlineSnapshot(`[]`);
+    expect(graph.get("foo")!.dependencies).toStrictEqual(["bar"]);
+    expect(valid).toBeTruthy();
+  });
 });

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -47,7 +47,7 @@ const getValidRange = (potentialRange: string) => {
   }
 
   try {
-    return new Range(potentialRange);
+    return new Range(potentialRange, { includePrerelease: true });
   } catch {
     return null;
   }


### PR DESCRIPTION
### Why?

When running `changeset` commands, received warning:

```
Package "foo" must depend on the current version of "bar": "1.2.3-beta.1" vs "^1.0.0-beta.0"
```

This is because even though the provided range was correct, the prerelease range was not supported while getting the dependency graph.

See failed CI from adding the test with expected behavior:

https://github.com/changesets/changesets/actions/runs/14954534600/job/42008430647?pr=1666#step:6:276

### How?

The functions of `semver` package has `includePrerelease` option that can opt-in to include prerelease tags for the version range.

x-ref: https://github.com/npm/node-semver?tab=readme-ov-file#prerelease-tags