### PR TITLE
fix(@changesets/read): ignore uppercase .md files in .changeset dir

### DIFF
--- a/.changeset/ignore-uppercase-md-files.md
+++ b/.changeset/ignore-uppercase-md-files.md
@@ -1,0 +1,5 @@
+---
+"@changesets/read": patch
+---
+
+Uppercase `.md` files in the `.changeset/` directory (such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`) are now silently ignored, matching the existing behavior for `README.md`. This allows keeping documentation or AI agent instructions inside `.changeset/` without causing parse errors.

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -47,6 +47,27 @@ Nice simple summary
       },
     ]);
   });
+  it("should ignore uppercase .md files (AGENTS.md, CLAUDE.md, etc.)", async () => {
+    const cwd = await testdir({
+      ".changeset/AGENTS.md": `Instructions for AI coding agents`,
+      ".changeset/CLAUDE.md": `Project context for Claude`,
+      ".changeset/one-chance.md": `---
+"cool-package": minor
+---
+
+Nice simple summary
+`,
+    });
+
+    const changesets = await read(cwd);
+    expect(changesets).toEqual([
+      {
+        releases: [{ name: "cool-package", type: "minor" }],
+        summary: "Nice simple summary",
+        id: "one-chance",
+      },
+    ]);
+  });
   it("read a changeset that isn't a three word id", async () => {
     // I just want it enshrined in the tests that the file name's format
     // is in no way part of the changeset spec

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -46,9 +46,7 @@ export default async function getChangesets(
 
   let changesets = contents.filter(
     (file) =>
-      !file.startsWith(".") &&
-      file.endsWith(".md") &&
-      !/^[A-Z]/.test(file)
+      !file.startsWith(".") && file.endsWith(".md") && !/^[A-Z]/.test(file)
   );
 
   const changesetContents = changesets.map(async (file) => {

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -48,7 +48,7 @@ export default async function getChangesets(
     (file) =>
       !file.startsWith(".") &&
       file.endsWith(".md") &&
-      !/^README\.md$/i.test(file)
+      !/^[A-Z]/.test(file)
   );
 
   const changesetContents = changesets.map(async (file) => {


### PR DESCRIPTION
Fixes #1906

Currently any `.md` file in `.changeset/` that isn't `README.md` gets parsed as a changeset. This causes a cryptic parse error when you put docs like `AGENTS.md` or `CLAUDE.md` in there:

```
Error: could not parse changeset - invalid frontmatter: Read AGENTS.md for project knowledge.
```

The fix extends the existing `README.md` exclusion to cover all uppercase-starting filenames. The convention is already established (README.md) and natural — changeset IDs are always lowercase adjective-noun pairs.

Changed `!/^README\.md$/i.test(file)` to `!/^[A-Z]/.test(file)`, so `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, etc. are all silently skipped.