### PR TITLE
chore: add more robust error handling to get-github-info

### DIFF
--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -105,9 +105,13 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     } catch (parseError) {
       const responseText = await response.text();
       if (!response.ok) {
-        throw new Error(`GitHub API request failed with status ${response.status}: ${response.statusText}\nResponse: ${responseText}`);
+        throw new Error(
+          `GitHub API request failed with status ${response.status}: ${response.statusText}\nResponse: ${responseText}`
+        );
       }
-      throw new Error(`Failed to parse response as JSON: ${parseError}\nResponse: ${responseText}`);
+      throw new Error(
+        `Failed to parse response as JSON: ${parseError}\nResponse: ${responseText}`
+      );
     }
 
     return responseData;

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -98,7 +98,20 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
       Authorization: `Token ${process.env.GITHUB_TOKEN}`,
     },
     body: JSON.stringify({ query: makeQuery(repos) }),
-  }).then((x: any) => x.json());
+  }).then(async (response: any) => {
+    let responseData;
+    try {
+      responseData = await response.json();
+    } catch (parseError) {
+      const responseText = await response.text();
+      if (!response.ok) {
+        throw new Error(`GitHub API request failed with status ${response.status}: ${response.statusText}\nResponse: ${responseText}`);
+      }
+      throw new Error(`Failed to parse response as JSON: ${parseError}\nResponse: ${responseText}`);
+    }
+
+    return responseData;
+  });
 
   if (data.errors) {
     throw new Error(


### PR DESCRIPTION
Adds check for when response.json() fails after fetching GitHub information to provide more error information