### PR TITLE
Replace `strip-ansi` with `node:util#stripVTControlCharacters`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,6 @@
     "@types/semver": "^7.5.0",
     "human-id": "^4.1.1",
     "outdent": "^0.8.0",
-    "strip-ansi": "^7.1.0",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import path from "path";
-import stripAnsi from "strip-ansi";
+import { stripVTControlCharacters } from "node:util";
 import * as git from "@changesets/git";
 import { defaultConfig } from "@changesets/config";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
@@ -72,7 +72,7 @@ const mockUserResponses = (mockResponses: {
     mockedUtils.askQuestion.mockResolvedValue(summary);
   }
   mockedUtils.askConfirm.mockImplementation(async (question) => {
-    question = stripAnsi(question);
+    question = stripVTControlCharacters(question);
     if (confirmAnswers[question]) {
       return confirmAnswers[question];
     }
@@ -168,7 +168,7 @@ describe("Add command", () => {
     mockedUtils.askQuestion.mockResolvedValue("");
     mockedUtils.askQuestionWithEditor.mockReturnValueOnce(summary);
     mockedUtils.askConfirm.mockImplementation(async (question) => {
-      question = stripAnsi(question);
+      question = stripVTControlCharacters(question);
       if (confirmAnswers[question]) {
         return confirmAnswers[question];
       }

--- a/packages/get-dependents-graph/package.json
+++ b/packages/get-dependents-graph/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@changesets/test-utils": "0.0.9-next.0",
-    "strip-ansi": "^7.1.0",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/packages/get-dependents-graph/src/get-dependency-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import stripAnsi from "strip-ansi";
+import { stripVTControlCharacters } from "node:util";
 import { temporarilySilenceLogs } from "@changesets/test-utils";
 import getDependencyGraph from "./get-dependency-graph.ts";
 
@@ -109,7 +109,9 @@ describe("getting the dependency graph", function () {
       });
       expect(valid).toBeFalsy();
       expect((console.error as any).mock.calls).toHaveLength(1);
-      expect(stripAnsi((console.error as any).mock.calls[0][0])).toBe(
+      expect(
+        stripVTControlCharacters((console.error as any).mock.calls[0][0])
+      ).toBe(
         `Package "foo" must depend on the current version of "bar": "1.0.0" vs "link:../bar"`
       );
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,7 +4774,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1, strip-ansi@^7.1.0:
+strip-ansi@^7.0.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==


### PR DESCRIPTION
Part of the test improvements removed from #1737

Replaces `strip-ansi` with the node built-in added in node 16