### PR TITLE
speed up `gitdir` function by ~20%

### DIFF
--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -105,6 +105,7 @@ export async function testdir(dir?: Fixture) {
 
 export async function gitdir(dir: Fixture) {
   const cwd = await testdir(dir);
+
   await exec("git", ["init"], { nodeOptions: { cwd } });
   // so that this works regardless of what the default branch of git init is and for git versions that don't support --initial-branch(like our CI)
   {
@@ -117,19 +118,18 @@ export async function gitdir(dir: Fixture) {
       await exec("git", ["checkout", "-b", "main"], { nodeOptions: { cwd } });
     }
   }
-  await exec("git", ["config", "user.email", "x@y.z"], {
-    nodeOptions: { cwd },
-  });
-  await exec("git", ["config", "user.name", "xyz"], { nodeOptions: { cwd } });
-  await exec("git", ["config", "commit.gpgSign", "false"], {
-    nodeOptions: { cwd },
-  });
-  await exec("git", ["config", "tag.gpgSign", "false"], {
-    nodeOptions: { cwd },
-  });
-  await exec("git", ["config", "tag.forceSignAnnotated", "false"], {
-    nodeOptions: { cwd },
-  });
+
+  const gitConfig = `
+[user]
+    email = x@y.z
+    name = xyz
+[commit]
+    gpgSign = false
+[tag]
+    gpgSign = false
+    forceSignAnnotated = false
+  `.trim();
+  await fsp.appendFile(path.join(cwd, ".git/config"), gitConfig, "utf8");
 
   await exec("git", ["add", "."], { nodeOptions: { cwd } });
   await exec("git", ["commit", "-m", "initial commit", "--allow-empty"], {


### PR DESCRIPTION
from my testing this reduces the time to run tests that use `gitdir` by about 20-30%

for example:
- `git.test.ts`: 40s -> 32s
- `status.test.ts`: 10s -> 7s

seems to be about 10s faster in ci as well

<details>
<summary>ci screenshots</summary>

`next`

<img width="353" height="125" alt="image" src="https://github.com/user-attachments/assets/43eeec5e-4370-4c95-aa65-fc77707e9446" />

this pr

<img width="405" height="117" alt="image" src="https://github.com/user-attachments/assets/8fb86f1b-9012-4c87-91fa-dfde1c18792d" />

</details>