### PR TITLE
docs(readme): add React Email to cool projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To make releasing easier, you can use [this changesets github action](https://gi
 - [Apollo Client](https://github.com/apollographql/apollo-client)
 - [Adobe Spectrum CSS](https://github.com/adobe/spectrum-css)
 - [Adobe Spectrum Web Components](https://github.com/adobe/spectrum-web-components)
+- [React Email](https://react.email)
 
 <!-- NOTE: we currently only accept new entries with at least 1000 GitHub stars -->
 


### PR DESCRIPTION
This adds [React Email](https://github.com/resend/react-email), which has 17.9K GitHub stars, to the cool projects list in README.md.