### PR TITLE
Add documentation for automating changesets when versioning apps

### DIFF
--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -34,3 +34,7 @@ For example, if you have an app `A` that depends on a private library `B`, you c
 ```
 
 This works because `A` is private and will never be published to npm with a stale reference to `B`.
+
+## Automated Releases
+
+When using the [Automating Changesets](./automating-changesets.md) you will still need the GitHub Action or similar to invoke `changeset version` and `changeset publish` in order for the release to be created, otherwise just the `CHANGELOG.md` is created, and the release on GitHub is not actually created.


### PR DESCRIPTION
(or for non-npm projects)

I just used changesets for versioning a swift package, with the GitHub Action and the GitHub changelog setup, and I was stuck for a moment where the release pull request would be created, but merging it would result in the following log output:

```
Run changesets/action@v1
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "<omitted>"
setting GitHub credentials
No changesets found. Attempting to publish any unpublished packages to npm
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```

And then no github release was actually created.

This was because I didn't supply the `publish` option to the GitHub Action, which needs to invoke `changeset publish`, because I was like "I don't have a publish command for swift, since there's no package registry", so I'd both omitted it initially, and then set `publish: /usr/bin/true` and both didn't have the expected results.

You can see the final configuration I'm using for publishing releases of swift packages here: https://github.com/germ-network/oauth4swift