### PR TITLE
Update `js-yaml` to `v4`

### DIFF
--- a/.changeset/tall-parks-worry.md
+++ b/.changeset/tall-parks-worry.md
@@ -1,0 +1,5 @@
+---
+"@changesets/parse": patch
+---
+
+Update `js-yaml` to `v4`

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/fs-extra": "^5.1.0",
     "@types/jest": "^24.0.12",
     "@types/jest-in-case": "^1.0.6",
-    "@types/js-yaml": "^3.12.1",
     "@types/lodash": "^4.17.13",
     "@types/node": "^22.14.1",
     "@types/prettier": "^2.7.1",

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -20,9 +20,10 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/parse",
   "dependencies": {
     "@changesets/types": "^6.1.0",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "outdent": "^0.5.0"
   }
 }

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -213,6 +213,20 @@ describe("parsing a changeset", () => {
       summary: "Nice simple summary",
     });
   });
+
+  it("should handle package name unquoted and version quoted", () => {
+    const changesetMd = `---
+    pkg: "minor"
+    ---
+
+    something`;
+    const changeset = parse(changesetMd);
+    expect(changeset).toEqual({
+      releases: [{ name: "pkg", type: "minor" }],
+      summary: "something",
+    });
+  });
+
   it("should throw if the frontmatter is followed by non-whitespace characters on the same line", () => {
     const changesetMd = outdent`---
     "cool-package": minor
@@ -225,6 +239,23 @@ describe("parsing a changeset", () => {
       "could not parse changeset - invalid frontmatter: ---
       "cool-package": minor
       ---  fail
+
+      Nice simple summary"
+    `);
+  });
+
+  it("should throw when frontmatter hasn't a valid yml structure", () => {
+    const changesetMd = outdent`---
+    : minor
+    ---
+
+    Nice simple summary
+    `;
+
+    expect(() => parse(changesetMd)).toThrowErrorMatchingInlineSnapshot(`
+      "could not parse changeset - invalid frontmatter: ---
+      : minor
+      ---
 
       Nice simple summary"
     `);

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -18,8 +18,10 @@ export default function parseChangesetFile(contents: string): {
 
   let releases: Release[];
   try {
-    const yamlStuff: { [key: string]: VersionType } =
-      yaml.safeLoad(roughReleases);
+    const yamlStuff = yaml.load(roughReleases) as
+      | Record<string, VersionType>
+      | undefined;
+
     if (yamlStuff) {
       releases = Object.entries(yamlStuff).map(([name, type]) => ({
         name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,10 +1777,10 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/js-yaml@^3.12.1":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.1.tgz#5c6f4a1eabca84792fbd916f0cb40847f123c656"
-  integrity sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
 "@types/json-schema@^7.0.9":
   version "7.0.11"
@@ -4611,6 +4611,13 @@ js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Closes #1762 

Followup of https://github.com/changesets/changesets/pull/1764#issuecomment-3540482892

> For now, I'd prefer to update the dependency instead to avoid some unexpected weird breaks.
