### PR TITLE
New config option: "requireSemverSatisfaction"

### DIFF
--- a/.changeset/public-gifts-beam.md
+++ b/.changeset/public-gifts-beam.md
@@ -1,0 +1,7 @@
+---
+"@changesets/apply-release-plan": minor
+"@changesets/config": minor
+"@changesets/types": minor
+---
+
+New config option: "requireSemverSatisfaction"

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -11,11 +11,12 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "requireSemverSatisfaction": false,
   "ignore": []
 }
 ```
 
-> NOTE: the `linked`, `fixed`, `updateInternalDependencies`, `bumpVersionsWithWorkspaceProtocolOnly`, and `ignore` options are only for behaviour in monorepos.
+> NOTE: the `linked`, `fixed`, `updateInternalDependencies`, `requireSemverSatisfaction`, `bumpVersionsWithWorkspaceProtocolOnly`, and `ignore` options are only for behaviour in monorepos.
 
 ## `commit` (`boolean`, or module path as a `string`, or a tuple like `[modulePath: string, options: any]`)
 
@@ -134,6 +135,34 @@ Using `minor` allows consumers to more actively control their own deduplication 
 Changesets will always update the dependency if it would leave the old semver range.
 
 > ⚠ Note: this is only applied for packages which are already released in the current release. If A depends on B and we only release B then A won't be bumped.
+
+## `requireSemverSatisfaction`
+
+Set this option to `true` if you want `changeset version` to skip updating internal dependencies if the new version you are releasing does not satisfy the semantic version range declared by your internal dependencies. This is particularly useful if you make breaking changes in one package but don't want to update your other packages at the same time.
+
+For example, if you change `pkg-spoon` from v1.5.2 to v2.0.0, and you have another package named `pkg-soup` that declares the dependency:
+
+```json
+{
+  "name": "pkg-soup",
+  "dependencies": {
+    "pkg-spoon": "^1.5.2"
+  }
+}
+```
+
+Setting `requireSemverSatisfaction` to `true` will NOT make an update to `pkg-soup` when running `changeset version`.
+
+Leaving this option `false` (default) will update `pkg-soup`'s package.json to:
+
+```json
+{
+  "name": "pkg-soup",
+  "dependencies": {
+    "pkg-spoon": "^2.0.0"
+  }
+}
+```
 
 ## `changelog` (false or a path)
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -31,9 +31,11 @@ export default async function getChangelogEntry(
   changelogOpts: any,
   {
     updateInternalDependencies,
+    requireSemverSatisfaction,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
     updateInternalDependencies: "patch" | "minor";
+    requireSemverSatisfaction: boolean;
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
 ) {
@@ -75,6 +77,7 @@ export default async function getChangelogEntry(
         },
         {
           minReleaseType: updateInternalDependencies,
+          requireSemverSatisfaction,
           onlyUpdatePeerDependentsWhenOutOfRange,
         }
       )

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -1935,7 +1935,7 @@ describe("apply release plan", () => {
               requireSemverSatisfaction: false,
             }),
           };
-    
+
           const releasePlan: ReleasePlan = {
             changesets: [
               {
@@ -1962,7 +1962,7 @@ describe("apply release plan", () => {
             ],
             preState: undefined,
           };
-    
+
           const packages = await getPackages(await testdir(fixture));
           const config = JSON.parse(
             await fs.readFile(
@@ -1970,21 +1970,20 @@ describe("apply release plan", () => {
               "utf-8"
             )
           ) as Config;
-    
+
           await applyReleasePlan(releasePlan, packages, config);
-    
-          const pkgADir = packages.packages.find(p => p.packageJson.name === "pkg-a")?.dir;
+
+          const pkgADir = packages.packages.find(
+            (p) => p.packageJson.name === "pkg-a"
+          )?.dir;
           if (!pkgADir) throw new Error("pkg-a not found in test setup");
-    
+
           const pkgAJson = JSON.parse(
-            await fs.readFile(
-              path.join(pkgADir, "package.json"),
-              "utf-8"
-            )
+            await fs.readFile(path.join(pkgADir, "package.json"), "utf-8")
           );
           expect(pkgAJson.dependencies["pkg-b"]).toBe("^2.0.0");
         });
-    
+
         it("should NOT update dependency if requireSemverSatisfaction is true and new version is out of range", async () => {
           const fixture = {
             "package.json": JSON.stringify({
@@ -2004,7 +2003,7 @@ describe("apply release plan", () => {
             }),
           };
           const tempDir = await testdir(fixture);
-    
+
           const releasePlan: ReleasePlan = {
             changesets: [
               {
@@ -2031,7 +2030,7 @@ describe("apply release plan", () => {
             ],
             preState: undefined,
           };
-    
+
           const packages = await getPackages(tempDir);
           // Explicitly define the config for this test
           const config: Config = {
@@ -2043,27 +2042,43 @@ describe("apply release plan", () => {
             linked: defaultConfig.linked || [],
             access: defaultConfig.access || "restricted",
             baseBranch: defaultConfig.baseBranch || "master",
-            updateInternalDependencies: defaultConfig.updateInternalDependencies || "patch",
+            updateInternalDependencies:
+              defaultConfig.updateInternalDependencies || "patch",
             ignore: defaultConfig.ignore || [],
             changedFilePatterns: defaultConfig.changedFilePatterns || ["**"],
-            bumpVersionsWithWorkspaceProtocolOnly: defaultConfig.bumpVersionsWithWorkspaceProtocolOnly || false,
+            bumpVersionsWithWorkspaceProtocolOnly:
+              defaultConfig.bumpVersionsWithWorkspaceProtocolOnly || false,
             prettier: defaultConfig.prettier !== false,
-            privatePackages: defaultConfig.privatePackages || { version: true, tag: false },
-            snapshot: defaultConfig.snapshot || { useCalculatedVersion: false, prereleaseTemplate: null },
-            ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH || {
-              onlyUpdatePeerDependentsWhenOutOfRange: false,
-              updateInternalDependents: "out-of-range",
+            privatePackages: defaultConfig.privatePackages || {
+              version: true,
+              tag: false,
             },
+            snapshot: defaultConfig.snapshot || {
+              useCalculatedVersion: false,
+              prereleaseTemplate: null,
+            },
+            ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH:
+              defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH || {
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
+              },
           };
-    
+
           await applyReleasePlan(releasePlan, packages, config);
-    
+
           const pkgAJson = JSON.parse(
-            await fs.readFile(path.join(packages.packages.find(p => p.packageJson.name === "pkg-a")!.dir, "package.json"), "utf-8")
+            await fs.readFile(
+              path.join(
+                packages.packages.find((p) => p.packageJson.name === "pkg-a")!
+                  .dir,
+                "package.json"
+              ),
+              "utf-8"
+            )
           );
           expect(pkgAJson.dependencies["pkg-b"]).toBe("^1.0.0"); // Should NOT change
         });
-    
+
         it("should update dependency if requireSemverSatisfaction is true and new version is IN range", async () => {
           const fixture = {
             "package.json": JSON.stringify({
@@ -2083,7 +2098,7 @@ describe("apply release plan", () => {
             }),
           };
           const tempDir = await testdir(fixture);
-    
+
           const releasePlan: ReleasePlan = {
             changesets: [
               {
@@ -2110,7 +2125,7 @@ describe("apply release plan", () => {
             ],
             preState: undefined,
           };
-    
+
           const packages = await getPackages(tempDir);
           // Explicitly define the config for this test
           const config: Config = {
@@ -2122,23 +2137,39 @@ describe("apply release plan", () => {
             linked: defaultConfig.linked || [],
             access: defaultConfig.access || "restricted",
             baseBranch: defaultConfig.baseBranch || "master",
-            updateInternalDependencies: defaultConfig.updateInternalDependencies || "patch",
+            updateInternalDependencies:
+              defaultConfig.updateInternalDependencies || "patch",
             ignore: defaultConfig.ignore || [],
             changedFilePatterns: defaultConfig.changedFilePatterns || ["**"],
-            bumpVersionsWithWorkspaceProtocolOnly: defaultConfig.bumpVersionsWithWorkspaceProtocolOnly || false,
+            bumpVersionsWithWorkspaceProtocolOnly:
+              defaultConfig.bumpVersionsWithWorkspaceProtocolOnly || false,
             prettier: defaultConfig.prettier !== false,
-            privatePackages: defaultConfig.privatePackages || { version: true, tag: false },
-            snapshot: defaultConfig.snapshot || { useCalculatedVersion: false, prereleaseTemplate: null },
-            ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH || {
-              onlyUpdatePeerDependentsWhenOutOfRange: false,
-              updateInternalDependents: "out-of-range",
+            privatePackages: defaultConfig.privatePackages || {
+              version: true,
+              tag: false,
             },
+            snapshot: defaultConfig.snapshot || {
+              useCalculatedVersion: false,
+              prereleaseTemplate: null,
+            },
+            ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH:
+              defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH || {
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
+              },
           };
-    
+
           await applyReleasePlan(releasePlan, packages, config);
-    
+
           const pkgAJson = JSON.parse(
-            await fs.readFile(path.join(packages.packages.find(p => p.packageJson.name === "pkg-a")!.dir, "package.json"), "utf-8")
+            await fs.readFile(
+              path.join(
+                packages.packages.find((p) => p.packageJson.name === "pkg-a")!
+                  .dir,
+                "package.json"
+              ),
+              "utf-8"
+            )
           );
           expect(pkgAJson.dependencies["pkg-b"]).toBe("^1.0.1"); // Should update
         });
@@ -3549,5 +3580,4 @@ describe("apply release plan", () => {
       expect(changesetsDeleted).toBe(true);
     });
   });
-
 });

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -50,7 +50,7 @@ class FakeReleasePlan {
       changedFilePatterns: ["**"],
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      satisfyInternalSemverWhenUpdating: false,
+      requireSemverSatisfaction: false,
       ignore: [],
       prettier: true,
       privatePackages: { version: true, tag: false },
@@ -95,7 +95,7 @@ async function testSetup(
       changedFilePatterns: ["**"],
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      satisfyInternalSemverWhenUpdating: false,
+      requireSemverSatisfaction: false,
       ignore: [],
       prettier: true,
       privatePackages: { version: true, tag: false },
@@ -669,7 +669,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           changedFilePatterns: ["**"],
           updateInternalDependencies: "patch",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           prettier: true,
           privatePackages: { version: true, tag: false },
           ignore: [],
@@ -747,7 +747,7 @@ describe("apply release plan", () => {
           baseBranch: "main",
           changedFilePatterns: ["**"],
           updateInternalDependencies: "patch",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           prettier: true,
           privatePackages: { version: true, tag: false },
           ignore: [],
@@ -1007,7 +1007,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1125,7 +1125,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1228,7 +1228,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1330,7 +1330,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1432,7 +1432,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1537,7 +1537,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1655,7 +1655,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1766,7 +1766,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1868,7 +1868,7 @@ describe("apply release plan", () => {
               changedFilePatterns: ["**"],
               baseBranch: "main",
               updateInternalDependencies,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
               ignore: [],
               prettier: true,
               privatePackages: { version: true, tag: false },
@@ -1912,8 +1912,8 @@ describe("apply release plan", () => {
         });
       });
 
-      describe("satisfyInternalSemverWhenUpdating option", () => {
-        it("should update dependency if satisfyInternalSemverWhenUpdating is false and new version is out of range", async () => {
+      describe("requireSemverSatisfaction option", () => {
+        it("should update dependency if requireSemverSatisfaction is false and new version is out of range", async () => {
           const fixture = {
             "package.json": JSON.stringify({
               private: true,
@@ -1932,7 +1932,7 @@ describe("apply release plan", () => {
             }),
             ".changeset/config.json": JSON.stringify({
               ...defaultConfig,
-              satisfyInternalSemverWhenUpdating: false,
+              requireSemverSatisfaction: false,
             }),
           };
     
@@ -1985,7 +1985,7 @@ describe("apply release plan", () => {
           expect(pkgAJson.dependencies["pkg-b"]).toBe("^2.0.0");
         });
     
-        it("should NOT update dependency if satisfyInternalSemverWhenUpdating is true and new version is out of range", async () => {
+        it("should NOT update dependency if requireSemverSatisfaction is true and new version is out of range", async () => {
           const fixture = {
             "package.json": JSON.stringify({
               private: true,
@@ -2036,7 +2036,7 @@ describe("apply release plan", () => {
           // Explicitly define the config for this test
           const config: Config = {
             ...defaultConfig,
-            satisfyInternalSemverWhenUpdating: true,
+            requireSemverSatisfaction: true,
             changelog: defaultConfig.changelog || false,
             commit: defaultConfig.commit || false,
             fixed: defaultConfig.fixed || [],
@@ -2064,7 +2064,7 @@ describe("apply release plan", () => {
           expect(pkgAJson.dependencies["pkg-b"]).toBe("^1.0.0"); // Should NOT change
         });
     
-        it("should update dependency if satisfyInternalSemverWhenUpdating is true and new version is IN range", async () => {
+        it("should update dependency if requireSemverSatisfaction is true and new version is IN range", async () => {
           const fixture = {
             "package.json": JSON.stringify({
               private: true,
@@ -2115,7 +2115,7 @@ describe("apply release plan", () => {
           // Explicitly define the config for this test
           const config: Config = {
             ...defaultConfig,
-            satisfyInternalSemverWhenUpdating: true, // Enable the feature
+            requireSemverSatisfaction: true, // Enable the feature
             changelog: defaultConfig.changelog || false,
             commit: defaultConfig.commit || false,
             fixed: defaultConfig.fixed || [],
@@ -2203,7 +2203,7 @@ describe("apply release plan", () => {
             changedFilePatterns: ["**"],
             baseBranch: "main",
             updateInternalDependencies: "patch",
-            satisfyInternalSemverWhenUpdating: false,
+            requireSemverSatisfaction: false,
             ignore: [],
             prettier: true,
             privatePackages: { version: true, tag: false },
@@ -2437,7 +2437,7 @@ describe("apply release plan", () => {
             null,
           ],
           updateInternalDependencies: "patch",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           ignore: [],
           prettier: true,
           privatePackages: { version: true, tag: false },
@@ -2577,7 +2577,7 @@ describe("apply release plan", () => {
           changedFilePatterns: ["**"],
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           ignore: [],
           prettier: true,
           privatePackages: { version: true, tag: false },
@@ -2688,7 +2688,7 @@ describe("apply release plan", () => {
           changedFilePatterns: ["**"],
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           ignore: [],
           prettier: true,
           privatePackages: { version: true, tag: false },
@@ -2811,7 +2811,7 @@ describe("apply release plan", () => {
           changedFilePatterns: ["**"],
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           ignore: [],
           prettier: true,
           privatePackages: { version: true, tag: false },
@@ -2948,7 +2948,7 @@ describe("apply release plan", () => {
           changedFilePatterns: ["**"],
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          satisfyInternalSemverWhenUpdating: false,
+          requireSemverSatisfaction: false,
           ignore: [],
           prettier: true,
           privatePackages: { version: true, tag: false },

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -123,7 +123,7 @@ export default async function applyReleasePlan(
   let finalisedRelease = releaseWithChangelogs.map((release) => {
     return versionPackage(release, versionsToUpdate, {
       updateInternalDependencies: config.updateInternalDependencies,
-      satisfyInternalSemverWhenUpdating: config.satisfyInternalSemverWhenUpdating,
+      requireSemverSatisfaction: config.requireSemverSatisfaction,
       onlyUpdatePeerDependentsWhenOutOfRange:
         config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .onlyUpdatePeerDependentsWhenOutOfRange,

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -252,6 +252,7 @@ async function getNewChangelogEntry(
         changelogOpts,
         {
           updateInternalDependencies: config.updateInternalDependencies,
+          requireSemverSatisfaction: config.requireSemverSatisfaction,
           onlyUpdatePeerDependentsWhenOutOfRange:
             config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange,

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -123,6 +123,7 @@ export default async function applyReleasePlan(
   let finalisedRelease = releaseWithChangelogs.map((release) => {
     return versionPackage(release, versionsToUpdate, {
       updateInternalDependencies: config.updateInternalDependencies,
+      satisfyInternalSemverWhenUpdating: config.satisfyInternalSemverWhenUpdating,
       onlyUpdatePeerDependentsWhenOutOfRange:
         config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .onlyUpdatePeerDependentsWhenOutOfRange,

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -31,14 +31,17 @@ export function shouldUpdateDependencyBasedOnConfig(
   {
     minReleaseType,
     onlyUpdatePeerDependentsWhenOutOfRange,
+    satisfyInternalSemverWhenUpdating,
   }: {
     minReleaseType: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+    satisfyInternalSemverWhenUpdating: boolean;
   }
 ): boolean {
   if (!semverSatisfies(release.version, depVersionRange)) {
-    // Dependencies leaving semver range should always be updated
-    return true;
+    // Dependencies leaving semver range should always be updated,
+    // unless the config is set to disable this behavior
+    return !satisfyInternalSemverWhenUpdating;
   }
 
   const minLevel = getBumpLevel(minReleaseType);

--- a/packages/apply-release-plan/src/utils.ts
+++ b/packages/apply-release-plan/src/utils.ts
@@ -31,17 +31,17 @@ export function shouldUpdateDependencyBasedOnConfig(
   {
     minReleaseType,
     onlyUpdatePeerDependentsWhenOutOfRange,
-    satisfyInternalSemverWhenUpdating,
+    requireSemverSatisfaction,
   }: {
     minReleaseType: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-    satisfyInternalSemverWhenUpdating: boolean;
+    requireSemverSatisfaction: boolean;
   }
 ): boolean {
   if (!semverSatisfies(release.version, depVersionRange)) {
     // Dependencies leaving semver range should always be updated,
     // unless the config is set to disable this behavior
-    return !satisfyInternalSemverWhenUpdating;
+    return !requireSemverSatisfaction;
   }
 
   const minLevel = getBumpLevel(minReleaseType);

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -25,13 +25,13 @@ export default function versionPackage(
   versionsToUpdate: Array<{ name: string; version: string; type: VersionType }>,
   {
     updateInternalDependencies,
-    satisfyInternalSemverWhenUpdating,
+    requireSemverSatisfaction,
     onlyUpdatePeerDependentsWhenOutOfRange,
     bumpVersionsWithWorkspaceProtocolOnly,
     snapshot,
   }: {
     updateInternalDependencies: "patch" | "minor";
-    satisfyInternalSemverWhenUpdating: boolean;
+    requireSemverSatisfaction: boolean;
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
     snapshot?: string | boolean | undefined;
@@ -59,7 +59,7 @@ export default function versionPackage(
             {
               minReleaseType: updateInternalDependencies,
               onlyUpdatePeerDependentsWhenOutOfRange,
-              satisfyInternalSemverWhenUpdating,
+              requireSemverSatisfaction,
             }
           )
         ) {

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -25,11 +25,13 @@ export default function versionPackage(
   versionsToUpdate: Array<{ name: string; version: string; type: VersionType }>,
   {
     updateInternalDependencies,
+    satisfyInternalSemverWhenUpdating,
     onlyUpdatePeerDependentsWhenOutOfRange,
     bumpVersionsWithWorkspaceProtocolOnly,
     snapshot,
   }: {
     updateInternalDependencies: "patch" | "minor";
+    satisfyInternalSemverWhenUpdating: boolean;
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
     snapshot?: string | boolean | undefined;
@@ -57,6 +59,7 @@ export default function versionPackage(
             {
               minReleaseType: updateInternalDependencies,
               onlyUpdatePeerDependentsWhenOutOfRange,
+              satisfyInternalSemverWhenUpdating,
             }
           )
         ) {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -48,7 +48,7 @@ test("read reads the config", async () => {
     baseBranch: "master",
     changedFilePatterns: ["**"],
     updateInternalDependencies: "patch",
-    satisfyInternalSemverWhenUpdating: false,
+    requireSemverSatisfaction: false,
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     prettier: true,
@@ -89,7 +89,7 @@ test("read can read config based on the passed in `cwd`", async () => {
     baseBranch: "master",
     changedFilePatterns: ["**"],
     updateInternalDependencies: "patch",
-    satisfyInternalSemverWhenUpdating: false,
+    requireSemverSatisfaction: false,
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     prettier: true,
@@ -149,7 +149,7 @@ let defaults: Config = {
   baseBranch: "master",
   changedFilePatterns: ["**"],
   updateInternalDependencies: "patch",
-  satisfyInternalSemverWhenUpdating: false,
+  requireSemverSatisfaction: false,
   ignore: [],
   prettier: true,
   privatePackages: { version: true, tag: false },
@@ -423,22 +423,22 @@ let correctCases: Record<string, CorrectCase> = {
       },
     },
   },
-  "satisfyInternalSemverWhenUpdating true": {
+  "requireSemverSatisfaction true": {
     input: {
-      satisfyInternalSemverWhenUpdating: true,
+      requireSemverSatisfaction: true,
     },
     output: {
       ...defaults,
-      satisfyInternalSemverWhenUpdating: true,
+      requireSemverSatisfaction: true,
     },
   },
-  "satisfyInternalSemverWhenUpdating false": {
+  "requireSemverSatisfaction false": {
     input: {
-      satisfyInternalSemverWhenUpdating: false,
+      requireSemverSatisfaction: false,
     },
     output: {
       ...defaults,
-      satisfyInternalSemverWhenUpdating: false,
+      requireSemverSatisfaction: false,
     },
   },
 };

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -48,6 +48,7 @@ test("read reads the config", async () => {
     baseBranch: "master",
     changedFilePatterns: ["**"],
     updateInternalDependencies: "patch",
+    satisfyInternalSemverWhenUpdating: false,
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     prettier: true,
@@ -88,6 +89,7 @@ test("read can read config based on the passed in `cwd`", async () => {
     baseBranch: "master",
     changedFilePatterns: ["**"],
     updateInternalDependencies: "patch",
+    satisfyInternalSemverWhenUpdating: false,
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     prettier: true,
@@ -147,6 +149,7 @@ let defaults: Config = {
   baseBranch: "master",
   changedFilePatterns: ["**"],
   updateInternalDependencies: "patch",
+  satisfyInternalSemverWhenUpdating: false,
   ignore: [],
   prettier: true,
   privatePackages: { version: true, tag: false },
@@ -418,6 +421,24 @@ let correctCases: Record<string, CorrectCase> = {
         useCalculatedVersion: true,
         prereleaseTemplate: null,
       },
+    },
+  },
+  "satisfyInternalSemverWhenUpdating true": {
+    input: {
+      satisfyInternalSemverWhenUpdating: true,
+    },
+    output: {
+      ...defaults,
+      satisfyInternalSemverWhenUpdating: true,
+    },
+  },
+  "satisfyInternalSemverWhenUpdating false": {
+    input: {
+      satisfyInternalSemverWhenUpdating: false,
+    },
+    output: {
+      ...defaults,
+      satisfyInternalSemverWhenUpdating: false,
     },
   },
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,7 +23,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  satisfyInternalSemverWhenUpdating: false,
+  requireSemverSatisfaction: false,
   ignore: [] as ReadonlyArray<string>,
 } as const;
 
@@ -457,10 +457,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         ? defaultWrittenConfig.updateInternalDependencies
         : json.updateInternalDependencies,
 
-    satisfyInternalSemverWhenUpdating:
-      json.satisfyInternalSemverWhenUpdating === undefined
-        ? defaultWrittenConfig.satisfyInternalSemverWhenUpdating
-        : json.satisfyInternalSemverWhenUpdating,
+    requireSemverSatisfaction:
+      json.requireSemverSatisfaction === undefined
+        ? defaultWrittenConfig.requireSemverSatisfaction
+        : json.requireSemverSatisfaction,
 
     ignore:
       json.ignore === undefined

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,6 +23,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
+  satisfyInternalSemverWhenUpdating: false,
   ignore: [] as ReadonlyArray<string>,
 } as const;
 
@@ -455,6 +456,11 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       json.updateInternalDependencies === undefined
         ? defaultWrittenConfig.updateInternalDependencies
         : json.updateInternalDependencies,
+
+    satisfyInternalSemverWhenUpdating:
+      json.satisfyInternalSemverWhenUpdating === undefined
+        ? defaultWrittenConfig.satisfyInternalSemverWhenUpdating
+        : json.satisfyInternalSemverWhenUpdating,
 
     ignore:
       json.ignore === undefined

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,6 +81,8 @@ export type Config = {
   privatePackages: PrivatePackages;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
+  /** Only update internal dependencies if the new version(s) satisfy the semver range */
+  satisfyInternalSemverWhenUpdating: boolean;
   ignore: ReadonlyArray<string>;
   /** This is supposed to be used with pnpm's `link-workspace-packages: false` and Berry's `enableTransparentWorkspaces: false` */
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
@@ -112,6 +114,8 @@ export type WrittenConfig = {
       };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
+  /** Only update internal dependencies if the new version(s) satisfy the semver range */
+  satisfyInternalSemverWhenUpdating?: boolean;
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   snapshot?: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -82,7 +82,7 @@ export type Config = {
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   /** Only update internal dependencies if the new version(s) satisfy the semver range */
-  satisfyInternalSemverWhenUpdating: boolean;
+  requireSemverSatisfaction: boolean;
   ignore: ReadonlyArray<string>;
   /** This is supposed to be used with pnpm's `link-workspace-packages: false` and Berry's `enableTransparentWorkspaces: false` */
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
@@ -115,7 +115,7 @@ export type WrittenConfig = {
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   /** Only update internal dependencies if the new version(s) satisfy the semver range */
-  satisfyInternalSemverWhenUpdating?: boolean;
+  requireSemverSatisfaction?: boolean;
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   snapshot?: {


### PR DESCRIPTION
Addresses #1238 

This allows other internal packages to upgrade to breaking changes separately from the packages that make the breaking changes.