### PR TITLE
Replace custom `pathExists` functions with `node:fs#existsSync`

### DIFF
--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   ReleasePlan,
 } from "@changesets/types";
 import * as git from "@changesets/git";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "path";
 import { outdent } from "outdent";
@@ -18,7 +19,6 @@ import { getPackages } from "@manypkg/get-packages";
 import {
   Fixture,
   outputFile,
-  pathExists,
   temporarilySilenceLogs,
   testdir,
 } from "@changesets/test-utils";
@@ -2979,7 +2979,7 @@ describe("apply release plan", () => {
         setupFunc
       );
 
-      let changesetExists = await pathExists(changesetPath);
+      let changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(false);
     });
     it("should NOT delete changesets for ignored packages", async () => {
@@ -3014,7 +3014,7 @@ describe("apply release plan", () => {
         setupFunc
       );
 
-      let changesetExists = await pathExists(changesetPath);
+      let changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(true);
     });
     it("should NOT delete changesets for private unversioned packages", async () => {
@@ -3053,7 +3053,7 @@ describe("apply release plan", () => {
         setupFunc
       );
 
-      let changesetExists = await pathExists(changesetPath);
+      let changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(true);
     });
     it("should delete an old format changeset if it is applied", async () => {
@@ -3104,8 +3104,8 @@ describe("apply release plan", () => {
         setupFunc
       );
 
-      let mdPathExists = await pathExists(changesetMDPath);
-      let JSONPathExists = await pathExists(changesetJSONPath);
+      let mdPathExists = existsSync(changesetMDPath);
+      let JSONPathExists = existsSync(changesetJSONPath);
 
       expect(mdPathExists).toEqual(false);
       expect(JSONPathExists).toEqual(false);
@@ -3280,7 +3280,7 @@ describe("apply release plan", () => {
         setupFunc
       );
 
-      let changesetExists = await pathExists(changesetPath);
+      let changesetExists = existsSync(changesetPath);
 
       expect(changesetExists).toEqual(false);
 

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "path";
 import { defaultWrittenConfig } from "@changesets/config";
-import {
-  pathExists,
-  silenceLogsInBlock,
-  testdir,
-} from "@changesets/test-utils";
+import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 
 import initializeCommand from "../index.ts";
 
@@ -21,11 +18,11 @@ describe("init", () => {
     const cwd = await testdir({});
     const { readmePath, configPath } = getPaths(cwd);
 
-    expect(await pathExists(readmePath)).toBe(false);
-    expect(await pathExists(configPath)).toBe(false);
+    expect(existsSync(readmePath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
     await initializeCommand(cwd);
-    expect(await pathExists(readmePath)).toBe(true);
-    expect(await pathExists(configPath)).toBe(true);
+    expect(existsSync(readmePath)).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
   });
   it("should write the default config if it doesn't exist", async () => {
     const cwd = await testdir({

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import path from "path";
+import path from "node:path";
 import pc from "picocolors";
 
 import { defaultWrittenConfig } from "@changesets/config";
@@ -8,13 +9,6 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
-async function pathExists(p: string) {
-  return fs.access(p).then(
-    () => true,
-    () => false
-  );
-}
-
 const pkgPath = path.dirname(require.resolve("@changesets/cli/package.json"));
 
 const defaultConfig = `${JSON.stringify(defaultWrittenConfig, null, 2)}\n`;
@@ -22,9 +16,9 @@ const defaultConfig = `${JSON.stringify(defaultWrittenConfig, null, 2)}\n`;
 export default async function init(cwd: string) {
   const changesetBase = path.resolve(cwd, ".changeset");
 
-  if (await pathExists(changesetBase)) {
-    if (!(await pathExists(path.join(changesetBase, "config.json")))) {
-      if (await pathExists(path.join(changesetBase, "config.js"))) {
+  if (existsSync(changesetBase)) {
+    if (!existsSync(path.join(changesetBase, "config.json"))) {
+      if (existsSync(path.join(changesetBase, "config.js"))) {
         error(
           "It looks like you're using the version 1 `.changeset/config.js` file"
         );

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -153,14 +153,6 @@ export async function outputFile(
   await fsp.writeFile(filePath, content, encoding);
 }
 
-// `fs.exists` is deprecated, and Node recommends this for asynchronous existence checks.
-export async function pathExists(p: string) {
-  return fsp.access(p).then(
-    () => true,
-    () => false
-  );
-}
-
 export async function linkNodeModules(cwd: string) {
   await fsp.symlink(
     path.join(


### PR DESCRIPTION
Part of the test improvements removed from #1737

Replaces the two custom `pathExists` utility functions with `existsSync`, as the tests don't use the access checks that `pathExists` performs