### PR TITLE
Fixed a crash in pre mode when trying to version private packages when tagging for private package is disabled

### DIFF
--- a/.changeset/green-rice-lead.md
+++ b/.changeset/green-rice-lead.md
@@ -1,0 +1,6 @@
+---
+"@changesets/assemble-release-plan": patch
+"@changesets/cli": patch
+---
+
+Fixed a crash in pre mode when trying to version private packages when tagging for private package is disabled

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -361,7 +361,7 @@ function getPreInfo(
     if (
       shouldSkipPackage(pkg, {
         ignore: config.ignore,
-        allowPrivatePackages: config.privatePackages.tag,
+        allowPrivatePackages: config.privatePackages.version,
       })
     ) {
       continue;

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -3028,6 +3028,43 @@ describe("pre", () => {
     ]);
   });
 
+  it("should version successfully a private package when tagging for them is disabled", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        private: true,
+        version: "1.0.0",
+      }),
+    });
+    await pre(cwd, { command: "enter", tag: "next" });
+    await writeChangeset(
+      {
+        releases: [{ name: "pkg-a", type: "patch" }],
+        summary: "a very useful summary for the first change",
+      },
+      cwd
+    );
+    await version(cwd, defaultOptions, {
+      ...modifiedDefaultConfig,
+      privatePackages: {
+        tag: false,
+        version: true,
+      },
+    });
+    let packages = (await getPackages(cwd))!;
+    expect(packages.packages.map((x) => x.packageJson)).toEqual([
+      {
+        name: "pkg-a",
+        private: true,
+        version: "1.0.1-next.0",
+      },
+    ]);
+  });
+
   describe("linked", () => {
     it("should work with linked", async () => {
       let linkedConfig = {


### PR DESCRIPTION
fixes https://github.com/changesets/changesets/issues/1658 (a regression from https://github.com/changesets/changesets/pull/1589 )