### PR TITLE
fix: pin 2 unpinned action(s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn jest --ci --color --runInBand --coverage --reporters=default --reporters=jest-junit
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         # https://github.com/changesets/action
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `ci.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `publish.yml` | Pinned 1 action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `publish.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `publish.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `publish.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-019 | medium | `publish.yml` | Step Output Interpolated in run Block |
| RGS-019 | medium | `publish.yml` | Step Output Interpolated in run Block |
| RGS-019 | medium | `publish.yml` | Step Output Interpolated in run Block |
| RGS-019 | medium | `publish.yml` | Step Output Interpolated in run Block |


## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since, where attackers compromise maintainer accounts and force-push malicious code to mutable action tags - every downstream project referencing those tags then executes the attacker's code with full access to secrets and deployment credentials.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've had 22 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))