### PR TITLE
fix: use minor bump for 0.x packages when peer dependency causes major

### DIFF
--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -89,7 +89,13 @@ export default function determineDependents({
                     .onlyUpdatePeerDependentsWhenOutOfRange,
               })
             ) {
-              type = "major";
+              // For 0.x versions, peer dependency major bump should be minor
+              // since semver allows breaking changes in minor versions for 0.x
+              if (dependentPackage.packageJson.version.startsWith("0.")) {
+                type = "minor";
+              } else {
+                type = "major";
+              }
             } else if (
               (!releases.has(dependent) ||
                 releases.get(dependent)!.type === "none") &&


### PR DESCRIPTION
### What changed

When a peer dependency change triggers a major bump for a dependent package with a 0.x version, the bump type is now  instead of . This avoids prematurely jumping from 0.x.y to 1.0.0.

### Why

By semver convention, 0.x packages are allowed to contain breaking changes in minor versions. A peer dependency change that would require a major bump in a stable package should only require a minor bump in a 0.x package. Before this fix, adding a peer dependency to a 0.x package would release 1.0.0, which is not desirable.

### How

In , the  check now additionally checks if the dependent package's current version starts with . If so,  is set to  instead of .

Closes #1887