### PR TITLE
Fix npm auth for path-based registries during publish by preserving configured registry URLs instead of normalizing them

### DIFF
--- a/.changeset/fix-registry-trailing-slash.md
+++ b/.changeset/fix-registry-trailing-slash.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-Fix npm auth for path-based registries during publish by fixing registry URL normalization logic.
+Fix npm auth for path-based registries during publish by preserving configured registry URLs instead of normalizing them.

--- a/.changeset/fix-registry-trailing-slash.md
+++ b/.changeset/fix-registry-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Fix npm auth for path-based registries during publish by fixing registry URL normalization logic.

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -12,29 +12,33 @@ afterAll(() => {
 
 describe("getCorrectRegistry", () => {
   it("falls back to the npm registry when no registry is configured", () => {
-    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org/");
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
   });
 
   it("maps the yarn registry to the npm registry", () => {
     process.env.npm_config_registry = "https://registry.yarnpkg.com";
 
-    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org/");
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
   });
 
-  it("adds a trailing slash to path-based registries from npm config", () => {
+  it("maps the normalized npm registry to the canonical npm registry", () => {
+    process.env.npm_config_registry = "https://registry.npmjs.org/";
+
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
+  });
+
+  it("preserves path-based registries from npm config", () => {
     process.env.npm_config_registry = "https://nexus.example.com/npm";
 
-    expect(getCorrectRegistry().registry).toBe(
-      "https://nexus.example.com/npm/"
-    );
+    expect(getCorrectRegistry().registry).toBe("https://nexus.example.com/npm");
   });
 
-  it("adds a trailing slash to scoped registries from npm config", () => {
+  it("preserves scoped registries from npm config", () => {
     process.env["npm_config_@acme:registry"] = "https://nexus.example.com/npm";
 
     expect(
       getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" }).registry
-    ).toBe("https://nexus.example.com/npm/");
+    ).toBe("https://nexus.example.com/npm");
   });
 
   it("prefers the scoped registry over the default registry", () => {
@@ -45,7 +49,7 @@ describe("getCorrectRegistry", () => {
       getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" })
     ).toEqual({
       scope: "@acme",
-      registry: "https://registry.example.com/acme/",
+      registry: "https://registry.example.com/acme",
     });
   });
 
@@ -56,7 +60,7 @@ describe("getCorrectRegistry", () => {
         version: "1.0.0",
         publishConfig: { registry: "https://registry.example.com/npm" },
       }).registry
-    ).toBe("https://registry.example.com/npm/");
+    ).toBe("https://registry.example.com/npm");
   });
 
   it("uses publishConfig scoped registry when provided", () => {
@@ -70,7 +74,7 @@ describe("getCorrectRegistry", () => {
       })
     ).toEqual({
       scope: "@acme",
-      registry: "https://registry.example.com/acme/",
+      registry: "https://registry.example.com/acme",
     });
   });
 
@@ -80,13 +84,19 @@ describe("getCorrectRegistry", () => {
     expect(getCorrectRegistry().registry).toBe("https://nexus.example.com/npm/");
   });
 
-  it("normalizes the pathname while preserving query params and hashes", () => {
+  it("preserves query params and hashes exactly", () => {
     process.env.npm_config_registry =
       "https://nexus.example.com/npm?token=abc#fragment";
 
     expect(getCorrectRegistry().registry).toBe(
-      "https://nexus.example.com/npm/?token=abc#fragment"
+      "https://nexus.example.com/npm?token=abc#fragment"
     );
+  });
+
+  it("maps the normalized yarn registry to the npm registry", () => {
+    process.env.npm_config_registry = "https://registry.yarnpkg.com/";
+
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
   });
 });
 

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -46,12 +46,12 @@ describe("getCorrectRegistry", () => {
     process.env["npm_config_@acme:registry"] =
       "https://registry.example.com/acme";
 
-    expect(
-      getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" })
-    ).toEqual({
-      scope: "@acme",
-      registry: "https://registry.example.com/acme",
-    });
+    expect(getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" })).toEqual(
+      {
+        scope: "@acme",
+        registry: "https://registry.example.com/acme",
+      }
+    );
   });
 
   it("uses publishConfig.registry when provided", () => {
@@ -82,7 +82,9 @@ describe("getCorrectRegistry", () => {
   it("preserves registry URLs that already end with a slash", () => {
     process.env.npm_config_registry = "https://nexus.example.com/npm/";
 
-    expect(getCorrectRegistry().registry).toBe("https://nexus.example.com/npm/");
+    expect(getCorrectRegistry().registry).toBe(
+      "https://nexus.example.com/npm/"
+    );
   });
 
   it("preserves query params and hashes exactly", () => {

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,0 +1,115 @@
+import { getCorrectRegistry, isCustomRegistry } from "../npm-utils";
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe("getCorrectRegistry", () => {
+  it("falls back to the npm registry when no registry is configured", () => {
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org/");
+  });
+
+  it("maps the yarn registry to the npm registry", () => {
+    process.env.npm_config_registry = "https://registry.yarnpkg.com";
+
+    expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org/");
+  });
+
+  it("adds a trailing slash to path-based registries from npm config", () => {
+    process.env.npm_config_registry = "https://nexus.example.com/npm";
+
+    expect(getCorrectRegistry().registry).toBe(
+      "https://nexus.example.com/npm/"
+    );
+  });
+
+  it("adds a trailing slash to scoped registries from npm config", () => {
+    process.env["npm_config_@acme:registry"] = "https://nexus.example.com/npm";
+
+    expect(
+      getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" }).registry
+    ).toBe("https://nexus.example.com/npm/");
+  });
+
+  it("prefers the scoped registry over the default registry", () => {
+    process.env.npm_config_registry = "https://registry.example.com/default";
+    process.env["npm_config_@acme:registry"] = "https://registry.example.com/acme";
+
+    expect(
+      getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" })
+    ).toEqual({
+      scope: "@acme",
+      registry: "https://registry.example.com/acme/",
+    });
+  });
+
+  it("uses publishConfig.registry when provided", () => {
+    expect(
+      getCorrectRegistry({
+        name: "pkg",
+        version: "1.0.0",
+        publishConfig: { registry: "https://registry.example.com/npm" },
+      }).registry
+    ).toBe("https://registry.example.com/npm/");
+  });
+
+  it("uses publishConfig scoped registry when provided", () => {
+    expect(
+      getCorrectRegistry({
+        name: "@acme/pkg",
+        version: "1.0.0",
+        publishConfig: {
+          "@acme:registry": "https://registry.example.com/acme",
+        },
+      })
+    ).toEqual({
+      scope: "@acme",
+      registry: "https://registry.example.com/acme/",
+    });
+  });
+
+  it("leaves already-normalized URLs unchanged", () => {
+    process.env.npm_config_registry = "https://nexus.example.com/npm/";
+
+    expect(getCorrectRegistry().registry).toBe("https://nexus.example.com/npm/");
+  });
+
+  it("normalizes the pathname while preserving query params and hashes", () => {
+    process.env.npm_config_registry =
+      "https://nexus.example.com/npm?token=abc#fragment";
+
+    expect(getCorrectRegistry().registry).toBe(
+      "https://nexus.example.com/npm/?token=abc#fragment"
+    );
+  });
+});
+
+describe("isCustomRegistry", () => {
+  it("returns false for an undefined registry", () => {
+    expect(isCustomRegistry(undefined)).toBe(false);
+  });
+
+  it("treats npm and yarn default registries as non-custom after normalization", () => {
+    expect(isCustomRegistry("https://registry.npmjs.org")).toBe(false);
+    expect(isCustomRegistry("https://registry.yarnpkg.com")).toBe(false);
+  });
+
+  it("treats already-normalized default registries as non-custom", () => {
+    expect(isCustomRegistry("https://registry.npmjs.org/")).toBe(false);
+    expect(isCustomRegistry("https://registry.yarnpkg.com/")).toBe(false);
+  });
+
+  it("returns true for a custom root registry", () => {
+    expect(isCustomRegistry("https://registry.example.com")).toBe(true);
+  });
+
+  it("returns true for a path-based custom registry", () => {
+    expect(isCustomRegistry("https://registry.example.com/npm")).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -43,7 +43,8 @@ describe("getCorrectRegistry", () => {
 
   it("prefers the scoped registry over the default registry", () => {
     process.env.npm_config_registry = "https://registry.example.com/default";
-    process.env["npm_config_@acme:registry"] = "https://registry.example.com/acme";
+    process.env["npm_config_@acme:registry"] =
+      "https://registry.example.com/acme";
 
     expect(
       getCorrectRegistry({ name: "@acme/pkg", version: "1.0.0" })

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -21,7 +21,7 @@ describe("getCorrectRegistry", () => {
     expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
   });
 
-  it("maps the normalized npm registry to the canonical npm registry", () => {
+  it("maps the slash-suffixed npm registry to the canonical npm registry", () => {
     process.env.npm_config_registry = "https://registry.npmjs.org/";
 
     expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
@@ -78,7 +78,7 @@ describe("getCorrectRegistry", () => {
     });
   });
 
-  it("leaves already-normalized URLs unchanged", () => {
+  it("preserves registry URLs that already end with a slash", () => {
     process.env.npm_config_registry = "https://nexus.example.com/npm/";
 
     expect(getCorrectRegistry().registry).toBe("https://nexus.example.com/npm/");
@@ -93,7 +93,7 @@ describe("getCorrectRegistry", () => {
     );
   });
 
-  it("maps the normalized yarn registry to the npm registry", () => {
+  it("maps the slash-suffixed yarn registry to the npm registry", () => {
     process.env.npm_config_registry = "https://registry.yarnpkg.com/";
 
     expect(getCorrectRegistry().registry).toBe("https://registry.npmjs.org");
@@ -105,12 +105,12 @@ describe("isCustomRegistry", () => {
     expect(isCustomRegistry(undefined)).toBe(false);
   });
 
-  it("treats npm and yarn default registries as non-custom after normalization", () => {
+  it("treats npm and yarn default registries as non-custom", () => {
     expect(isCustomRegistry("https://registry.npmjs.org")).toBe(false);
     expect(isCustomRegistry("https://registry.yarnpkg.com")).toBe(false);
   });
 
-  it("treats already-normalized default registries as non-custom", () => {
+  it("treats slash-suffixed default registries as non-custom", () => {
     expect(isCustomRegistry("https://registry.npmjs.org/")).toBe(false);
     expect(isCustomRegistry("https://registry.yarnpkg.com/")).toBe(false);
   });

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -76,7 +76,7 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
   return {
     scope: undefined,
-    registry: !registry || !isCustomRegistry(registry) ? NPM_REGISTRY : registry,
+    registry: !isCustomRegistry(registry) ? NPM_REGISTRY : registry,
   };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -19,6 +19,8 @@ interface PublishOptions {
 
 const NPM_REQUEST_CONCURRENCY_LIMIT = 40;
 const NPM_PUBLISH_CONCURRENCY_LIMIT = 10;
+const NPM_REGISTRY = "https://registry.npmjs.org/";
+const YARN_REGISTRY = "https://registry.yarnpkg.com/";
 
 export const npmRequestQueue = createPromiseQueue(
   NPM_REQUEST_CONCURRENCY_LIMIT
@@ -40,11 +42,7 @@ function jsonParse(input: string) {
 
 export const isCustomRegistry = (registry?: string): boolean => {
   registry = normalizeRegistry(registry);
-  return (
-    !!registry &&
-    registry !== "https://registry.npmjs.org" &&
-    registry !== "https://registry.yarnpkg.com"
-  );
+  return !!registry && registry !== NPM_REGISTRY && registry !== YARN_REGISTRY;
 };
 
 interface RegistryInfo {
@@ -53,7 +51,19 @@ interface RegistryInfo {
 }
 
 function normalizeRegistry(registry: string | undefined) {
-  return registry && registry.replace(/\/+$/, "");
+  if (!registry) {
+    return registry;
+  }
+
+  try {
+    const url = new URL(registry);
+    if (!url.pathname.endsWith("/")) {
+      url.pathname = `${url.pathname}/`;
+    }
+    return url.toString();
+  } catch {
+    return registry;
+  }
 }
 
 export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
@@ -79,10 +89,7 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
   return {
     scope: undefined,
-    registry:
-      !registry || registry === "https://registry.yarnpkg.com"
-        ? "https://registry.npmjs.org"
-        : registry,
+    registry: !registry || registry === YARN_REGISTRY ? NPM_REGISTRY : registry,
   };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -29,12 +29,12 @@ export const npmPublishQueue = createPromiseQueue(
   NPM_PUBLISH_CONCURRENCY_LIMIT
 );
 
-function isDefaultRegistry(
-  registry: string | undefined,
-  defaultRegistry: string
-): boolean {
+function isDefaultRegistry(registry: string | undefined): boolean {
   return (
-    registry === defaultRegistry || registry === `${defaultRegistry}/`
+    registry === NPM_REGISTRY ||
+    registry === `${NPM_REGISTRY}/` ||
+    registry === YARN_REGISTRY ||
+    registry === `${YARN_REGISTRY}/`
   );
 }
 
@@ -50,11 +50,7 @@ function jsonParse(input: string) {
 }
 
 export const isCustomRegistry = (registry?: string): boolean => {
-  return (
-    !!registry &&
-    !isDefaultRegistry(registry, NPM_REGISTRY) &&
-    !isDefaultRegistry(registry, YARN_REGISTRY)
-  );
+  return !!registry && !isDefaultRegistry(registry);
 };
 
 interface RegistryInfo {
@@ -83,12 +79,7 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
   return {
     scope: undefined,
-    registry:
-      !registry ||
-      isDefaultRegistry(registry, NPM_REGISTRY) ||
-      isDefaultRegistry(registry, YARN_REGISTRY)
-        ? NPM_REGISTRY
-        : registry,
+    registry: !registry || isDefaultRegistry(registry) ? NPM_REGISTRY : registry,
   };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -76,7 +76,8 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
   return {
     scope: undefined,
-    registry: !isCustomRegistry(registry) ? NPM_REGISTRY : registry,
+    registry:
+      !registry || !isCustomRegistry(registry) ? NPM_REGISTRY : registry,
   };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -29,15 +29,6 @@ export const npmPublishQueue = createPromiseQueue(
   NPM_PUBLISH_CONCURRENCY_LIMIT
 );
 
-function isDefaultRegistry(registry: string | undefined): boolean {
-  return (
-    registry === NPM_REGISTRY ||
-    registry === `${NPM_REGISTRY}/` ||
-    registry === YARN_REGISTRY ||
-    registry === `${YARN_REGISTRY}/`
-  );
-}
-
 function jsonParse(input: string) {
   try {
     return JSON.parse(input);
@@ -50,7 +41,13 @@ function jsonParse(input: string) {
 }
 
 export const isCustomRegistry = (registry?: string): boolean => {
-  return !!registry && !isDefaultRegistry(registry);
+  return (
+    !!registry &&
+    registry !== NPM_REGISTRY &&
+    registry !== `${NPM_REGISTRY}/` &&
+    registry !== YARN_REGISTRY &&
+    registry !== `${YARN_REGISTRY}/`
+  );
 };
 
 interface RegistryInfo {
@@ -79,7 +76,7 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
 
   return {
     scope: undefined,
-    registry: !registry || isDefaultRegistry(registry) ? NPM_REGISTRY : registry,
+    registry: !registry || !isCustomRegistry(registry) ? NPM_REGISTRY : registry,
   };
 }
 

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -19,8 +19,8 @@ interface PublishOptions {
 
 const NPM_REQUEST_CONCURRENCY_LIMIT = 40;
 const NPM_PUBLISH_CONCURRENCY_LIMIT = 10;
-const NPM_REGISTRY = "https://registry.npmjs.org/";
-const YARN_REGISTRY = "https://registry.yarnpkg.com/";
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const YARN_REGISTRY = "https://registry.yarnpkg.com";
 
 export const npmRequestQueue = createPromiseQueue(
   NPM_REQUEST_CONCURRENCY_LIMIT
@@ -28,6 +28,15 @@ export const npmRequestQueue = createPromiseQueue(
 export const npmPublishQueue = createPromiseQueue(
   NPM_PUBLISH_CONCURRENCY_LIMIT
 );
+
+function isDefaultRegistry(
+  registry: string | undefined,
+  defaultRegistry: string
+): boolean {
+  return (
+    registry === defaultRegistry || registry === `${defaultRegistry}/`
+  );
+}
 
 function jsonParse(input: string) {
   try {
@@ -41,8 +50,11 @@ function jsonParse(input: string) {
 }
 
 export const isCustomRegistry = (registry?: string): boolean => {
-  registry = normalizeRegistry(registry);
-  return !!registry && registry !== NPM_REGISTRY && registry !== YARN_REGISTRY;
+  return (
+    !!registry &&
+    !isDefaultRegistry(registry, NPM_REGISTRY) &&
+    !isDefaultRegistry(registry, YARN_REGISTRY)
+  );
 };
 
 interface RegistryInfo {
@@ -50,31 +62,14 @@ interface RegistryInfo {
   registry: string;
 }
 
-function normalizeRegistry(registry: string | undefined) {
-  if (!registry) {
-    return registry;
-  }
-
-  try {
-    const url = new URL(registry);
-    if (!url.pathname.endsWith("/")) {
-      url.pathname = `${url.pathname}/`;
-    }
-    return url.toString();
-  } catch {
-    return registry;
-  }
-}
-
 export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
   const packageName = packageJson?.name;
 
   if (packageName?.startsWith("@")) {
     const scope = packageName.split("/")[0];
-    const scopedRegistry = normalizeRegistry(
+    const scopedRegistry =
       packageJson!.publishConfig?.[`${scope}:registry`] ||
-        process.env[`npm_config_${scope}:registry`]
-    );
+      process.env[`npm_config_${scope}:registry`];
     if (scopedRegistry) {
       return {
         scope,
@@ -83,13 +78,17 @@ export function getCorrectRegistry(packageJson?: PackageJSON): RegistryInfo {
     }
   }
 
-  const registry = normalizeRegistry(
-    packageJson?.publishConfig?.registry || process.env.npm_config_registry
-  );
+  const registry =
+    packageJson?.publishConfig?.registry || process.env.npm_config_registry;
 
   return {
     scope: undefined,
-    registry: !registry || registry === YARN_REGISTRY ? NPM_REGISTRY : registry,
+    registry:
+      !registry ||
+      isDefaultRegistry(registry, NPM_REGISTRY) ||
+      isDefaultRegistry(registry, YARN_REGISTRY)
+        ? NPM_REGISTRY
+        : registry,
   };
 }
 


### PR DESCRIPTION
fixes https://github.com/changesets/changesets/issues/1932