### PR TITLE
Replace `file-url` with `node:url#pathToFileUrl`

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -17,8 +17,7 @@
   },
   "devDependencies": {
     "@changesets/test-utils": "0.0.9-next.0",
-    "@changesets/write": "1.0.0-next.0",
-    "file-url": "^3.0.0"
+    "@changesets/write": "1.0.0-next.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import spawn from "spawndamnit";
-import fileUrl from "file-url";
+import { pathToFileURL } from "node:url";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from "vitest";
 import { gitdir, outputFile, tempdir } from "@changesets/test-utils";
@@ -295,7 +295,13 @@ describe("git", () => {
           "git",
           // Note: a file:// URL is needed in order to make a shallow clone of
           // a local repo
-          ["clone", "--depth", depth.toString(), fileUrl(cwd), "."],
+          [
+            "clone",
+            "--depth",
+            depth.toString(),
+            pathToFileURL(cwd).toString(),
+            ".",
+          ],
           {
             cwd: cloneDir,
           }

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -22,7 +22,6 @@
     "@changesets/git": "4.0.0-next.0",
     "@changesets/test-utils": "0.0.9-next.0",
     "@changesets/write": "1.0.0-next.0",
-    "file-url": "^3.0.0",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@changesets/test-utils";
 import type { Changeset } from "@changesets/types";
 import writeChangeset from "@changesets/write";
-import fileUrl from "file-url";
+import { pathToFileURL } from "node:url";
 import fs from "node:fs/promises";
 import path from "path";
 import spawn from "spawndamnit";
@@ -39,7 +39,7 @@ async function setupRepoAndClone(cwd: string) {
     "git",
     // Note: a file:// URL is needed in order to make a shallow clone of
     // a local repo
-    ["clone", "--depth", "1", fileUrl(cwd), "."],
+    ["clone", "--depth", "1", pathToFileURL(cwd).toString(), "."],
     {
       cwd: clone,
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,11 +2778,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-url@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
-  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"


### PR DESCRIPTION
Part of the test improvements removed from #1737

Replaces `file-url` with the [node built-in](https://nodejs.org/api/url.html#urlpathtofileurlpath-options) added in node 10