### PR TITLE
docs(readme): updated leftover

### DIFF
--- a/.changeset/kind-numbers-refuse.md
+++ b/.changeset/kind-numbers-refuse.md
@@ -1,0 +1,6 @@
+---
+"@changesets/cli": patch
+"@changesets/get-github-info": patch
+---
+
+docs(readmes): updated previous GitHub org leftovers

--- a/.changeset/kind-numbers-refuse.md
+++ b/.changeset/kind-numbers-refuse.md
@@ -1,6 +1,0 @@
----
-"@changesets/cli": patch
-"@changesets/get-github-info": patch
----
-
-docs(readmes): updated previous GitHub org leftovers

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 [![npm package](https://img.shields.io/npm/v/@changesets/cli)](https://npmjs.com/package/@changesets/cli)
 [![View changelog](https://img.shields.io/badge/Explore%20Changelog-brightgreen)](./CHANGELOG.md)
 
-The primary implementation of [changesets](https://github.com/Noviny/changesets). Helps you manage the versioning
+The primary implementation of [changesets](https://github.com/changesets/changesets). Helps you manage the versioning
 and changelog entries for your packages, with a focus on versioning within a mono-repository (though we support
 single-package repositories too).
 

--- a/packages/get-github-info/README.md
+++ b/packages/get-github-info/README.md
@@ -37,7 +37,7 @@ const getReleaseLine = async (changeset, type) => {
   // but it also exposes a set of links for the commit, PR and GH username
   let { user, pull, links } = await getInfo({
     // replace this with your own repo
-    repo: "Noviny/changesets",
+    repo: "changesets/changesets",
     commit: changeset.commit,
   });
   let returnVal = `- ${links.commit}${


### PR DESCRIPTION
switched https://github.com/Noviny/changesets to https://github.com/changesets/changesets for the README.

There are still further old org names in CHANGELOG files, didn't touch those.