### PR TITLE
fix: Unpublished software packages should be filtered.

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -216,7 +216,8 @@ function assembleReleasePlan(
       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
       // we want to give it a patch release.
       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
-      if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
+      const preReleasePackage = preInfo.preVersions.get(pkg.packageJson.name)
+      if (preReleasePackage && preReleasePackage !== 0) {
         const existingRelease = releases.get(pkg.packageJson.name);
         if (!existingRelease) {
           releases.set(pkg.packageJson.name, {


### PR DESCRIPTION
When pre-release packages exist, unreleased packages should be filtered out.

example: 
There are 3 packages in the project. 
```text
- packageA
- packageB
- packageC
```
Step 1: Pre-release packageA first

Step 2: Publish packageA again

The packages that should be changed at this time should only be packageA.
```text
- packageA
	- package.json
	- CHANGELOG.md
```
But in reality, they include packageA, packageB, and packageC
```text
- packageA
	- package.json
	- CHANGELOG.md
 - packageB
	- package.json
	- CHANGELOG.md
- packageC
	- package.json
	- CHANGELOG.md
```
The cause of the issue was a misjudgment when incorporating the pre-release package into the current release process.
```text
preInfo.preVersions -> {
	"packageA" => version
}
```
```ts
preInfo.preVersions.get('packageB') 
// It should be undefined, but in the code, a strict comparison is used to check if it is not equal to 0
```

