### PR TITLE
Drop the legacy compatibility shim in `assembleReleasePlan` that accepted older `config` and `snapshot` argument shapes

### DIFF
--- a/.changeset/green-pianos-sneeze.md
+++ b/.changeset/green-pianos-sneeze.md
@@ -1,0 +1,4 @@
+"@changesets/assemble-release-plan": major
+---
+
+Drop the legacy compatibility shim in `assembleReleasePlan` that accepted older `config` and `snapshot` argument shapes.

--- a/.changeset/green-pianos-sneeze.md
+++ b/.changeset/green-pianos-sneeze.md
@@ -1,4 +1,3 @@
-"@changesets/assemble-release-plan": major
----
+## "@changesets/assemble-release-plan": major
 
 Drop the legacy compatibility shim in `assembleReleasePlan` that accepted older `config` and `snapshot` argument shapes.

--- a/.changeset/green-pianos-sneeze.md
+++ b/.changeset/green-pianos-sneeze.md
@@ -1,3 +1,5 @@
-## "@changesets/assemble-release-plan": major
+---
+"@changesets/assemble-release-plan": major
+---
 
 Drop the legacy compatibility shim in `assembleReleasePlan` that accepted older `config` and `snapshot` argument shapes.

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -142,21 +142,12 @@ function assembleReleasePlan(
     preState,
   );
 
-  const preInfo = getPreInfo(
-    changesets,
-    packagesByName,
-    config,
-    preState,
-  );
+  const preInfo = getPreInfo(changesets, packagesByName, config, preState);
 
   // releases is, at this point a list of all packages we are going to releases,
   // flattened down to one release per package, having a reference back to their
   // changesets, and with a calculated new versions
-  let releases = flattenReleases(
-    relevantChangesets,
-    packagesByName,
-    config,
-  );
+  let releases = flattenReleases(relevantChangesets, packagesByName, config);
 
   // Unlike the config/CLI validation graphs, this graph intentionally includes
   // devDependencies. While devDeps don't cause version bumps (determineDependents
@@ -185,11 +176,7 @@ function assembleReleasePlan(
       packagesByName,
       config,
     );
-    let linksUpdated = applyLinks(
-      releases,
-      packagesByName,
-      config.linked,
-    );
+    let linksUpdated = applyLinks(releases, packagesByName, config.linked);
 
     releasesValidated =
       !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
@@ -224,11 +211,7 @@ function assembleReleasePlan(
 
   // Caching the snapshot version here and use this if it is snapshot release
   const snapshotSuffix =
-    snapshot &&
-    getSnapshotSuffix(
-      config.snapshot.prereleaseTemplate,
-      snapshot,
-    );
+    snapshot && getSnapshotSuffix(config.snapshot.prereleaseTemplate, snapshot);
 
   return {
     changesets: relevantChangesets,

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -120,37 +120,17 @@ function getNewVersion(
   return incrementVersion(release, preInfo);
 }
 
-type OptionalProp<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
 function assembleReleasePlan(
   changesets: NewChangeset[],
   packages: Packages,
-  config: OptionalProp<Config, "snapshot">,
+  config: Config,
   // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
   preState: PreState | undefined,
   // snapshot: undefined            ->  not using snapshot
   // snapshot: { tag: undefined }   ->  --snapshot (empty tag)
   // snapshot: { tag: "canary" }    ->  --snapshot canary
-  snapshot?: SnapshotReleaseParameters | string | boolean,
+  snapshot?: SnapshotReleaseParameters,
 ): ReleasePlan {
-  // TODO: remove `refined*` in the next major version of this package
-  // just use `config` and `snapshot` parameters directly, typed as: `config: Config, snapshot?: SnapshotReleaseParameters`
-  const refinedConfig: Config = config.snapshot
-    ? (config as Config)
-    : {
-        ...config,
-        snapshot: {
-          prereleaseTemplate: null,
-          useCalculatedVersion: false,
-        },
-      };
-  const refinedSnapshot: SnapshotReleaseParameters | undefined =
-    typeof snapshot === "string"
-      ? { tag: snapshot }
-      : typeof snapshot === "boolean"
-        ? { tag: undefined }
-        : snapshot;
-
   let packagesByName = new Map(
     packages.packages.map((x) => [x.packageJson.name, x]),
   );
@@ -158,14 +138,14 @@ function assembleReleasePlan(
   const relevantChangesets = getRelevantChangesets(
     changesets,
     packagesByName,
-    refinedConfig,
+    config,
     preState,
   );
 
   const preInfo = getPreInfo(
     changesets,
     packagesByName,
-    refinedConfig,
+    config,
     preState,
   );
 
@@ -175,7 +155,7 @@ function assembleReleasePlan(
   let releases = flattenReleases(
     relevantChangesets,
     packagesByName,
-    refinedConfig,
+    config,
   );
 
   // Unlike the config/CLI validation graphs, this graph intentionally includes
@@ -184,7 +164,7 @@ function assembleReleasePlan(
   // apply-release-plan can update their version ranges in package.json.
   let dependencyGraph = getDependentsGraph(packages, {
     bumpVersionsWithWorkspaceProtocolOnly:
-      refinedConfig.bumpVersionsWithWorkspaceProtocolOnly,
+      config.bumpVersionsWithWorkspaceProtocolOnly,
   });
 
   let releasesValidated = false;
@@ -196,19 +176,19 @@ function assembleReleasePlan(
       rootDir: packages.rootDir,
       dependencyGraph,
       preInfo,
-      config: refinedConfig,
+      config,
     });
 
     // `releases` might get mutated here
     let fixedConstraintUpdated = matchFixedConstraint(
       releases,
       packagesByName,
-      refinedConfig,
+      config,
     );
     let linksUpdated = applyLinks(
       releases,
       packagesByName,
-      refinedConfig.linked,
+      config.linked,
     );
 
     releasesValidated =
@@ -232,8 +212,8 @@ function assembleReleasePlan(
         } else if (
           existingRelease.type === "none" &&
           !shouldSkipPackage(pkg, {
-            ignore: refinedConfig.ignore,
-            allowPrivatePackages: refinedConfig.privatePackages.version,
+            ignore: config.ignore,
+            allowPrivatePackages: config.privatePackages.version,
           })
         ) {
           existingRelease.type = "patch";
@@ -244,10 +224,10 @@ function assembleReleasePlan(
 
   // Caching the snapshot version here and use this if it is snapshot release
   const snapshotSuffix =
-    refinedSnapshot &&
+    snapshot &&
     getSnapshotSuffix(
-      refinedConfig.snapshot.prereleaseTemplate,
-      refinedSnapshot,
+      config.snapshot.prereleaseTemplate,
+      snapshot,
     );
 
   return {
@@ -259,7 +239,7 @@ function assembleReleasePlan(
           ? getSnapshotVersion(
               incompleteRelease,
               preInfo,
-              refinedConfig.snapshot.useCalculatedVersion,
+              config.snapshot.useCalculatedVersion,
               snapshotSuffix,
             )
           : getNewVersion(incompleteRelease, preInfo),


### PR DESCRIPTION
followup to https://github.com/changesets/changesets/pull/1652