### PR TITLE
Compute the terminal's size lazily to avoid spurious stderr output in non-interactive mode

### DIFF
--- a/.changeset/brave-eagles-pick.md
+++ b/.changeset/brave-eagles-pick.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Compute the terminal's size lazily to avoid spurious stderr output in non-interactive mode

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -38,7 +38,9 @@ const serialId: () => number = (function () {
   return () => id++;
 })();
 
-const limit = Math.max(termSize().rows - 5, 10);
+// this can exec tput so we make it compute lazily to avoid such side effects at init time
+let limit: number | undefined;
+const getLimit = () => (limit ??= Math.max(termSize().rows - 5, 10));
 
 let cancelFlow = () => {
   success("Cancelled... 👋 ");
@@ -60,7 +62,7 @@ async function askCheckboxPlus(
     multiple: true,
     choices,
     format,
-    limit,
+    limit: getLimit(),
     onCancel: cancelFlow,
     symbols: {
       indicator: symbols.radioOff,


### PR DESCRIPTION
It avoid Changesets from printing smth like this on CI at times:
```
tput: No value for $TERM and no -T specified
```