### PR TITLE
remove unused `signal-exit` package

### DIFF
--- a/.changeset/two-hoops-fix.md
+++ b/.changeset/two-hoops-fix.md
@@ -1,0 +1,5 @@
+---
+"@changesets/release-utils": patch
+---
+
+Removed the unused `signal-exit` dependency

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -16,7 +16,6 @@
     "mdast-util-to-markdown": "^2.1.2",
     "mdast-util-to-string": "^4.0.0",
     "semver": "^7.5.3",
-    "signal-exit": "^4.1.0",
     "tinyexec": "^1.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4250,11 +4250,6 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-signal-exit@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"


### PR DESCRIPTION
i can't find `signal-exit` anywhere in the project but here, let's remove it!