### PR TITLE
Add --enable-pnpm-catalog flag to opt into pnpm workspace catalog detection

### DIFF
--- a/.changeset/kind-radios-make.md
+++ b/.changeset/kind-radios-make.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Add --enable-pnpm-catalog flag to opt into pnpm workspace catalog detection

--- a/.changeset/tender-socks-tie.md
+++ b/.changeset/tender-socks-tie.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": minor
+---
+
+Add support for catalog feature with pnpm workspace

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -3,10 +3,10 @@
 The command line for changesets is the main way of interacting with it. There are 4 main commands. If you are looking for how we recommend you setup and manage changesets with the commands, check out our [intro to using changesets](./intro-to-using-changesets.md)
 
 - init
-- add [--empty][--open]
+- add [--empty][--open][--enable-pnpm-catalog]
 - version [--ignore, --snapshot]
 - publish [--otp=code, --tag]
-- status [--since=master --verbose --output=JSON_FILE.json]
+- status [--since=master --verbose --output=JSON_FILE.json --enable-pnpm-catalog]
 - pre [exit|enter {tag}]
 - tag
 
@@ -65,6 +65,7 @@ A changeset created with the empty flag would look like this:
 If you set the commit option in the config, the command will add the updated changeset files and then commit them.
 
 - `--open` - opens the created changeset in an external editor
+- `--enable-pnpm-catalog` - surface packages whose versions resolve through pnpm's catalog feature so they can be included in a changeset; by default catalog-only edits are ignored.
 
 ## version
 
@@ -130,6 +131,8 @@ The status command provides information about the changesets that currently exis
 - `--output` - allows you to write the JSON object of the status output for consumption by other tools, such as CI.
 
 - `--since` - to only display information about changesets since a specific branch or git tag (such as `main`, or the git hash of latest). While this can be used to add a CI check for changesets, we recommend not doing this. We instead recommend using the [changeset bot](https://github.com/apps/changeset-bot) to detect pull requests missing changesets, as not all pull requests need one if you are on GitHub.
+
+- `--enable-pnpm-catalog` - treat pnpm catalog entries as dependency updates when determining whether packages have changed. Without the flag, catalog-only edits are ignored so existing release flows stay the same.
 
 > NOTE: `status` will fail if you are in the middle of running `version` or `publish`. If you want to get changeset status at the time of a version increase and publish, you need to run it immediately before running `version`.
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -18,7 +18,11 @@ import printConfirmationMessage from "./messages";
 
 export default async function add(
   cwd: string,
-  { empty, open }: { empty?: boolean; open?: boolean },
+  {
+    empty,
+    open,
+    enablePnpmCatalog,
+  }: { empty?: boolean; open?: boolean; enablePnpmCatalog?: boolean },
   config: Config
 ): Promise<void> {
   const packages = await getPackages(cwd);
@@ -59,6 +63,7 @@ export default async function add(
       changedPackagesNames = (
         await getVersionableChangedPackages(config, {
           cwd,
+          enablePnpmCatalog,
         })
       ).map((pkg) => pkg.packageJson.name);
     } catch (e: any) {

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -18,11 +18,13 @@ export default async function status(
     since,
     verbose,
     output,
+    enablePnpmCatalog,
   }: {
     sinceMaster?: boolean;
     since?: string;
     verbose?: boolean;
     output?: string;
+    enablePnpmCatalog?: boolean;
   },
   config: Config
 ) {
@@ -39,6 +41,7 @@ export default async function status(
   const changedPackages = await getVersionableChangedPackages(config, {
     cwd,
     ref: sinceBranch,
+    enablePnpmCatalog,
   });
 
   if (changedPackages.length > 0 && changesets.length === 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,15 @@ import { run } from "./run";
 const args = process.argv.slice(2);
 
 const parsed = mri(args, {
-  boolean: ["sinceMaster", "verbose", "empty", "open", "gitTag", "snapshot"],
+  boolean: [
+    "sinceMaster",
+    "verbose",
+    "empty",
+    "open",
+    "gitTag",
+    "snapshot",
+    "enablePnpmCatalog",
+  ],
   string: [
     "output",
     "otp",
@@ -25,6 +33,7 @@ const parsed = mri(args, {
     "since-master": "sinceMaster",
     "git-tag": "gitTag",
     "snapshot-prerelease-template": "snapshotPrereleaseTemplate",
+    "enable-pnpm-catalog": "enablePnpmCatalog",
     // Deprecated flags
     "update-changelog": "updateChangelog",
     "is-public": "isPublic",
@@ -52,10 +61,10 @@ if (parsed.help && args.length === 1) {
     $ changeset [command]
   Commands
     init
-    add [--empty] [--open]
+    add [--empty] [--open] [--enable-pnpm-catalog]
     version [--ignore] [--snapshot <?name>] [--snapshot-prerelease-template <template>]
     publish [--tag <name>] [--otp <code>] [--no-git-tag]
-    status [--since <branch>] [--verbose] [--output JSON_FILE.json]
+    status [--since <branch>] [--verbose] [--output JSON_FILE.json] [--enable-pnpm-catalog]
     pre <enter|exit> <tag>
     tag
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -64,9 +64,9 @@ export async function run(
   }
 
   if (input.length < 1) {
-    const { empty, open }: CliOptions = flags;
+    const { empty, open, enablePnpmCatalog }: CliOptions = flags;
     // @ts-ignore if this is undefined, we have already exited
-    await add(cwd, { empty, open }, config);
+    await add(cwd, { empty, open, enablePnpmCatalog }, config);
   } else if (input[0] !== "pre" && input.length > 1) {
     error(
       "Too many arguments passed to changesets - we only accept the command name as an argument"
@@ -85,6 +85,7 @@ export async function run(
       tag,
       open,
       gitTag,
+      enablePnpmCatalog,
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -106,7 +107,7 @@ export async function run(
 
     switch (input[0]) {
       case "add": {
-        await add(cwd, { empty, open }, config);
+        await add(cwd, { empty, open, enablePnpmCatalog }, config);
         return;
       }
       case "version": {
@@ -195,7 +196,11 @@ export async function run(
         return;
       }
       case "status": {
-        await status(cwd, { sinceMaster, since, verbose, output }, config);
+        await status(
+          cwd,
+          { sinceMaster, since, verbose, output, enablePnpmCatalog },
+          config
+        );
         return;
       }
       case "tag": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -12,6 +12,7 @@ export type CliOptions = {
   tag?: string;
   gitTag?: boolean;
   open?: boolean;
+  enablePnpmCatalog?: boolean;
 };
 
 export type CommandOptions = CliOptions & {

--- a/packages/cli/src/utils/versionablePackages.ts
+++ b/packages/cli/src/utils/versionablePackages.ts
@@ -2,26 +2,27 @@ import { Config } from "@changesets/types";
 import { getChangedPackagesSinceRef } from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 
+type ChangedPackageOptions = {
+  cwd: string;
+  ref?: string;
+  enablePnpmCatalog?: boolean;
+};
+
 export async function getVersionableChangedPackages(
   config: Config,
-  {
-    cwd,
-    ref,
-  }: {
-    cwd: string;
-    ref?: string;
-  }
+  options: ChangedPackageOptions
 ) {
+  const { cwd, ref, enablePnpmCatalog } = options;
   const changedPackages = await getChangedPackagesSinceRef({
     ref: ref ?? config.baseBranch,
     changedFilePatterns: config.changedFilePatterns,
     cwd,
+    includeCatalogUpdates: enablePnpmCatalog ?? false,
   });
-  return changedPackages.filter(
-    (pkg) =>
-      !shouldSkipPackage(pkg, {
-        ignore: config.ignore,
-        allowPrivatePackages: config.privatePackages.version,
-      })
-  );
+  return changedPackages.filter((pkg) => {
+    return !shouldSkipPackage(pkg, {
+      ignore: config.ignore,
+      allowPrivatePackages: config.privatePackages.version,
+    });
+  });
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -22,6 +22,7 @@
     "@changesets/errors": "^0.2.0",
     "@manypkg/get-packages": "^1.1.3",
     "is-subdir": "^1.1.1",
+    "js-yaml": "^3.13.1",
     "micromatch": "^4.0.8",
     "spawndamnit": "^3.0.1"
   },


### PR DESCRIPTION
When using pnpm workspaces with the catalog feature, updating a dependency version in the catalog section of pnpm-workspace.yaml is detected as a change by changesets.

Allow `changeset add` and `changeset status` to include updates from pnpm workspace catalogs when requested via the new flag.

Fixes #1707 