### PR TITLE
fix: bumping dependent packages in pre mode

### DIFF
--- a/.changeset/real-nails-sit.md
+++ b/.changeset/real-nails-sit.md
@@ -1,0 +1,5 @@
+---
+"@changesets/assemble-release-plan": patch
+---
+
+Fixed bumping dependent packages in pre mode when `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` is set to true.

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -97,7 +97,10 @@ export default function determineDependents({
                   incrementVersion(nextRelease, preInfo),
                   versionRange,
                   {
-                    includePrerelease: isPreMode,
+                    includePrerelease:
+                      isPreMode &&
+                      config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+                        .onlyUpdatePeerDependentsWhenOutOfRange,
                   }
                 ))
             ) {
@@ -243,7 +246,7 @@ function shouldBumpMajor({
     // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
     (!onlyUpdatePeerDependentsWhenOutOfRange ||
       !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange, {
-        includePrerelease: isPreMode,
+        includePrerelease: isPreMode && onlyUpdatePeerDependentsWhenOutOfRange,
       })) &&
     // bump major only if the dependent doesn't already has a major release.
     (!releases.has(dependent) ||

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -1478,6 +1478,38 @@ describe("bumping peerDeps", () => {
       expect(releases[0].newVersion).toEqual("1.1.0");
     });
 
+    it("should not bump dependent when still in range for prerelease versions", () => {
+      setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
+      setup.addChangeset({
+        id: "anyway-the-windblows",
+        releases: [{ name: "pkg-a", type: "minor" }],
+      });
+
+      let { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+            onlyUpdatePeerDependentsWhenOutOfRange: true,
+          },
+        },
+        {
+          mode: "pre",
+          tag: "alpha",
+          initialVersions: {
+            "pkg-a": "1.0.0",
+            "pkg-b": "1.0.0",
+          },
+          changesets: [],
+        }
+      );
+      expect(releases.length).toBe(1);
+      expect(releases[0].name).toEqual("pkg-a");
+      expect(releases[0].newVersion).toEqual("1.1.0-alpha.0");
+    });
+
     it("should major bump dependent when leaving range", () => {
       setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
       setup.addChangeset({


### PR DESCRIPTION
This PR fixes bumping dependent packages in pre mode when `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` is set to true