### PR TITLE
eslint update followup 1 & allow custom functions to be sync

### DIFF
--- a/.changeset/some-papayas-bet.md
+++ b/.changeset/some-papayas-bet.md
@@ -1,0 +1,5 @@
+---
+"@changesets/changelog-git": major
+---
+
+`ChangelogFunctions` can now be both sync and async, and the `defaultChangelogFunctions` are now sync.

--- a/.changeset/some-papayas-gamble.md
+++ b/.changeset/some-papayas-gamble.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": major
+---
+
+`CommitFunctions` can now be both sync and async, and the `defaultCommitFunctions` are now sync.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,7 +58,6 @@ export default defineConfig(
 
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-floating-promises": "off", // TODO enable and fix errors
-      "@typescript-eslint/no-unnecessary-type-assertion": "off", // TODO enable and fix errors
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-call": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,6 @@ export default defineConfig(
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-return": "off",
-      "@typescript-eslint/require-await": "off", // TODO enable and fix errors
       "@typescript-eslint/unbound-method": "off",
 
       // these rules are slow, require extensive config, and/or don't provide much
@@ -83,6 +82,13 @@ export default defineConfig(
   {
     files: ["**/*.{js,mjs}"],
     ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    files: ["**/*.test.*"],
+    rules: {
+      // mock functions often have to be async to match the original fn
+      "@typescript-eslint/require-await": "off",
+    },
   },
   eslintConfigPrettier,
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,7 +57,6 @@ export default defineConfig(
       ],
 
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-floating-promises": "off", // TODO enable and fix errors
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-call": "off",

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -55,7 +55,9 @@ export default async function getChangelogEntry(
     const rls = cs.releases.find((r) => r.name === release.name);
     if (rls && rls.type !== "none") {
       changelogLines[rls.type].push(
-        changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts),
+        Promise.resolve(
+          changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts),
+        ),
       );
     }
   });
@@ -102,10 +104,12 @@ export default async function getChangelogEntry(
   );
 
   changelogLines.patch.push(
-    changelogFuncs.getDependencyReleaseLine(
-      relevantChangesets,
-      dependentReleases,
-      changelogOpts,
+    Promise.resolve(
+      changelogFuncs.getDependencyReleaseLine(
+        relevantChangesets,
+        dependentReleases,
+        changelogOpts,
+      ),
     ),
   );
 

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -5,11 +5,11 @@ import type {
   ModCompWithPackage,
 } from "@changesets/types";
 
-const getReleaseLine = async (
+const getReleaseLine = (
   changeset: NewChangesetWithCommit,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _type: VersionType,
-) => {
+): string => {
   const [firstLine, ...futureLines] = changeset.summary
     .split("\n")
     .map((l) => l.trimEnd());
@@ -25,10 +25,10 @@ const getReleaseLine = async (
   return returnVal;
 };
 
-const getDependencyReleaseLine = async (
+const getDependencyReleaseLine = (
   changesets: NewChangesetWithCommit[],
   dependenciesUpdated: ModCompWithPackage[],
-) => {
+): string => {
   if (dependenciesUpdated.length === 0) return "";
 
   const changesetLinks = changesets.map(
@@ -45,9 +45,9 @@ const getDependencyReleaseLine = async (
   return [...changesetLinks, ...updatedDependenciesList].join("\n");
 };
 
-const defaultChangelogFunctions: ChangelogFunctions = {
+const defaultChangelogFunctions = {
   getReleaseLine,
   getDependencyReleaseLine,
-};
+} satisfies ChangelogFunctions;
 
 export default defaultChangelogFunctions;

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -156,13 +156,13 @@ const changelogFunctions: ChangelogFunctions = {
 
     return `\n\n-${prefix ? `${prefix} -` : ""} ${linkifyIssueRefs(firstLine, {
       serverUrl: GITHUB_SERVER_URL,
-      repo: options!.repo,
+      repo: options.repo,
     })}\n${futureLines
       .map(
         (l) =>
           `  ${linkifyIssueRefs(l, {
             serverUrl: GITHUB_SERVER_URL,
-            repo: options!.repo,
+            repo: options.repo,
           })}`,
       )
       .join("\n")}`;

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -1403,7 +1403,7 @@ describe("same package in different dependency types", () => {
 
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         devDependencies: {
@@ -2318,7 +2318,7 @@ describe("pre", () => {
       cwd,
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         dependencies: {
@@ -2516,7 +2516,7 @@ describe("pre", () => {
     );
 
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         dependencies: {
@@ -2601,7 +2601,7 @@ describe("pre", () => {
       cwd,
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2669,7 +2669,7 @@ describe("pre", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         dependencies: {
@@ -2733,7 +2733,7 @@ describe("pre", () => {
 
     await pre(cwd, { command: "enter", tag: "next" });
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2800,7 +2800,7 @@ describe("pre", () => {
     );
 
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2867,7 +2867,7 @@ describe("pre", () => {
 
     await pre(cwd, { command: "enter", tag: "next" });
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2922,7 +2922,7 @@ describe("pre", () => {
       ...modifiedDefaultConfig,
       ignore: ["pkg-a"],
     });
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -3292,7 +3292,7 @@ describe("pre", () => {
       cwd,
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -3334,7 +3334,7 @@ describe("pre", () => {
         version: true,
       },
     });
-    let packages = (await getPackages(cwd))!;
+    let packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -3376,7 +3376,7 @@ describe("pre", () => {
         cwd,
       );
       await version(cwd, defaultOptions, linkedConfig);
-      let packages = (await getPackages(cwd))!;
+      let packages = await getPackages(cwd);
 
       expect(packages.packages.map((x) => x.packageJson)).toEqual([
         {
@@ -3490,7 +3490,7 @@ describe("pre", () => {
         cwd,
       );
       await version(cwd, defaultOptions, linkedConfig);
-      let packages = (await getPackages(cwd))!;
+      let packages = await getPackages(cwd);
 
       expect(packages.packages.map((x) => x.packageJson)).toEqual([
         {
@@ -3565,7 +3565,7 @@ describe("pre", () => {
         cwd,
       );
       await version(cwd, defaultOptions, linkedConfig);
-      let packages = (await getPackages(cwd))!;
+      let packages = await getPackages(cwd);
 
       expect(packages.packages.map((x) => x.packageJson)).toEqual([
         {

--- a/packages/cli/src/commit/index.ts
+++ b/packages/cli/src/commit/index.ts
@@ -6,19 +6,19 @@ import type {
 
 type SkipCI = boolean | "add" | "version";
 
-const getAddMessage: CommitFunctions["getAddMessage"] = async (
+const getAddMessage: CommitFunctions["getAddMessage"] = (
   changeset: Changeset,
   options: { skipCI?: SkipCI } | null,
-) => {
+): string => {
   const skipCI = options?.skipCI === "add" || options?.skipCI === true;
   const skipMsg = skipCI ? `\n\n[skip ci]\n` : "";
   return `docs(changeset): ${changeset.summary}${skipMsg}`;
 };
 
-const getVersionMessage: CommitFunctions["getVersionMessage"] = async (
+const getVersionMessage: CommitFunctions["getVersionMessage"] = (
   releasePlan: ReleasePlan,
   options: { skipCI?: SkipCI } | null,
-) => {
+): string => {
   const skipCI = options?.skipCI === "version" || options?.skipCI === true;
   const publishableReleases = releasePlan.releases.filter(
     (release) => release.type !== "none",

--- a/packages/cli/src/commit/index.ts
+++ b/packages/cli/src/commit/index.ts
@@ -36,9 +36,9 @@ ${releasesLines}
 ${skipCI ? `\n[skip ci]\n` : ""}`;
 };
 
-const defaultCommitFunctions: Required<CommitFunctions> = {
+const defaultCommitFunctions = {
   getAddMessage,
   getVersionMessage,
-};
+} satisfies Required<CommitFunctions>;
 
 export default defaultCommitFunctions;

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -23,11 +23,6 @@ type ArrayPromptOptions = Extract<
       | "scale";
   }
 >;
-type BooleanPromptOptions = Extract<PromptOptions, { type: "confirm" }>;
-type StringPromptOptions = Extract<
-  PromptOptions,
-  { type: "input" | "invisible" | "list" | "password" | "text" }
->;
 
 /* Notes on using inquirer:
  * Each question needs a key, as inquirer is assembling an object behind-the-scenes.
@@ -87,7 +82,7 @@ async function askQuestion(message: string): Promise<string> {
       name,
       prefix,
       onCancel: cancelFlow,
-    } as StringPromptOptions,
+    },
   ])
     .then((responses: any) => responses[name])
     .catch((err: unknown) => {
@@ -114,7 +109,7 @@ async function askConfirm(message: string): Promise<boolean> {
       type: "confirm",
       initial: true,
       onCancel: cancelFlow,
-    } as BooleanPromptOptions,
+    },
   ])
     .then((responses: any) => responses[name])
     .catch((err: unknown) => {
@@ -136,7 +131,7 @@ async function askList<Choice extends string>(
       prefix,
       type: "select",
       onCancel: cancelFlow,
-    } as ArrayPromptOptions,
+    },
   ])
     .then((responses: any) => responses[name])
     .catch((err: unknown) => {

--- a/packages/cli/src/utils/createPromiseQueue.test.ts
+++ b/packages/cli/src/utils/createPromiseQueue.test.ts
@@ -9,33 +9,33 @@ function syncSpy(implementation: () => unknown = () => {}) {
   return vi.fn().mockImplementation(() => implementation());
 }
 
-describe("createPromiseQueue", () => {
-  it("should start jobs immediately before hitting the concurrency limit", () => {
+describe("createPromiseQueue", async () => {
+  it("should start jobs immediately before hitting the concurrency limit", async () => {
     const queue = createPromiseQueue(3);
 
     const job1 = asyncSpy();
     const job2 = asyncSpy();
     const job3 = asyncSpy();
 
-    queue.add(job1);
-    queue.add(job2);
-    queue.add(job3);
+    void queue.add(job1);
+    void queue.add(job2);
+    void queue.add(job3);
 
     expect(job1).toHaveBeenCalled();
     expect(job2).toHaveBeenCalled();
     expect(job3).toHaveBeenCalled();
   });
 
-  it("should not start a job immediately after hitting the concurrency limit", () => {
+  it("should not start a job immediately after hitting the concurrency limit", async () => {
     const queue = createPromiseQueue(2);
 
     const job1 = asyncSpy();
     const job2 = asyncSpy();
     const job3 = asyncSpy();
 
-    queue.add(job1);
-    queue.add(job2);
-    queue.add(job3);
+    void queue.add(job1);
+    void queue.add(job2);
+    void queue.add(job3);
 
     expect(job3).not.toHaveBeenCalled();
   });
@@ -47,9 +47,9 @@ describe("createPromiseQueue", () => {
     const job2 = asyncSpy();
     const job3 = asyncSpy();
 
-    queue.add(job1);
+    void queue.add(job1);
     const queuedJob2 = queue.add(job2);
-    queue.add(job3);
+    void queue.add(job3);
 
     expect(job3).not.toHaveBeenCalled();
 
@@ -127,8 +127,8 @@ describe("createPromiseQueue", () => {
     const job1 = asyncSpy();
     const job2 = asyncSpy();
 
-    queue.add(job1);
-    queue.add(job2);
+    void queue.add(job1);
+    void queue.add(job2);
 
     expect(job2).not.toHaveBeenCalled();
 

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -91,7 +91,7 @@ export default function getDependencyGraph(
   }
 
   for (const pkg of queue) {
-    const { name } = pkg!.packageJson;
+    const { name } = pkg.packageJson;
     const dependencies = [];
     const allDependencies = getAllDependencies(
       pkg.packageJson,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -131,13 +131,13 @@ export type GetReleaseLine = (
   changeset: NewChangesetWithCommit,
   type: VersionType,
   changelogOpts: null | Record<string, any>,
-) => Promise<string>;
+) => string | Promise<string>;
 
 export type GetDependencyReleaseLine = (
   changesets: NewChangesetWithCommit[],
   dependenciesUpdated: ModCompWithPackage[],
   changelogOpts: any,
-) => Promise<string>;
+) => string | Promise<string>;
 
 export type ChangelogFunctions = {
   getReleaseLine: GetReleaseLine;
@@ -147,12 +147,12 @@ export type ChangelogFunctions = {
 export type GetAddMessage = (
   changeset: Changeset,
   commitOptions: any,
-) => Promise<string>;
+) => string | Promise<string>;
 
 export type GetVersionMessage = (
   releasePlan: ReleasePlan,
   commitOptions: any,
-) => Promise<string>;
+) => string | Promise<string>;
 
 export type CommitFunctions = {
   getAddMessage?: GetAddMessage;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,5 @@
+type MaybePromise<T> = T | Promise<T>;
+
 export type VersionType = "major" | "minor" | "patch" | "none";
 
 // NB: Bolt check uses a different dependency set to every other package.
@@ -131,13 +133,13 @@ export type GetReleaseLine = (
   changeset: NewChangesetWithCommit,
   type: VersionType,
   changelogOpts: null | Record<string, any>,
-) => string | Promise<string>;
+) => MaybePromise<string>;
 
 export type GetDependencyReleaseLine = (
   changesets: NewChangesetWithCommit[],
   dependenciesUpdated: ModCompWithPackage[],
   changelogOpts: any,
-) => string | Promise<string>;
+) => MaybePromise<string>;
 
 export type ChangelogFunctions = {
   getReleaseLine: GetReleaseLine;
@@ -147,12 +149,12 @@ export type ChangelogFunctions = {
 export type GetAddMessage = (
   changeset: Changeset,
   commitOptions: any,
-) => string | Promise<string>;
+) => MaybePromise<string>;
 
 export type GetVersionMessage = (
   releasePlan: ReleasePlan,
   commitOptions: any,
-) => string | Promise<string>;
+) => MaybePromise<string>;
 
 export type CommitFunctions = {
   getAddMessage?: GetAddMessage;


### PR DESCRIPTION
follow up to #1876 

the only functional change here is allowing sync functions in `CommitFunctions` and `ChangelogFunctions`.

async is still supported, but the default functions are now sync which could be a breaking change which is why i marked them as `major`