### PR TITLE
docs: fix dependency version typo in prereleases.md

### DIFF
--- a/docs/prereleases.md
+++ b/docs/prereleases.md
@@ -46,7 +46,7 @@ The repo would now look like this:
 
 ```
 packages/
-  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.0.1
+  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.0 has no deps
 .changeset/
@@ -72,7 +72,7 @@ Let's say we add some changesets and a new package so our repo looks like this
 
 ```
 packages/
-  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.0.1
+  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.0 has no deps
   pkg-d@0.0.0 has no deps
@@ -91,7 +91,7 @@ The version command will behave just like it does for the first versioning of a 
 
 ```
 packages/
-  pkg-a@1.1.0-next.1 has dep on pkg-b@^2.0.1
+  pkg-a@1.1.0-next.1 has dep on pkg-b@^2.1.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.1-next.0 has no deps
   pkg-d@1.0.0-next.0 has no deps
@@ -128,7 +128,7 @@ The version command will apply any changesets currently in the repo and then rem
 
 ```
 packages/
-  pkg-a@1.1.0 has dep on pkg-b@^2.0.1
+  pkg-a@1.1.0 has dep on pkg-b@^2.1.0
   pkg-b@2.1.0 has no deps
   pkg-c@3.0.1 has no deps
   pkg-d@1.0.0 has no deps

--- a/docs/prereleases.md
+++ b/docs/prereleases.md
@@ -46,7 +46,7 @@ The repo would now look like this:
 
 ```
 packages/
-  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0
+  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0-next.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.0 has no deps
 .changeset/
@@ -72,7 +72,7 @@ Let's say we add some changesets and a new package so our repo looks like this
 
 ```
 packages/
-  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0
+  pkg-a@1.0.1-next.0 has dep on pkg-b@^2.1.0-next.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.0 has no deps
   pkg-d@0.0.0 has no deps
@@ -91,7 +91,7 @@ The version command will behave just like it does for the first versioning of a 
 
 ```
 packages/
-  pkg-a@1.1.0-next.1 has dep on pkg-b@^2.1.0
+  pkg-a@1.1.0-next.1 has dep on pkg-b@^2.1.0-next.0
   pkg-b@2.1.0-next.0 has no deps
   pkg-c@3.0.1-next.0 has no deps
   pkg-d@1.0.0-next.0 has no deps


### PR DESCRIPTION
## Summary

Fixes #1822

The documentation incorrectly showed `pkg-a`'s dependency on `pkg-b` as `^2.0.1` when it should be `^2.1.0`.

### Why this is a bug

In the example:
- Initial state: `pkg-b@2.0.0` with changeset `pkg-b@minor`
- After versioning: `pkg-b@2.1.0-next.0`

Since pkg-b received a **minor** bump (2.0.0 → 2.1.0), the caret range should be `^2.1.0`, not `^2.0.1`.

### Changes

Fixed all 4 occurrences of this typo in the prereleases documentation:
- Line 49
- Line 75
- Line 94
- Line 131