### PR TITLE
feat(cli): add Bun support for publishing packages

### DIFF
--- a/.changeset/sour-moments-feel.md
+++ b/.changeset/sour-moments-feel.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Add Bun support for publishing packages. When a project uses Bun as its package manager (detected via `bun.lockb` or `packageManager` field), changesets will now use `bun publish` instead of `npm publish`.

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -148,6 +148,33 @@ describe("npm-utils", () => {
       );
     });
 
+    it("should use pnpm publish without --no-git-checks when version check fails", async () => {
+      mockDetect.mockResolvedValue({
+        name: "pnpm",
+        agent: "pnpm@8.0.0",
+      });
+      // Mock pnpm version check to fail
+      mockSpawn
+        .mockRejectedValueOnce(new Error("pnpm not found"))
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from(""),
+        } as any);
+
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      // Second call is publish without --no-git-checks
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        "pnpm",
+        ["publish", "--json", "--access", "public", "--tag", "latest"],
+        expect.objectContaining({
+          cwd: "/test/cwd",
+        })
+      );
+    });
+
     it("should use npm publish when npm is detected", async () => {
       mockDetect.mockResolvedValue({
         name: "npm",

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -141,7 +141,15 @@ describe("npm-utils", () => {
       expect(mockSpawn).toHaveBeenNthCalledWith(
         2,
         "pnpm",
-        ["publish", "--json", "--access", "public", "--tag", "latest", "--no-git-checks"],
+        [
+          "publish",
+          "--json",
+          "--access",
+          "public",
+          "--tag",
+          "latest",
+          "--no-git-checks",
+        ],
         expect.objectContaining({
           cwd: "/test/cwd",
         })
@@ -190,7 +198,15 @@ describe("npm-utils", () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         "npm",
-        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        [
+          "publish",
+          "/test/publish-dir",
+          "--json",
+          "--access",
+          "public",
+          "--tag",
+          "latest",
+        ],
         expect.any(Object)
       );
     });
@@ -210,7 +226,15 @@ describe("npm-utils", () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         "npm",
-        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        [
+          "publish",
+          "/test/publish-dir",
+          "--json",
+          "--access",
+          "public",
+          "--tag",
+          "latest",
+        ],
         expect.any(Object)
       );
     });
@@ -227,7 +251,15 @@ describe("npm-utils", () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         "npm",
-        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        [
+          "publish",
+          "/test/publish-dir",
+          "--json",
+          "--access",
+          "public",
+          "--tag",
+          "latest",
+        ],
         expect.any(Object)
       );
     });

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -91,7 +91,7 @@ describe("npm-utils", () => {
     it("should use bun publish when bun is detected", async () => {
       mockDetect.mockResolvedValue({
         name: "bun",
-        agent: "bun@1.0.0",
+        agent: "bun",
       });
       mockSpawn.mockResolvedValue({
         code: 0,
@@ -113,7 +113,7 @@ describe("npm-utils", () => {
     it("should use pnpm publish when pnpm is detected", async () => {
       mockDetect.mockResolvedValue({
         name: "pnpm",
-        agent: "pnpm@8.0.0",
+        agent: "pnpm",
       });
       // Mock pnpm version check
       mockSpawn
@@ -151,7 +151,7 @@ describe("npm-utils", () => {
     it("should use pnpm publish without --no-git-checks when version check fails", async () => {
       mockDetect.mockResolvedValue({
         name: "pnpm",
-        agent: "pnpm@8.0.0",
+        agent: "pnpm",
       });
       // Mock pnpm version check to fail
       mockSpawn
@@ -178,7 +178,7 @@ describe("npm-utils", () => {
     it("should use npm publish when npm is detected", async () => {
       mockDetect.mockResolvedValue({
         name: "npm",
-        agent: "npm@10.0.0",
+        agent: "npm",
       });
       mockSpawn.mockResolvedValue({
         code: 0,
@@ -198,7 +198,7 @@ describe("npm-utils", () => {
     it("should use npm publish when yarn is detected (yarn uses npm for publishing)", async () => {
       mockDetect.mockResolvedValue({
         name: "yarn",
-        agent: "yarn@1.22.0",
+        agent: "yarn",
       });
       mockSpawn.mockResolvedValue({
         code: 0,
@@ -233,7 +233,7 @@ describe("npm-utils", () => {
     });
 
     it("should return published: true when publish succeeds", async () => {
-      mockDetect.mockResolvedValue({ name: "bun", agent: "bun@1.0.0" });
+      mockDetect.mockResolvedValue({ name: "bun", agent: "bun" });
       mockSpawn.mockResolvedValue({
         code: 0,
         stdout: Buffer.from(""),
@@ -246,7 +246,7 @@ describe("npm-utils", () => {
     });
 
     it("should return published: false when publish fails", async () => {
-      mockDetect.mockResolvedValue({ name: "bun", agent: "bun@1.0.0" });
+      mockDetect.mockResolvedValue({ name: "bun", agent: "bun" });
       mockSpawn.mockResolvedValue({
         code: 1,
         stdout: Buffer.from(""),

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,0 +1,116 @@
+import { getCorrectRegistry } from "../npm-utils";
+
+// Mock package-manager-detector
+jest.mock("package-manager-detector", () => ({
+  detect: jest.fn(),
+}));
+
+// Mock spawndamnit
+jest.mock("spawndamnit", () => jest.fn());
+
+import { detect } from "package-manager-detector";
+import spawn from "spawndamnit";
+
+describe("npm-utils", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getCorrectRegistry", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("should return default registry when no config", () => {
+      const result = getCorrectRegistry({ name: "test-pkg", version: "1.0.0" });
+      expect(result.registry).toBe("https://registry.npmjs.org");
+      expect(result.scope).toBeUndefined();
+    });
+
+    it("should return scoped registry for scoped packages", () => {
+      const result = getCorrectRegistry({
+        name: "@scope/test-pkg",
+        version: "1.0.0",
+        publishConfig: {
+          "@scope:registry": "https://custom.registry.com",
+        },
+      });
+      expect(result.registry).toBe("https://custom.registry.com");
+      expect(result.scope).toBe("@scope");
+    });
+
+    it("should return publishConfig registry", () => {
+      const result = getCorrectRegistry({
+        name: "test-pkg",
+        version: "1.0.0",
+        publishConfig: {
+          registry: "https://custom.registry.com",
+        },
+      });
+      expect(result.registry).toBe("https://custom.registry.com");
+    });
+
+    it("should convert yarnpkg registry to npmjs", () => {
+      const result = getCorrectRegistry({
+        name: "test-pkg",
+        version: "1.0.0",
+        publishConfig: {
+          registry: "https://registry.yarnpkg.com",
+        },
+      });
+      expect(result.registry).toBe("https://registry.npmjs.org");
+    });
+  });
+
+  describe("getPublishTool detection", () => {
+    // Note: getPublishTool is not exported, but we can test its behavior
+    // through the publish function behavior or by refactoring to export it
+
+    it("should detect bun when bun.lockb is present", async () => {
+      (detect as jest.Mock).mockResolvedValue({
+        name: "bun",
+        agent: "bun",
+      });
+
+      // The detect function should return bun
+      const result = await detect({ cwd: "/test" });
+      expect(result?.name).toBe("bun");
+    });
+
+    it("should detect pnpm when pnpm-lock.yaml is present", async () => {
+      (detect as jest.Mock).mockResolvedValue({
+        name: "pnpm",
+        agent: "pnpm",
+      });
+
+      const result = await detect({ cwd: "/test" });
+      expect(result?.name).toBe("pnpm");
+    });
+
+    it("should detect yarn when yarn.lock is present", async () => {
+      (detect as jest.Mock).mockResolvedValue({
+        name: "yarn",
+        agent: "yarn",
+      });
+
+      const result = await detect({ cwd: "/test" });
+      expect(result?.name).toBe("yarn");
+    });
+
+    it("should detect npm when package-lock.json is present", async () => {
+      (detect as jest.Mock).mockResolvedValue({
+        name: "npm",
+        agent: "npm",
+      });
+
+      const result = await detect({ cwd: "/test" });
+      expect(result?.name).toBe("npm");
+    });
+  });
+});

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,4 +1,6 @@
-import { getCorrectRegistry } from "../npm-utils";
+import { getCorrectRegistry, publish } from "../npm-utils";
+import { detect } from "package-manager-detector";
+import spawn from "spawndamnit";
 
 // Mock package-manager-detector
 jest.mock("package-manager-detector", () => ({
@@ -8,8 +10,13 @@ jest.mock("package-manager-detector", () => ({
 // Mock spawndamnit
 jest.mock("spawndamnit", () => jest.fn());
 
-import { detect } from "package-manager-detector";
-import spawn from "spawndamnit";
+// Mock ci-info
+jest.mock("ci-info", () => ({
+  isCI: true,
+}));
+
+const mockDetect = detect as jest.MockedFunction<typeof detect>;
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
 describe("npm-utils", () => {
   beforeEach(() => {
@@ -68,49 +75,160 @@ describe("npm-utils", () => {
     });
   });
 
-  describe("getPublishTool detection", () => {
-    // Note: getPublishTool is not exported, but we can test its behavior
-    // through the publish function behavior or by refactoring to export it
+  describe("publish", () => {
+    const packageJson = { name: "test-pkg", version: "1.0.0" };
+    const publishOpts = {
+      cwd: "/test/cwd",
+      publishDir: "/test/publish-dir",
+      access: "public" as const,
+      tag: "latest",
+    };
+    const twoFactorState = {
+      token: null,
+      isRequired: Promise.resolve(false),
+    };
 
-    it("should detect bun when bun.lockb is present", async () => {
-      (detect as jest.Mock).mockResolvedValue({
+    it("should use bun publish when bun is detected", async () => {
+      mockDetect.mockResolvedValue({
         name: "bun",
-        agent: "bun",
+        agent: "bun@1.0.0",
       });
+      mockSpawn.mockResolvedValue({
+        code: 0,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(""),
+      } as any);
 
-      // The detect function should return bun
-      const result = await detect({ cwd: "/test" });
-      expect(result?.name).toBe("bun");
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "bun",
+        ["publish", "--access", "public", "--tag", "latest"],
+        expect.objectContaining({
+          cwd: "/test/publish-dir",
+        })
+      );
     });
 
-    it("should detect pnpm when pnpm-lock.yaml is present", async () => {
-      (detect as jest.Mock).mockResolvedValue({
+    it("should use pnpm publish when pnpm is detected", async () => {
+      mockDetect.mockResolvedValue({
         name: "pnpm",
-        agent: "pnpm",
+        agent: "pnpm@8.0.0",
       });
+      // Mock pnpm version check
+      mockSpawn
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: Buffer.from("8.0.0"),
+          stderr: Buffer.from(""),
+        } as any)
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from(""),
+        } as any);
 
-      const result = await detect({ cwd: "/test" });
-      expect(result?.name).toBe("pnpm");
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      // First call is version check
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        1,
+        "pnpm",
+        ["--version"],
+        expect.any(Object)
+      );
+      // Second call is publish
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        "pnpm",
+        ["publish", "--json", "--access", "public", "--tag", "latest", "--no-git-checks"],
+        expect.objectContaining({
+          cwd: "/test/cwd",
+        })
+      );
     });
 
-    it("should detect yarn when yarn.lock is present", async () => {
-      (detect as jest.Mock).mockResolvedValue({
-        name: "yarn",
-        agent: "yarn",
-      });
-
-      const result = await detect({ cwd: "/test" });
-      expect(result?.name).toBe("yarn");
-    });
-
-    it("should detect npm when package-lock.json is present", async () => {
-      (detect as jest.Mock).mockResolvedValue({
+    it("should use npm publish when npm is detected", async () => {
+      mockDetect.mockResolvedValue({
         name: "npm",
-        agent: "npm",
+        agent: "npm@10.0.0",
       });
+      mockSpawn.mockResolvedValue({
+        code: 0,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(""),
+      } as any);
 
-      const result = await detect({ cwd: "/test" });
-      expect(result?.name).toBe("npm");
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npm",
+        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        expect.any(Object)
+      );
+    });
+
+    it("should use npm publish when yarn is detected (yarn uses npm for publishing)", async () => {
+      mockDetect.mockResolvedValue({
+        name: "yarn",
+        agent: "yarn@1.22.0",
+      });
+      mockSpawn.mockResolvedValue({
+        code: 0,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(""),
+      } as any);
+
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npm",
+        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        expect.any(Object)
+      );
+    });
+
+    it("should fallback to npm when no package manager is detected", async () => {
+      mockDetect.mockResolvedValue(null);
+      mockSpawn.mockResolvedValue({
+        code: 0,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(""),
+      } as any);
+
+      await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npm",
+        ["publish", "/test/publish-dir", "--json", "--access", "public", "--tag", "latest"],
+        expect.any(Object)
+      );
+    });
+
+    it("should return published: true when publish succeeds", async () => {
+      mockDetect.mockResolvedValue({ name: "bun", agent: "bun@1.0.0" });
+      mockSpawn.mockResolvedValue({
+        code: 0,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(""),
+      } as any);
+
+      const result = await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(result.published).toBe(true);
+    });
+
+    it("should return published: false when publish fails", async () => {
+      mockDetect.mockResolvedValue({ name: "bun", agent: "bun@1.0.0" });
+      mockSpawn.mockResolvedValue({
+        code: 1,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from("Error publishing"),
+      } as any);
+
+      const result = await publish(packageJson, publishOpts, twoFactorState);
+
+      expect(result.published).toBe(false);
     });
   });
 });

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -67,24 +67,37 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
 async function getPublishTool(
   cwd: string
-): Promise<{ name: "npm" } | { name: "pnpm"; shouldAddNoGitChecks: boolean }> {
+): Promise<
+  | { name: "npm" }
+  | { name: "pnpm"; shouldAddNoGitChecks: boolean }
+  | { name: "bun" }
+> {
   const pm = await detect({ cwd });
-  if (!pm || pm.name !== "pnpm") return { name: "npm" };
-  try {
-    let result = await spawn("pnpm", ["--version"], { cwd });
-    let version = result.stdout.toString().trim();
-    let parsed = semverParse(version);
-    return {
-      name: "pnpm",
-      shouldAddNoGitChecks:
-        parsed?.major === undefined ? false : parsed.major >= 5,
-    };
-  } catch (e) {
-    return {
-      name: "pnpm",
-      shouldAddNoGitChecks: false,
-    };
+  if (!pm) return { name: "npm" };
+
+  if (pm.name === "bun") {
+    return { name: "bun" };
   }
+
+  if (pm.name === "pnpm") {
+    try {
+      let result = await spawn("pnpm", ["--version"], { cwd });
+      let version = result.stdout.toString().trim();
+      let parsed = semverParse(version);
+      return {
+        name: "pnpm",
+        shouldAddNoGitChecks:
+          parsed?.major === undefined ? false : parsed.major >= 5,
+      };
+    } catch (e) {
+      return {
+        name: "pnpm",
+        shouldAddNoGitChecks: false,
+      };
+    }
+  }
+
+  return { name: "npm" };
 }
 
 export async function getTokenIsRequired() {
@@ -216,6 +229,11 @@ async function internalPublish(
       ? await spawn("pnpm", ["publish", "--json", ...publishFlags], {
           env: Object.assign({}, process.env, envOverride),
           cwd: opts.cwd,
+        })
+      : publishTool.name === "bun"
+      ? await spawn("bun", ["publish", ...publishFlags], {
+          env: Object.assign({}, process.env, envOverride),
+          cwd: opts.publishDir,
         })
       : await spawn(
           publishTool.name,


### PR DESCRIPTION
## Summary
- Add Bun detection in `getPublishTool` using `package-manager-detector`
- Use `bun publish` command when Bun is detected as the package manager
- Add tests for npm-utils including registry configuration and PM detection

## Details

When a project uses Bun as its package manager (detected via `bun.lockb` or `packageManager` field in package.json), changesets will now use `bun publish` instead of `npm publish`.

Bun automatically resolves `workspace:*`, `workspace:^`, and `workspace:~` references to actual version numbers during publish, so no additional changes are needed for workspace protocol handling.

## Test plan
- [x] Added unit tests for `getCorrectRegistry` function
- [x] Added unit tests for package manager detection (bun, pnpm, yarn, npm)
- [x] All existing publish tests pass
- [x] TypeScript compilation passes
- [x] Build succeeds

## Related issues
Closes https://github.com/changesets/changesets/issues/1080 (Bun support request)