### PR TITLE
Update .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,3 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "grammarly.selectors": [
-    {
-      "language": "markdown",
-      "scheme": "file"
-    }
-  ]
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
`typescript.tsdk` was renamed to `js/ts.tsdk.path`. The Grammarly extension is also discontinued so removed its settings entirely.