### PR TITLE
feat: add command line flags for automation

### DIFF
--- a/packages/cli/src/commands/add/__tests__/add-automate.ts
+++ b/packages/cli/src/commands/add/__tests__/add-automate.ts
@@ -5,6 +5,7 @@ import { getVersionableChangedPackages } from "../../../utils/versionablePackage
 import addChangeset from "..";
 
 jest.mock("../../../utils/versionablePackages");
+jest.mock("@changesets/write");
 
 // @ts-ignore
 writeChangeset.mockImplementation(() => Promise.resolve("abcdefg"));

--- a/packages/cli/src/commands/add/__tests__/add-automate.ts
+++ b/packages/cli/src/commands/add/__tests__/add-automate.ts
@@ -1,0 +1,65 @@
+import { testdir } from "@changesets/test-utils";
+import { defaultConfig } from "@changesets/config";
+import writeChangeset from "@changesets/write";
+import { getVersionableChangedPackages } from "../../../utils/versionablePackages";
+import addChangeset from "..";
+
+jest.mock("../../../utils/versionablePackages");
+
+// @ts-ignore
+writeChangeset.mockImplementation(() => Promise.resolve("abcdefg"));
+// @ts-ignore
+getVersionableChangedPackages.mockImplementation(() => {
+  return [
+    {
+      packageJson: { name: "pkg-a" },
+      dir: "/pkg-a",
+    },
+    {
+      packageJson: { name: "pkg-b" },
+      dir: "/pkg-b",
+    },
+  ];
+});
+
+it("should skip questions when allChanged, minor and summary flags passed in", async () => {
+  const cwd = await testdir({
+    "package.json": JSON.stringify({
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    "packages/pkg-a/package.json": JSON.stringify({
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: {
+        "pkg-b": "1.0.0",
+      },
+    }),
+    "packages/pkg-b/package.json": JSON.stringify({
+      name: "pkg-b",
+      version: "1.0.0",
+    }),
+  });
+
+  await addChangeset(
+    cwd,
+    { empty: false, allChanged: true, minor: true, summary: "foo-bar" },
+    {
+      ...defaultConfig,
+    }
+  );
+
+  // @ts-ignore
+  const call = writeChangeset.mock.calls[0][0];
+  expect(call).toEqual(
+    expect.objectContaining({
+      summary: "foo-bar",
+      releases: [
+        { name: "pkg-a", type: "minor" },
+        { name: "pkg-b", type: "minor" },
+      ],
+    })
+  );
+  // @ts-ignore
+  jest.unmock("../../../utils/versionablePackages");
+});

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -110,7 +110,7 @@ export default async function createChangeset(
   takeAllChanged: boolean,
   minor: boolean,
   patch: boolean,
-  preparedSummary: string
+  preparedSummary: string | undefined
 ): Promise<{ confirmed: boolean; summary: string; releases: Array<Release> }> {
   const releases: Array<Release> = [];
 

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -115,10 +115,9 @@ export default async function createChangeset(
   const releases: Array<Release> = [];
 
   if (allPackages.length > 1) {
-    const packagesToRelease = takeAllChanged ? changedPackages : await getPackagesToRelease(
-      changedPackages,
-      allPackages
-    );
+    const packagesToRelease = takeAllChanged
+      ? changedPackages
+      : await getPackagesToRelease(changedPackages, allPackages);
 
     let pkgJsonsByName = getPkgJsonsByName(allPackages);
 
@@ -180,7 +179,7 @@ export default async function createChangeset(
       if (minor) {
         pkgsThatShouldBeMinorBumped = [...pkgsLeftToGetBumpTypeFor];
       } else if (patch) {
-        pkgsThatShouldBeMinorBumped = []
+        pkgsThatShouldBeMinorBumped = [];
       } else {
         pkgsThatShouldBeMinorBumped = (
           await cli.askCheckboxPlus(
@@ -257,7 +256,7 @@ export default async function createChangeset(
     log(gray("  (submit empty line to open external editor)"));
   }
 
-  let summary = preparedSummary || await cli.askQuestion("Summary");
+  let summary = preparedSummary || (await cli.askQuestion("Summary"));
   if (summary.length === 0) {
     try {
       summary = cli.askQuestionWithEditor(

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -254,9 +254,15 @@ export default async function createChangeset(
       "Please enter a summary for this change (this will be in the changelogs)."
     );
     log(gray("  (submit empty line to open external editor)"));
+  } else {
+    return {
+      confirmed: true,
+      summary: preparedSummary,
+      releases,
+    };
   }
 
-  let summary = preparedSummary || (await cli.askQuestion("Summary"));
+  let summary = await cli.askQuestion("Summary");
   if (summary.length === 0) {
     try {
       summary = cli.askQuestionWithEditor(

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -18,13 +18,20 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open, allChanged, minor, patch, summary }: {
+  {
+    empty,
+    open,
+    allChanged,
+    minor,
+    patch,
+    summary,
+  }: {
     empty?: boolean;
-    open?: boolean,
-    allChanged?: boolean,
-    minor?: boolean,
-    patch?: boolean,
-    summary?: string
+    open?: boolean;
+    allChanged?: boolean;
+    minor?: boolean;
+    patch?: boolean;
+    summary?: string;
   },
   config: Config
 ): Promise<void> {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -18,7 +18,14 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open }: { empty?: boolean; open?: boolean },
+  { empty, open, allChanged, minor, patch, summary }: {
+    empty?: boolean;
+    open?: boolean,
+    allChanged?: boolean,
+    minor?: boolean,
+    patch?: boolean,
+    summary?: string
+  },
   config: Config
 ): Promise<void> {
   const packages = await getPackages(cwd);
@@ -72,7 +79,11 @@ export default async function add(
 
     newChangeset = await createChangeset(
       changedPackagesNames,
-      versionablePackages
+      versionablePackages,
+      !!allChanged,
+      !!minor,
+      !!patch,
+      summary
     );
     printConfirmationMessage(newChangeset, versionablePackages.length > 1);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ import { run } from "./run";
 const args = process.argv.slice(2);
 
 const parsed = mri(args, {
-  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot"],
+  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot", "allChanged", "minor", "patch"],
   string: [
     "output",
     "otp",
@@ -16,6 +16,7 @@ const parsed = mri(args, {
     "tag",
     "snapshot",
     "snapshotPrereleaseTemplate",
+    "summary"
   ],
   alias: {
     // Short flags
@@ -93,7 +94,7 @@ ${format("", err).replace(process.cwd(), "<cwd>")}
 - @changesets/cli@${
         // eslint-disable-next-line import/no-extraneous-dependencies
         require("@changesets/cli/package.json").version
-      }
+        }
 - node@${process.version}
 
 ## Extra details

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,17 @@ import { run } from "./run";
 const args = process.argv.slice(2);
 
 const parsed = mri(args, {
-  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot", "allChanged", "minor", "patch"],
+  boolean: [
+    "sinceMaster",
+    "verbose",
+    "empty",
+    "open",
+    "gitTag",
+    "snapshot",
+    "allChanged",
+    "minor",
+    "patch",
+  ],
   string: [
     "output",
     "otp",
@@ -16,7 +26,7 @@ const parsed = mri(args, {
     "tag",
     "snapshot",
     "snapshotPrereleaseTemplate",
-    "summary"
+    "summary",
   ],
   alias: {
     // Short flags
@@ -94,7 +104,7 @@ ${format("", err).replace(process.cwd(), "<cwd>")}
 - @changesets/cli@${
         // eslint-disable-next-line import/no-extraneous-dependencies
         require("@changesets/cli/package.json").version
-        }
+      }
 - node@${process.version}
 
 ## Extra details

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -85,6 +85,10 @@ export async function run(
       tag,
       open,
       gitTag,
+      allChanged,
+      minor,
+      patch,
+      summary
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -106,7 +110,7 @@ export async function run(
 
     switch (input[0]) {
       case "add": {
-        await add(cwd, { empty, open }, config);
+        await add(cwd, { empty, open, allChanged, minor, patch, summary }, config);
         return;
       }
       case "version": {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -88,7 +88,7 @@ export async function run(
       allChanged,
       minor,
       patch,
-      summary
+      summary,
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -110,7 +110,11 @@ export async function run(
 
     switch (input[0]) {
       case "add": {
-        await add(cwd, { empty, open, allChanged, minor, patch, summary }, config);
+        await add(
+          cwd,
+          { empty, open, allChanged, minor, patch, summary },
+          config
+        );
         return;
       }
       case "version": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -12,6 +12,11 @@ export type CliOptions = {
   tag?: string;
   gitTag?: boolean;
   open?: boolean;
+  allChanged?: boolean;
+  major?: boolean;
+  minor?: boolean;
+  patch?: boolean;
+  summary?: string;
 };
 
 export type CommandOptions = CliOptions & {


### PR DESCRIPTION
addresses #1698 

Adds cli arguments to skip questions:  
* `--all-changed` - for automatically selecting all changed packages. 
* `--minor` - for automatically marking them all as minor changes.  
* `--patch` - for automatically marking them all as patches.  
* `--summary` - to add a given summary.  

All of these can work separately to skip just some of the questions.