### PR TITLE
fix(config): do not error on unmatched ignore patterns

### DIFF
--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -711,18 +711,15 @@ describe("parser errors", () => {
     `);
   });
   test("ignore package that does not exist", () => {
-    expect(() => unsafeParse({ ignore: ["pkg-a"] }, defaultPackages))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Some errors occurred when validating the changesets config:
-      The package or glob expression "pkg-a" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch"
-    `);
+    // Should not throw - unmatched ignore patterns are allowed (e.g. for
+    // dynamically generated packages that may not always be present)
+    const config = unsafeParse({ ignore: ["pkg-a"] }, defaultPackages);
+    expect(config.ignore).toEqual([]);
   });
   test("ignore package that does not exist (using glob expressions)", () => {
-    expect(() => unsafeParse({ ignore: ["pkg-*"] }, defaultPackages))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Some errors occurred when validating the changesets config:
-      The package or glob expression "pkg-*" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch"
-    `);
+    // Should not throw - unmatched glob patterns in ignore are allowed
+    const config = unsafeParse({ ignore: ["pkg-*"] }, defaultPackages);
+    expect(config.ignore).toEqual([]);
   });
   test("ignore missing dependent packages", async () => {
     expect(() =>

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -358,13 +358,6 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           2
         )} when the only valid values are undefined or an array of package names`
       );
-    } else {
-      messages.push(
-        ...getUnmatchedPatterns(json.ignore, pkgNames).map(
-          (pkgOrGlob) =>
-            `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch`
-        )
-      );
     }
   }
 


### PR DESCRIPTION
## Problem

When specifying a package name or glob expression in the `ignore` config option that doesn't match any workspace package, changesets throws a validation error:

```
The package or glob expression "generated-package-*" is specified in the `ignore` option but it is not found in the project.
```

This makes it impossible to use `ignore` patterns for packages that may not always be present, such as:
- Dynamically generated packages (e.g. Prisma client packages that only exist after `prisma generate`)
- Conditionally installed packages (present in some environments but not others)
- Future packages not yet created but already listed in config

## Solution

Remove the unmatched-pattern validation for the `ignore` option. Unlike `fixed` and `linked` groups — where all packages must exist to form a valid constraint group — ignoring a non-existent package is a safe no-op: the pattern simply matches nothing and has no effect on the release plan.

The `fixed` and `linked` group validations are unchanged, since those do require all referenced packages to exist.

## Changes

- Removes the unmatched-pattern error check in `@changesets/config`
- Updates tests: the two tests that previously expected errors for non-existent ignore packages now verify the config parses successfully with an empty `ignore` array

## Related

Closes #1794