### PR TITLE
Update `@manypkg/get-packages` to `v2`

### DIFF
--- a/.changeset/warm-times-hug.md
+++ b/.changeset/warm-times-hug.md
@@ -1,0 +1,14 @@
+---
+"@changesets/assemble-release-plan": minor
+"@changesets/get-dependents-graph": minor
+"@changesets/should-skip-package": minor
+"@changesets/apply-release-plan": minor
+"@changesets/get-release-plan": minor
+"@changesets/release-utils": minor
+"@changesets/config": minor
+"@changesets/cli": minor
+"@changesets/git": minor
+"@changesets/pre": minor
+---
+
+Update `@manypkg/get-packages` to `v2`

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dist
 __fixtures__
+coverage

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -24,7 +24,7 @@
     "@changesets/git": "^3.0.4",
     "@changesets/should-skip-package": "^0.1.2",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "detect-indent": "^6.0.0",
     "fs-extra": "^7.0.1",
     "lodash.startcase": "^4.4.0",

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -71,7 +71,7 @@ export default async function applyReleasePlan(
   snapshot?: string | boolean,
   contextDir = __dirname
 ) {
-  let cwd = packages.root.dir;
+  let cwd = packages.rootPackage!.dir;
 
   let touchedFiles = [];
 

--- a/packages/assemble-release-plan/package.json
+++ b/packages/assemble-release-plan/package.json
@@ -23,7 +23,7 @@
     "@changesets/get-dependents-graph": "^2.1.3",
     "@changesets/should-skip-package": "^0.1.2",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "semver": "^7.5.3"
   },
   "devDependencies": {

--- a/packages/assemble-release-plan/src/test-utils.ts
+++ b/packages/assemble-release-plan/src/test-utils.ts
@@ -13,6 +13,7 @@ function getPackage({
       name,
       version,
     },
+    relativeDir: "this-shouldn't-matter",
     dir: "this-shouldn't-matter",
   };
 }
@@ -44,17 +45,22 @@ function getRelease({
   return { name, type };
 }
 
-let getSimpleSetup = () => ({
+let getSimpleSetup = (): {
+  packages: Packages;
+  changesets: NewChangeset[];
+} => ({
   packages: {
-    root: {
+    rootDir: "/",
+    rootPackage: {
       packageJson: {
         name: "root",
         version: "0.0.0",
       },
-      dir: "/",
+      relativeDir: "/",
+      dir: "a",
     },
     packages: [getPackage({ name: "pkg-a", version: "1.0.0" })],
-    tool: "yarn" as const,
+    tool: { type: "yarn" as const } as Packages["tool"],
   },
   changesets: [
     getChangeset({ releases: [getRelease({ name: "pkg-a", type: "patch" })] }),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,7 +81,7 @@
     "@changesets/types": "^6.1.0",
     "@changesets/write": "^0.4.0",
     "@inquirer/external-editor": "^1.0.2",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "ansi-colors": "^4.1.3",
     "ci-info": "^3.7.0",
     "enquirer": "^2.4.1",

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -97,7 +97,7 @@ export default async function publish(
       // fail if we are behind the base branch).
       log(`Creating git tag${successfulNpmPublishes.length > 1 ? "s" : ""}...`);
 
-      await tagPublish(tool, successfulNpmPublishes, cwd);
+      await tagPublish(tool.type, successfulNpmPublishes, cwd);
     }
   }
 
@@ -105,7 +105,7 @@ export default async function publish(
     success("found untagged projects:");
     logReleases(untaggedPrivatePackageReleases);
 
-    await tagPublish(tool, untaggedPrivatePackageReleases, cwd);
+    await tagPublish(tool.type, untaggedPrivatePackageReleases, cwd);
   }
 
   if (unsuccessfulNpmPublishes.length > 0) {

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -23,7 +23,8 @@ export default async function tag(cwd: string, config: Config) {
     cwd,
     tool
   )) {
-    const tag = tool !== "root" ? `${name}@${newVersion}` : `v${newVersion}`;
+    const tag =
+      tool.type !== "root" ? `${name}@${newVersion}` : `v${newVersion}`;
 
     if (allExistingTags.has(tag)) {
       log("Skipping tag (already exists): ", tag);

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -11,6 +11,7 @@ export function getCommitFunctions(
     return [commitFunctions, null];
   }
   let commitOpts: any = commit[1];
+
   let changesetPath = path.join(cwd, ".changeset");
   let commitPath = resolveFrom(changesetPath, commit[0]);
 

--- a/packages/cli/src/utils/getUntaggedPackages.ts
+++ b/packages/cli/src/utils/getUntaggedPackages.ts
@@ -10,7 +10,7 @@ export async function getUntaggedPackages(
   const packageWithTags = await Promise.all(
     packages.map(async (pkg) => {
       const tagName =
-        tool === "root"
+        tool.type === "root"
           ? `v${pkg.packageJson.version}`
           : `${pkg.packageJson.name}@${pkg.packageJson.version}`;
       const isMissingTag = !(

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,7 +27,7 @@
     "@changesets/get-dependents-graph": "^2.1.3",
     "@changesets/logger": "^0.1.1",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "fs-extra": "^7.0.1",
     "micromatch": "^4.0.8"
   },

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -25,19 +25,22 @@ type CorrectCase = {
 };
 
 let defaultPackages: Packages = {
-  root: {
-    packageJson: { name: "", version: "" },
+  rootDir: "/",
+  rootPackage: {
+    relativeDir: ".",
     dir: "/",
+    packageJson: { name: "", version: "" },
   },
   packages: [],
-  tool: "yarn",
+  tool: { type: "yarn" } as Packages["tool"],
 };
 
-const withPackages = (pkgNames: string[]) => ({
+const withPackages = (pkgNames: string[]): Packages => ({
   ...defaultPackages,
   packages: pkgNames.map((pkgName) => ({
-    packageJson: { name: pkgName, version: "" },
+    relativeDir: ".",
     dir: "dir",
+    packageJson: { name: pkgName, version: "" },
   })),
 });
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,8 @@ import path from "path";
 import micromatch from "micromatch";
 import { ValidationError } from "@changesets/errors";
 import { warn } from "@changesets/logger";
-import { Packages, getPackages } from "@manypkg/get-packages";
+import { getPackages } from "@manypkg/get-packages";
+import type { Package, Packages, Tool } from "@manypkg/get-packages";
 import {
   Config,
   WrittenConfig,
@@ -519,7 +520,8 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   return config;
 };
 
-let fakePackage = {
+let fakePackage: Package = {
+  relativeDir: "",
   dir: "",
   packageJson: {
     name: "",
@@ -528,7 +530,8 @@ let fakePackage = {
 };
 
 export let defaultConfig = parse(defaultWrittenConfig, {
-  root: fakePackage,
-  tool: "root",
+  rootDir: "/",
+  rootPackage: fakePackage,
+  tool: { type: "root" } as Tool,
   packages: [fakePackage],
 });

--- a/packages/get-dependents-graph/package.json
+++ b/packages/get-dependents-graph/package.json
@@ -20,7 +20,7 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/get-dependents-graph",
   "dependencies": {
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "picocolors": "^1.1.0",
     "semver": "^7.5.3"
   },

--- a/packages/get-dependents-graph/src/get-dependency-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.test.ts
@@ -1,5 +1,6 @@
 import { temporarilySilenceLogs } from "@changesets/test-utils";
 import getDependencyGraph from "./get-dependency-graph";
+import type { Tool } from "@manypkg/get-packages";
 
 const consoleError = console.error;
 
@@ -14,12 +15,15 @@ afterEach(() => {
 describe("getting the dependency graph", function () {
   it("should skip dependencies specified through the link protocol", function () {
     const { graph, valid } = getDependencyGraph({
-      root: {
+      rootDir: "/",
+      rootPackage: {
+        relativeDir: ".",
         dir: ".",
         packageJson: { name: "root", version: "1.0.0" },
       },
       packages: [
         {
+          relativeDir: ".",
           dir: "foo",
           packageJson: {
             name: "foo",
@@ -30,6 +34,7 @@ describe("getting the dependency graph", function () {
           },
         },
         {
+          relativeDir: ".",
           dir: "bar",
           packageJson: {
             name: "bar",
@@ -37,7 +42,7 @@ describe("getting the dependency graph", function () {
           },
         },
       ],
-      tool: "pnpm",
+      tool: { type: "pnpm" } as Tool,
     });
     expect(graph.get("foo")!.dependencies).toStrictEqual([]);
     expect(valid).toBeTruthy();
@@ -46,12 +51,15 @@ describe("getting the dependency graph", function () {
 
   it("should skip dependencies specified using a tag", function () {
     const { graph, valid } = getDependencyGraph({
-      root: {
+      rootDir: "/",
+      rootPackage: {
+        relativeDir: ".",
         dir: ".",
         packageJson: { name: "root", version: "1.0.0" },
       },
       packages: [
         {
+          relativeDir: ".",
           dir: "examples/foo",
           packageJson: {
             name: "foo-example",
@@ -62,6 +70,7 @@ describe("getting the dependency graph", function () {
           },
         },
         {
+          relativeDir: ".",
           dir: "packages/bar",
           packageJson: {
             name: "bar",
@@ -69,7 +78,7 @@ describe("getting the dependency graph", function () {
           },
         },
       ],
-      tool: "pnpm",
+      tool: { type: "pnpm" } as Tool,
     });
     expect(graph.get("foo-example")!.dependencies).toStrictEqual([]);
     expect(valid).toBeTruthy();
@@ -80,12 +89,15 @@ describe("getting the dependency graph", function () {
     "should set valid to false if the link protocol is used in a non-dev dep",
     temporarilySilenceLogs(() => {
       const { valid } = getDependencyGraph({
-        root: {
-          dir: ".",
+        rootDir: "/",
+        rootPackage: {
+          relativeDir: ".",
+          dir: "root",
           packageJson: { name: "root", version: "1.0.0" },
         },
         packages: [
           {
+            relativeDir: ".",
             dir: "foo",
             packageJson: {
               name: "foo",
@@ -96,6 +108,7 @@ describe("getting the dependency graph", function () {
             },
           },
           {
+            relativeDir: ".",
             dir: "bar",
             packageJson: {
               name: "bar",
@@ -103,7 +116,7 @@ describe("getting the dependency graph", function () {
             },
           },
         ],
-        tool: "pnpm",
+        tool: { type: "pnpm" } as Tool,
       });
       expect(valid).toBeFalsy();
       expect((console.error as any).mock.calls).toMatchInlineSnapshot(`
@@ -120,12 +133,15 @@ describe("getting the dependency graph", function () {
     "should error on dependencies not specified using workspace protocol when bumpVersionsWithWorkspaceProtocolOnly is false",
     temporarilySilenceLogs(() => {
       const { valid } = getDependencyGraph({
-        root: {
+        rootDir: "/",
+        rootPackage: {
+          relativeDir: ".",
           dir: ".",
           packageJson: { name: "root", version: "1.0.0" },
         },
         packages: [
           {
+            relativeDir: ".",
             dir: "foo",
             packageJson: {
               name: "foo",
@@ -136,6 +152,7 @@ describe("getting the dependency graph", function () {
             },
           },
           {
+            relativeDir: ".",
             dir: "bar",
             packageJson: {
               name: "bar",
@@ -143,7 +160,7 @@ describe("getting the dependency graph", function () {
             },
           },
         ],
-        tool: "pnpm",
+        tool: { type: "pnpm" } as Tool,
       });
       expect(valid).toBe(false);
       expect((console.error as any).mock.calls).toMatchInlineSnapshot(`
@@ -161,12 +178,15 @@ describe("getting the dependency graph", function () {
     temporarilySilenceLogs(() => {
       const { valid } = getDependencyGraph(
         {
-          root: {
-            dir: ".",
+          rootDir: "/",
+          rootPackage: {
+            relativeDir: ".",
+            dir: "root",
             packageJson: { name: "root", version: "1.0.0" },
           },
           packages: [
             {
+              relativeDir: ".",
               dir: "foo",
               packageJson: {
                 name: "foo",
@@ -177,6 +197,7 @@ describe("getting the dependency graph", function () {
               },
             },
             {
+              relativeDir: ".",
               dir: "bar",
               packageJson: {
                 name: "bar",
@@ -184,7 +205,7 @@ describe("getting the dependency graph", function () {
               },
             },
           ],
-          tool: "pnpm",
+          tool: { type: "pnpm" } as Tool,
         },
         {
           bumpVersionsWithWorkspaceProtocolOnly: true,

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -73,10 +73,10 @@ export default function getDependencyGraph(
   let valid = true;
 
   const packagesByName: { [key: string]: Package } = {
-    [packages.root.packageJson.name]: packages.root,
+    [packages.rootPackage!.packageJson.name]: packages.rootPackage!,
   };
 
-  const queue = [packages.root];
+  const queue = [packages.rootPackage!];
 
   for (const pkg of packages.packages) {
     queue.push(pkg);

--- a/packages/get-dependents-graph/src/index.ts
+++ b/packages/get-dependents-graph/src/index.ts
@@ -15,8 +15,8 @@ export function getDependentsGraph(
   const dependentsLookup: {
     [key: string]: { pkg: Package; dependents: Array<string> };
   } = {
-    [packages.root.packageJson.name]: {
-      pkg: packages.root,
+    [packages.rootPackage!.packageJson.name]: {
+      pkg: packages.rootPackage!,
       dependents: [],
     },
   };

--- a/packages/get-release-plan/package.json
+++ b/packages/get-release-plan/package.json
@@ -24,6 +24,6 @@
     "@changesets/pre": "^2.0.2",
     "@changesets/read": "^0.6.6",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3"
+    "@manypkg/get-packages": "^2.2.0"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -20,7 +20,7 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/git",
   "dependencies": {
     "@changesets/errors": "^0.2.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "is-subdir": "^1.1.1",
     "micromatch": "^4.0.8",
     "spawndamnit": "^3.0.1"

--- a/packages/pre/package.json
+++ b/packages/pre/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@changesets/errors": "^0.2.0",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "fs-extra": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -46,8 +46,14 @@ export async function exitPre(cwd: string) {
 
 export async function enterPre(cwd: string, tag: string) {
   let packages = await getPackages(cwd);
-  let preStatePath = path.resolve(packages.root.dir, ".changeset", "pre.json");
-  let preState: PreState | undefined = await readPreState(packages.root.dir);
+  let preStatePath = path.resolve(
+    packages.rootPackage!.dir,
+    ".changeset",
+    "pre.json"
+  );
+  let preState: PreState | undefined = await readPreState(
+    packages.rootPackage!.dir
+  );
   // can't reenter if pre mode still exists, but we should allow exited pre mode to be reentered
   if (preState?.mode === "pre") {
     throw new PreEnterButInPreModeError();

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -20,7 +20,7 @@
     "@changesets/pre": "^2.0.2",
     "@changesets/read": "^0.6.6",
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3",
+    "@manypkg/get-packages": "^2.2.0",
     "fs-extra": "^7.0.1",
     "mdast-util-to-string": "^1.0.6",
     "remark-parse": "^7.0.1",

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -156,6 +156,7 @@ describe("version", () => {
     );
     expect(changedPackages).toEqual([
       {
+        relativeDir: path.join("packages", "pkg-a"),
         dir: path.join(clone, "packages", "pkg-a"),
         packageJson: {
           name: "pkg-a",
@@ -166,6 +167,7 @@ describe("version", () => {
         },
       },
       {
+        relativeDir: path.join("packages", "pkg-b"),
         dir: path.join(clone, "packages", "pkg-b"),
         packageJson: { name: "pkg-b", version: "1.1.0" },
       },
@@ -269,6 +271,7 @@ describe("version", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
     expect(changedPackages).toEqual([
       {
+        relativeDir: path.join("packages", "pkg-a"),
         dir: path.join(clone, "packages", "pkg-a"),
         packageJson: {
           name: "pkg-a",
@@ -327,6 +330,7 @@ describe("version", () => {
     });
     expect(changedPackages).toEqual([
       {
+        relativeDir: path.join("packages", "pkg-b"),
         dir: path.join(clone, "packages", "pkg-b"),
         packageJson: { name: "pkg-b", version: "1.1.0" },
       },

--- a/packages/release-utils/src/run.ts
+++ b/packages/release-utils/src/run.ts
@@ -44,7 +44,7 @@ export async function runPublish({
   let { packages, tool } = await getPackages(cwd);
   let releasedPackages: Package[] = [];
 
-  if (tool !== "root") {
+  if (tool.type !== "root") {
     let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
     let packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
 

--- a/packages/should-skip-package/package.json
+++ b/packages/should-skip-package/package.json
@@ -20,7 +20,7 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/should-skip-package",
   "dependencies": {
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3"
+    "@manypkg/get-packages": "^2.2.0"
   },
   "devDependencies": {
     "@changesets/test-utils": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,7 +959,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.26.3"
     "@babel/plugin-transform-typescript" "^7.27.0"
 
-"@babel/runtime@^7.5.5", "@babel/runtime@^7.7.7":
+"@babel/runtime@^7.7.7":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
   integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
@@ -1000,11 +1000,6 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
-
-"@changesets/types@^4.0.1":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.1.0.tgz#fb8f7ca2324fd54954824e864f9a61a82cb78fe0"
-  integrity sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
@@ -1349,15 +1344,12 @@
     tinyexec "^1.0.1"
     validate-npm-package-name "^6.0.0"
 
-"@manypkg/find-root@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
-  integrity sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==
+"@manypkg/find-root@^2.2.2":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-2.2.3.tgz#3e9be5dff4a008c228649a34e2af65288ff13c26"
+  integrity sha512-jtEZKczWTueJYHjGpxU3KJQ08Gsrf4r6Q2GjmPp/RGk5leeYAA1eyDADSAF+KVCsQ6EwZd/FMcOFCoMhtqdCtQ==
   dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@types/node" "^12.7.1"
-    find-up "^4.1.0"
-    fs-extra "^8.1.0"
+    "@manypkg/tools" "^1.1.2"
 
 "@manypkg/find-root@^3.1.0":
   version "3.1.0"
@@ -1366,17 +1358,13 @@
   dependencies:
     "@manypkg/tools" "^2.1.0"
 
-"@manypkg/get-packages@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz#e184db9bba792fa4693de4658cfb1463ac2c9c47"
-  integrity sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==
+"@manypkg/get-packages@^2.2.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@manypkg/get-packages/-/get-packages-2.2.2.tgz#6eb16fc1ccf8c903aff5cde4e535c7574e965b0d"
+  integrity sha512-3+Zd8kLZmsyJFmWTBtY0MAuCErI7yKB2cjMBlujvSVKZ2R/BMXi0kjCXu2dtRlSq/ML86t1FkumT0yreQ3n8OQ==
   dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@changesets/types" "^4.0.1"
-    "@manypkg/find-root" "^1.1.0"
-    fs-extra "^8.1.0"
-    globby "^11.0.0"
-    read-yaml-file "^1.1.0"
+    "@manypkg/find-root" "^2.2.2"
+    "@manypkg/tools" "^1.1.1"
 
 "@manypkg/get-packages@^3.1.0":
   version "3.1.0"
@@ -1385,6 +1373,15 @@
   dependencies:
     "@manypkg/find-root" "^3.1.0"
     "@manypkg/tools" "^2.1.0"
+
+"@manypkg/tools@^1.1.1", "@manypkg/tools@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@manypkg/tools/-/tools-1.1.2.tgz#15d0abb66aa04cee83e7fe75839d56ddfdd5196f"
+  integrity sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==
+  dependencies:
+    fast-glob "^3.3.2"
+    jju "^1.4.0"
+    js-yaml "^4.1.0"
 
 "@manypkg/tools@^2.1.0":
   version "2.1.0"
@@ -1734,11 +1731,6 @@
   integrity sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==
   dependencies:
     undici-types "~7.16.0"
-
-"@types/node@^12.7.1":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/prettier@^2.1.5", "@types/prettier@^2.7.1":
   version "2.7.1"
@@ -2223,7 +2215,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3124,18 +3116,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
-  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
-
 fast-glob@^3.2.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
@@ -3157,6 +3137,17 @@ fast-glob@^3.2.9:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
+
+fast-glob@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -3279,15 +3270,6 @@ fs-extra@^7.0.1:
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -3416,13 +3398,6 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -3464,18 +3439,6 @@ globalthis@^1.0.4:
     define-properties "^1.2.1"
     gopd "^1.0.1"
 
-globby@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
-  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
-
 globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -3510,7 +3473,7 @@ graceful-fs@4.2.10, graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -3623,7 +3586,7 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -4510,7 +4473,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.6.1:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4741,14 +4704,6 @@ merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
 
 micromatch@^4.0.4:
   version "4.0.5"
@@ -5153,7 +5108,7 @@ picomatch@^2.0.4, picomatch@^2.2.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
@@ -5263,16 +5218,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-read-yaml-file@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-yaml-file/-/read-yaml-file-1.1.0.tgz#9362bbcbdc77007cc8ea4519fe1c0b821a7ce0d8"
-  integrity sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==
-  dependencies:
-    graceful-fs "^4.1.5"
-    js-yaml "^3.6.1"
-    pify "^4.0.1"
-    strip-bom "^3.0.0"
 
 readdirp@~3.6.0:
   version "3.6.0"


### PR DESCRIPTION
- Follow-up to **#1772**

`@manypkg/get-packages@1` depends on `read-yml-files@1`, which uses `js-yaml@3`.

Upgrading to **`@manypkg/get-packages@2.2.2`** removes this and other dependencies.

### Why not `@manypkg/get-packages@3`?

Version 3 is ESM-only. 
This repository still relies on Jest 29, which does not support ESM by default, so upgrading to v3 isn’t feasible yet.

---

I’m aware that a few changes may conflict with the `next` branch, 
but I believe it’s worthwhile to merge this into `main` to reduce unnecessary dependencies.

If you're happy with this PR, I can also prepare a follow-up to bring the same changes into `next`. 
Since `next` branch uses `vitest`, we could consider upgrading `@manypkg/get-packages` to v3 there.
