### PR TITLE
eslint followup 2 - `prefer-const`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,6 @@ export default defineConfig(
     },
     rules: {
       eqeqeq: ["off", "always", { null: "never", undefined: "never" }], // TODO enable and fix errors
-      "prefer-const": "off", // TODO enable and fix errors
 
       "@typescript-eslint/consistent-type-exports": [
         "error",

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -59,7 +59,7 @@ export default async function getChangelogEntry(
       );
     }
   });
-  let dependentReleases = releases.filter((rel) => {
+  const dependentReleases = releases.filter((rel) => {
     const dependencyVersionRange = release.packageJson.dependencies?.[rel.name];
     const peerDependencyVersionRange =
       release.packageJson.peerDependencies?.[rel.name];
@@ -89,7 +89,7 @@ export default async function getChangelogEntry(
     );
   });
 
-  let relevantChangesetIds: Set<string> = new Set();
+  const relevantChangesetIds: Set<string> = new Set();
 
   dependentReleases.forEach((rel) => {
     rel.changesets.forEach((cs) => {
@@ -97,7 +97,7 @@ export default async function getChangelogEntry(
     });
   });
 
-  let relevantChangesets = changesets.filter((cs) =>
+  const relevantChangesets = changesets.filter((cs) =>
     relevantChangesetIds.has(cs.id),
   );
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2888,7 +2888,7 @@ describe("apply release plan", () => {
   describe("should error and not write if", () => {
     // This is skipped as *for now* we are assuming we have been passed
     // valid releasePlans - this may get work done on it in the future
-    it.skip("a package appears twice", async () => {
+    it.todo("a package appears twice", async () => {
       let changedFiles;
       try {
         const testResults = await testSetup(

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -111,7 +111,7 @@ async function testSetup(
       },
     };
   }
-  let tempDir = await testdir(fixture);
+  const tempDir = await testdir(fixture);
 
   if (setupFunc) {
     await setupFunc(tempDir);
@@ -145,7 +145,7 @@ describe("apply release plan", () => {
     describe("formatting", () => {
       it("should not reformat a small array in a package.json", async () => {
         const releasePlan = new FakeReleasePlan();
-        let { changedFiles } = await testSetup(
+        const { changedFiles } = await testSetup(
           {
             "package.json": `{
   "name": "pkg-a",
@@ -158,10 +158,10 @@ describe("apply release plan", () => {
           releasePlan.getReleasePlan(),
           releasePlan.config,
         );
-        let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
+        const pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        const pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -173,7 +173,7 @@ describe("apply release plan", () => {
       });
       it("should not change tab indentation in a package.json", async () => {
         const releasePlan = new FakeReleasePlan();
-        let { changedFiles } = await testSetup(
+        const { changedFiles } = await testSetup(
           {
             "package.json": JSON.stringify(
               {
@@ -187,10 +187,10 @@ describe("apply release plan", () => {
           releasePlan.getReleasePlan(),
           releasePlan.config,
         );
-        let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
+        const pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        const pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
 \t"name": "pkg-a",
@@ -199,7 +199,7 @@ describe("apply release plan", () => {
       });
       it("should not add trailing newlines in a package.json if they don't exist", async () => {
         const releasePlan = new FakeReleasePlan();
-        let { changedFiles } = await testSetup(
+        const { changedFiles } = await testSetup(
           {
             "package.json": JSON.stringify({
               name: "pkg-a",
@@ -209,10 +209,10 @@ describe("apply release plan", () => {
           releasePlan.getReleasePlan(),
           releasePlan.config,
         );
-        let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
+        const pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        const pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -221,7 +221,7 @@ describe("apply release plan", () => {
       });
       it("should not remove trailing newlines in a package.json if they exist", async () => {
         const releasePlan = new FakeReleasePlan();
-        let { changedFiles } = await testSetup(
+        const { changedFiles } = await testSetup(
           {
             "package.json":
               JSON.stringify({
@@ -232,10 +232,10 @@ describe("apply release plan", () => {
           releasePlan.getReleasePlan(),
           releasePlan.config,
         );
-        let pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
+        const pkgPath = changedFiles.find((a) => a.endsWith(`package.json`));
 
         if (!pkgPath) throw new Error(`could not find an updated package json`);
-        let pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
+        const pkgJSON = await fs.readFile(pkgPath, { encoding: "utf-8" });
 
         expect(pkgJSON).toStrictEqual(`{
   "name": "pkg-a",
@@ -246,7 +246,7 @@ describe("apply release plan", () => {
 
     it("should update a version for one package", async () => {
       const releasePlan = new FakeReleasePlan();
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -261,12 +261,12 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgPath = changedFiles.find((a) =>
+      const pkgPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await readJson(pkgPath);
+      const pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toMatchObject({
         name: "pkg-a",
@@ -293,7 +293,7 @@ describe("apply release plan", () => {
           },
         ],
       );
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -315,12 +315,12 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgPath = changedFiles.find((a) =>
+      const pkgPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await readJson(pkgPath);
+      const pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -350,7 +350,7 @@ describe("apply release plan", () => {
           },
         ],
       );
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -372,12 +372,12 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgPath = changedFiles.find((a) =>
+      const pkgPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await readJson(pkgPath);
+      const pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -431,7 +431,7 @@ describe("apply release plan", () => {
           },
         ],
       );
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -463,12 +463,12 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgPath = changedFiles.find((a) =>
+      const pkgPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await readJson(pkgPath);
+      const pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toEqual({
         name: "pkg-a",
@@ -513,7 +513,7 @@ describe("apply release plan", () => {
           bumpVersionsWithWorkspaceProtocolOnly: true,
         },
       );
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -542,12 +542,12 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgAPath = changedFiles.find((a) =>
+      const pkgAPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgAPath) throw new Error(`could not find an updated package json`);
-      let pkgAJSON = await readJson(pkgAPath);
+      const pkgAJSON = await readJson(pkgAPath);
 
       expect(pkgAJSON).toEqual({
         name: "pkg-a",
@@ -557,12 +557,12 @@ describe("apply release plan", () => {
         },
       });
 
-      let pkgCPath = changedFiles.find((a) =>
+      const pkgCPath = changedFiles.find((a) =>
         a.endsWith(`pkg-c${path.sep}package.json`),
       );
 
       if (!pkgCPath) throw new Error(`could not find an updated package json`);
-      let pkgCJSON = await readJson(pkgCPath);
+      const pkgCJSON = await readJson(pkgCPath);
 
       expect(pkgCJSON).toEqual({
         name: "pkg-c",
@@ -587,7 +587,7 @@ describe("apply release plan", () => {
         ],
       );
 
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -609,18 +609,18 @@ describe("apply release plan", () => {
         releasePlan.getReleasePlan(),
         releasePlan.config,
       );
-      let pkgPathA = changedFiles.find((a) =>
+      const pkgPathA = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
-      let pkgPathB = changedFiles.find((b) =>
+      const pkgPathB = changedFiles.find((b) =>
         b.endsWith(`pkg-b${path.sep}package.json`),
       );
 
       if (!pkgPathA || !pkgPathB) {
         throw new Error(`could not find an updated package json`);
       }
-      let pkgJSONA = await readJson(pkgPathA);
-      let pkgJSONB = await readJson(pkgPathB);
+      const pkgJSONA = await readJson(pkgPathA);
+      const pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONA).toMatchObject({
         name: "pkg-a",
@@ -633,7 +633,7 @@ describe("apply release plan", () => {
     });
 
     it("should not update the version of the dependent package if the released dep is a dev dep", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -703,18 +703,18 @@ describe("apply release plan", () => {
           },
         },
       );
-      let pkgPathA = changedFiles.find((a) =>
+      const pkgPathA = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
-      let pkgPathB = changedFiles.find((b) =>
+      const pkgPathB = changedFiles.find((b) =>
         b.endsWith(`pkg-b${path.sep}package.json`),
       );
 
       if (!pkgPathA || !pkgPathB) {
         throw new Error(`could not find an updated package json`);
       }
-      let pkgJSONA = await readJson(pkgPathA);
-      let pkgJSONB = await readJson(pkgPathB);
+      const pkgJSONA = await readJson(pkgPathA);
+      const pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONA).toMatchObject({
         name: "pkg-a",
@@ -730,7 +730,7 @@ describe("apply release plan", () => {
     });
 
     it("should skip dependencies that have the same name as the package", async () => {
-      let { tempDir } = await testSetup(
+      const { tempDir } = await testSetup(
         {
           "package.json": JSON.stringify({
             name: "self-referenced",
@@ -782,7 +782,7 @@ describe("apply release plan", () => {
         },
       );
 
-      let pkgJSON = await readJson(path.join(tempDir, "package.json"));
+      const pkgJSON = await readJson(path.join(tempDir, "package.json"));
 
       expect(pkgJSON).toMatchObject({
         name: "self-referenced",
@@ -794,7 +794,7 @@ describe("apply release plan", () => {
     });
 
     it("should not update dependent versions when a package has a changeset type of none", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -834,17 +834,17 @@ describe("apply release plan", () => {
         },
         { ...defaultConfig, changelog: false },
       );
-      let pkgPathA = changedFiles.find((a) =>
+      const pkgPathA = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
-      let pkgPathB = changedFiles.find((b) =>
+      const pkgPathB = changedFiles.find((b) =>
         b.endsWith(`pkg-b${path.sep}package.json`),
       );
 
       expect(pkgPathA).toBeUndefined();
       if (!pkgPathB) throw new Error(`could not find an updated package json`);
 
-      let pkgJSONB = await readJson(pkgPathB);
+      const pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONB).toMatchObject({
         name: "pkg-b",
@@ -853,7 +853,7 @@ describe("apply release plan", () => {
     });
 
     it("should not update workspace dependent versions when a package has a changeset type of none", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -893,17 +893,17 @@ describe("apply release plan", () => {
         },
         { ...defaultConfig, changelog: false },
       );
-      let pkgPathA = changedFiles.find((a) =>
+      const pkgPathA = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
-      let pkgPathB = changedFiles.find((b) =>
+      const pkgPathB = changedFiles.find((b) =>
         b.endsWith(`pkg-b${path.sep}package.json`),
       );
 
       expect(pkgPathA).toBeUndefined();
       if (!pkgPathB) throw new Error(`could not find an updated package json`);
 
-      let pkgJSONB = await readJson(pkgPathB);
+      const pkgJSONB = await readJson(pkgPathB);
 
       expect(pkgJSONB).toMatchObject({
         name: "pkg-b",
@@ -930,7 +930,7 @@ describe("apply release plan", () => {
           },
         ],
       );
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -954,12 +954,12 @@ describe("apply release plan", () => {
         "canary",
       );
 
-      let pkgPath = changedFiles.find((a) =>
+      const pkgPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}package.json`),
       );
 
       if (!pkgPath) throw new Error(`could not find an updated package json`);
-      let pkgJSON = await readJson(pkgPath);
+      const pkgJSON = await readJson(pkgPath);
 
       expect(pkgJSON).toMatchObject({
         name: "pkg-a",
@@ -974,7 +974,7 @@ describe("apply release plan", () => {
       describe("updateInternalDependencies set to patch", () => {
         const updateInternalDependencies = "patch";
         it("should update min version ranges of patch bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1047,18 +1047,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1076,7 +1076,7 @@ describe("apply release plan", () => {
           });
         });
         it("should still update min version ranges of patch bumped internal dependencies that have left semver range", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1165,18 +1165,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1195,7 +1195,7 @@ describe("apply release plan", () => {
           });
         });
         it("should update min version ranges of minor bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1268,18 +1268,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1297,7 +1297,7 @@ describe("apply release plan", () => {
           });
         });
         it("should update min version ranges of major bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1370,18 +1370,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1399,7 +1399,7 @@ describe("apply release plan", () => {
           });
         });
         it("should not update dependant's dependency range when it depends on a tag of a bumped dependency", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1472,18 +1472,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1504,7 +1504,7 @@ describe("apply release plan", () => {
       describe("updateInternalDependencies set to minor", () => {
         const updateInternalDependencies = "minor";
         it("should NOT update min version ranges of patch bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1577,18 +1577,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1606,7 +1606,7 @@ describe("apply release plan", () => {
           });
         });
         it("should still update min version ranges of patch bumped internal dependencies that have left semver range", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1695,18 +1695,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1725,7 +1725,7 @@ describe("apply release plan", () => {
           });
         });
         it("should update min version ranges of minor bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1806,18 +1806,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1835,7 +1835,7 @@ describe("apply release plan", () => {
           });
         });
         it("should update min version ranges of major bumped internal dependencies", async () => {
-          let { changedFiles } = await testSetup(
+          const { changedFiles } = await testSetup(
             {
               "package.json": JSON.stringify({
                 private: true,
@@ -1908,18 +1908,18 @@ describe("apply release plan", () => {
               },
             },
           );
-          let pkgPathA = changedFiles.find((a) =>
+          const pkgPathA = changedFiles.find((a) =>
             a.endsWith(`pkg-a${path.sep}package.json`),
           );
-          let pkgPathB = changedFiles.find((b) =>
+          const pkgPathB = changedFiles.find((b) =>
             b.endsWith(`pkg-b${path.sep}package.json`),
           );
 
           if (!pkgPathA || !pkgPathB) {
             throw new Error(`could not find an updated package json`);
           }
-          let pkgJSONA = await readJson(pkgPathA);
-          let pkgJSONB = await readJson(pkgPathB);
+          const pkgJSONA = await readJson(pkgPathA);
+          const pkgJSONB = await readJson(pkgPathB);
 
           expect(pkgJSONA).toMatchObject({
             name: "pkg-a",
@@ -1941,7 +1941,7 @@ describe("apply release plan", () => {
 
     describe("onlyUpdatePeerDependentsWhenOutOfRange set to true", () => {
       it("should not bump peerDependencies if they are still in range", async () => {
-        let { changedFiles } = await testSetup(
+        const { changedFiles } = await testSetup(
           {
             "package.json": JSON.stringify({
               private: true,
@@ -2011,18 +2011,18 @@ describe("apply release plan", () => {
             },
           },
         );
-        let pkgPathDependent = changedFiles.find((a) =>
+        const pkgPathDependent = changedFiles.find((a) =>
           a.endsWith(`has-peer-dep${path.sep}package.json`),
         );
-        let pkgPathDepended = changedFiles.find((b) =>
+        const pkgPathDepended = changedFiles.find((b) =>
           b.endsWith(`depended-upon${path.sep}package.json`),
         );
 
         if (!pkgPathDependent || !pkgPathDepended) {
           throw new Error(`could not find an updated package json`);
         }
-        let pkgJSONDependent = await readJson(pkgPathDependent);
-        let pkgJSONDepended = await readJson(pkgPathDepended);
+        const pkgJSONDependent = await readJson(pkgPathDependent);
+        const pkgJSONDepended = await readJson(pkgPathDepended);
 
         expect(pkgJSONDependent).toMatchObject({
           name: "has-peer-dep",
@@ -2042,7 +2042,7 @@ describe("apply release plan", () => {
   describe("changelogs", () => {
     it("should not generate any changelogs", async () => {
       const releasePlan = new FakeReleasePlan();
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2068,7 +2068,7 @@ describe("apply release plan", () => {
 
     it("should update a changelog for one package", async () => {
       const releasePlan = new FakeReleasePlan();
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2093,12 +2093,12 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2111,7 +2111,7 @@ describe("apply release plan", () => {
 
     it("should insert new entry before existing version heading when no package title is present", async () => {
       const releasePlan = new FakeReleasePlan();
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2138,12 +2138,12 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
 
       expect(readme).toMatchInlineSnapshot(`
         "## 1.1.0
@@ -2175,7 +2175,7 @@ describe("apply release plan", () => {
         ],
       );
 
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2207,17 +2207,17 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
-      let readmePathB = changedFiles.find((a) =>
+      const readmePathB = changedFiles.find((a) =>
         a.endsWith(`pkg-b${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
+      const readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2237,7 +2237,7 @@ describe("apply release plan", () => {
     });
 
     it("should not update the changelog if only devDeps changed", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2313,7 +2313,7 @@ describe("apply release plan", () => {
           },
         },
       );
-      let pkgAChangelogPath = changedFiles.find((a) =>
+      const pkgAChangelogPath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
 
@@ -2335,7 +2335,7 @@ describe("apply release plan", () => {
       ]);
       releasePlan.releases[0].changesets.push("some-id-1", "some-id-2");
 
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2360,12 +2360,12 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
       expect(readme.trim()).toEqual(
         [
           "# pkg-a\n",
@@ -2381,7 +2381,7 @@ describe("apply release plan", () => {
     });
 
     it("should add an updated dependencies line when dependencies have been updated", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2461,17 +2461,17 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
-      let readmePathB = changedFiles.find((a) =>
+      const readmePathB = changedFiles.find((a) =>
         a.endsWith(`pkg-b${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
+      const readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2495,7 +2495,7 @@ describe("apply release plan", () => {
     });
 
     it("should NOT add updated dependencies line if dependencies have NOT been updated", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2575,17 +2575,17 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
-      let readmePathB = changedFiles.find((a) =>
+      const readmePathB = changedFiles.find((a) =>
         a.endsWith(`pkg-b${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath || !readmePathB)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
+      const readmeB = await fs.readFile(readmePathB, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2605,7 +2605,7 @@ describe("apply release plan", () => {
     });
 
     it("should only add updated dependencies line for dependencies that have been updated", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2701,21 +2701,21 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
-      let readmePathB = changedFiles.find((a) =>
+      const readmePathB = changedFiles.find((a) =>
         a.endsWith(`pkg-b${path.sep}CHANGELOG.md`),
       );
-      let readmePathC = changedFiles.find((a) =>
+      const readmePathC = changedFiles.find((a) =>
         a.endsWith(`pkg-c${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
-      let readmeC = await fs.readFile(readmePathC, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
+      const readmeB = await fs.readFile(readmePathB, "utf-8");
+      const readmeC = await fs.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2745,7 +2745,7 @@ describe("apply release plan", () => {
     });
 
     it("should still add updated dependencies line for dependencies that have a bump type less than the minimum internal bump range but leave semver range", async () => {
-      let { changedFiles } = await testSetup(
+      const { changedFiles } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -2841,21 +2841,21 @@ describe("apply release plan", () => {
         },
       );
 
-      let readmePath = changedFiles.find((a) =>
+      const readmePath = changedFiles.find((a) =>
         a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
       );
-      let readmePathB = changedFiles.find((a) =>
+      const readmePathB = changedFiles.find((a) =>
         a.endsWith(`pkg-b${path.sep}CHANGELOG.md`),
       );
-      let readmePathC = changedFiles.find((a) =>
+      const readmePathC = changedFiles.find((a) =>
         a.endsWith(`pkg-c${path.sep}CHANGELOG.md`),
       );
 
       if (!readmePath || !readmePathB || !readmePathC)
         throw new Error(`could not find an updated changelog`);
-      let readme = await fs.readFile(readmePath, "utf-8");
-      let readmeB = await fs.readFile(readmePathB, "utf-8");
-      let readmeC = await fs.readFile(readmePathC, "utf-8");
+      const readme = await fs.readFile(readmePath, "utf-8");
+      const readmeB = await fs.readFile(readmePathB, "utf-8");
+      const readmeC = await fs.readFile(readmePathC, "utf-8");
 
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
@@ -2891,7 +2891,7 @@ describe("apply release plan", () => {
     it.skip("a package appears twice", async () => {
       let changedFiles;
       try {
-        let testResults = await testSetup(
+        const testResults = await testSetup(
           {
             "package.json": JSON.stringify({
               private: true,
@@ -2946,7 +2946,7 @@ describe("apply release plan", () => {
     });
 
     it("a package cannot be found", async () => {
-      let releasePlan = new FakeReleasePlan(
+      const releasePlan = new FakeReleasePlan(
         [],
         [
           {
@@ -2959,7 +2959,7 @@ describe("apply release plan", () => {
         ],
       );
 
-      let tempDir = await testdir({
+      const tempDir = await testdir({
         "package.json": JSON.stringify({
           private: true,
           workspaces: ["packages/*"],
@@ -2996,7 +2996,7 @@ describe("apply release plan", () => {
           "Could not find matching package for release of: impossible-package",
         );
 
-        let gitCmd = await exec("git", ["status"], {
+        const gitCmd = await exec("git", ["status"], {
           nodeOptions: { cwd: tempDir },
         });
 
@@ -3013,9 +3013,9 @@ describe("apply release plan", () => {
     it(
       "a provided changelog function fails",
       temporarilySilenceLogs(async () => {
-        let releasePlan = new FakeReleasePlan();
+        const releasePlan = new FakeReleasePlan();
 
-        let tempDir = await testdir({
+        const tempDir = await testdir({
           "package.json": JSON.stringify({
             private: true,
             workspaces: ["packages/*"],
@@ -3056,7 +3056,7 @@ describe("apply release plan", () => {
           // eslint-disable-next-line vitest/no-conditional-expect
           expect((e as Error).message).toEqual("no chance");
 
-          let gitCmd = await exec("git", ["status"], {
+          const gitCmd = await exec("git", ["status"], {
             nodeOptions: { cwd: tempDir },
           });
 
@@ -3117,7 +3117,7 @@ describe("apply release plan", () => {
         setupFunc,
       );
 
-      let changesetExists = existsSync(changesetPath);
+      const changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(false);
     });
 
@@ -3154,7 +3154,7 @@ describe("apply release plan", () => {
         setupFunc,
       );
 
-      let changesetExists = existsSync(changesetPath);
+      const changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(true);
     });
 
@@ -3195,7 +3195,7 @@ describe("apply release plan", () => {
         setupFunc,
       );
 
-      let changesetExists = existsSync(changesetPath);
+      const changesetExists = existsSync(changesetPath);
       expect(changesetExists).toEqual(true);
     });
 
@@ -3248,8 +3248,8 @@ describe("apply release plan", () => {
         setupFunc,
       );
 
-      let mdPathExists = existsSync(changesetMDPath);
-      let JSONPathExists = existsSync(changesetJSONPath);
+      const mdPathExists = existsSync(changesetMDPath);
+      const JSONPathExists = existsSync(changesetJSONPath);
 
       expect(mdPathExists).toEqual(false);
       expect(JSONPathExists).toEqual(false);
@@ -3282,7 +3282,7 @@ describe("apply release plan", () => {
         }),
       );
 
-    let { tempDir } = await testSetup(
+    const { tempDir } = await testSetup(
       {
         "package.json": JSON.stringify({
           private: true,
@@ -3316,12 +3316,12 @@ describe("apply release plan", () => {
       setupFunc,
     );
 
-    let thing = await exec("git", ["rev-list", "HEAD"], {
+    const thing = await exec("git", ["rev-list", "HEAD"], {
       nodeOptions: { cwd: tempDir },
     });
-    let commits = thing.stdout.split("\n").filter((x) => x);
+    const commits = thing.stdout.split("\n").filter((x) => x);
 
-    let lastCommit = commits[commits.length - 1].substring(0, 7);
+    const lastCommit = commits[commits.length - 1].substring(0, 7);
 
     expect(
       await fs.readFile(
@@ -3342,7 +3342,7 @@ describe("apply release plan", () => {
     it("shouldn't commit updated files from packages", async () => {
       const releasePlan = new FakeReleasePlan();
 
-      let { tempDir } = await testSetup(
+      const { tempDir } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -3374,7 +3374,7 @@ describe("apply release plan", () => {
         },
       );
 
-      let gitCmd = await exec("git", ["status"], {
+      const gitCmd = await exec("git", ["status"], {
         nodeOptions: { cwd: tempDir },
       });
 
@@ -3386,7 +3386,7 @@ describe("apply release plan", () => {
         "modified:   packages/pkg-a/package.json",
       );
 
-      let lastCommit = await exec("git", ["log", "-1"], {
+      const lastCommit = await exec("git", ["log", "-1"], {
         nodeOptions: { cwd: tempDir },
       });
 
@@ -3408,7 +3408,7 @@ describe("apply release plan", () => {
           }),
         );
 
-      let { tempDir } = await testSetup(
+      const { tempDir } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -3442,11 +3442,11 @@ describe("apply release plan", () => {
         setupFunc,
       );
 
-      let changesetExists = existsSync(changesetPath);
+      const changesetExists = existsSync(changesetPath);
 
       expect(changesetExists).toEqual(false);
 
-      let gitCmd = await exec("git", ["status"], {
+      const gitCmd = await exec("git", ["status"], {
         nodeOptions: { cwd: tempDir },
       });
 
@@ -3476,7 +3476,7 @@ describe("apply release plan", () => {
         changesets: [],
       };
 
-      let { tempDir } = await testSetup(
+      const { tempDir } = await testSetup(
         {
           "package.json": JSON.stringify({
             private: true,
@@ -3512,7 +3512,7 @@ describe("apply release plan", () => {
         },
       );
 
-      let gitCmd = await exec("git", ["status"], {
+      const gitCmd = await exec("git", ["status"], {
         nodeOptions: { cwd: tempDir },
       });
 

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -173,7 +173,10 @@ export default async function applyReleasePlan(
     const changesetFolder = path.resolve(cwd, ".changeset");
     await Promise.all(
       changesets.map(async (changeset) => {
-        const changesetPath = path.resolve(changesetFolder, `${changeset.id}.md`);
+        const changesetPath = path.resolve(
+          changesetFolder,
+          `${changeset.id}.md`,
+        );
         const changesetFolderPath = path.resolve(changesetFolder, changeset.id);
         if (
           await fs.access(changesetPath).then(

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -79,18 +79,18 @@ export default async function applyReleasePlan(
   snapshot?: string | boolean,
   contextDir = import.meta.dirname,
 ) {
-  let cwd = packages.rootDir;
+  const cwd = packages.rootDir;
 
-  let touchedFiles = [];
+  const touchedFiles = [];
 
   const packagesByName = new Map(
     packages.packages.map((x) => [x.packageJson.name, x]),
   );
 
-  let { releases, changesets } = releasePlan;
+  const { releases, changesets } = releasePlan;
 
-  let releasesWithPackage = releases.map((release) => {
-    let pkg = packagesByName.get(release.name);
+  const releasesWithPackage = releases.map((release) => {
+    const pkg = packagesByName.get(release.name);
     if (!pkg)
       throw new Error(
         `Could not find matching package for release of: ${release.name}`,
@@ -102,7 +102,7 @@ export default async function applyReleasePlan(
   });
 
   // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
-  let releaseWithChangelogs = await getNewChangelogEntry(
+  const releaseWithChangelogs = await getNewChangelogEntry(
     releasesWithPackage,
     changesets,
     config,
@@ -125,7 +125,7 @@ export default async function applyReleasePlan(
     touchedFiles.push(path.join(cwd, ".changeset", "pre.json"));
   }
 
-  let versionsToUpdate = releases.map(
+  const versionsToUpdate = releases.map(
     ({ name, newVersion, oldVersion, type }) => ({
       name,
       version: newVersion,
@@ -136,7 +136,7 @@ export default async function applyReleasePlan(
   );
 
   // iterate over releases updating packages
-  let finalisedRelease = releaseWithChangelogs.map((release) => {
+  const finalisedRelease = releaseWithChangelogs.map((release) => {
     return versionPackage(release, versionsToUpdate, {
       cwd,
       updateInternalDependencies: config.updateInternalDependencies,
@@ -149,11 +149,11 @@ export default async function applyReleasePlan(
     });
   });
 
-  let prettierInstance =
+  const prettierInstance =
     config.prettier !== false ? getPrettierInstance(cwd) : undefined;
 
-  for (let release of finalisedRelease) {
-    let { changelog, packageJson, dir, name } = release;
+  for (const release of finalisedRelease) {
+    const { changelog, packageJson, dir, name } = release;
 
     const pkgJSONPath = path.resolve(dir, "package.json");
     await updatePackageJson(pkgJSONPath, packageJson);
@@ -170,11 +170,11 @@ export default async function applyReleasePlan(
     releasePlan.preState === undefined ||
     releasePlan.preState.mode === "exit"
   ) {
-    let changesetFolder = path.resolve(cwd, ".changeset");
+    const changesetFolder = path.resolve(cwd, ".changeset");
     await Promise.all(
       changesets.map(async (changeset) => {
-        let changesetPath = path.resolve(changesetFolder, `${changeset.id}.md`);
-        let changesetFolderPath = path.resolve(changesetFolder, changeset.id);
+        const changesetPath = path.resolve(changesetFolder, `${changeset.id}.md`);
+        const changesetFolderPath = path.resolve(changesetFolder, changeset.id);
         if (
           await fs.access(changesetPath).then(
             () => true,
@@ -237,7 +237,7 @@ async function getNewChangelogEntry(
   };
 
   const changelogOpts = config.changelog[1];
-  let changesetPath = path.join(cwd, ".changeset");
+  const changesetPath = path.join(cwd, ".changeset");
   let changelogPath;
 
   try {
@@ -264,18 +264,18 @@ async function getNewChangelogEntry(
     throw new Error("Could not resolve changelog generation functions");
   }
 
-  let commits = await getCommitsThatAddChangesets(
+  const commits = await getCommitsThatAddChangesets(
     changesets.map((cs) => cs.id),
     cwd,
   );
-  let moddedChangesets = changesets.map((cs, i) => ({
+  const moddedChangesets = changesets.map((cs, i) => ({
     ...cs,
     commit: commits[i],
   }));
 
   return Promise.all(
     releasesWithPackage.map(async (release) => {
-      let changelog = await getChangelogEntry(
+      const changelog = await getChangelogEntry(
         cwd,
         release,
         releasesWithPackage,
@@ -312,7 +312,7 @@ async function updateChangelog(
   name: string,
   prettierInstance: typeof prettier | undefined,
 ) {
-  let templateString = `\n\n${changelog.trim()}\n`;
+  const templateString = `\n\n${changelog.trim()}\n`;
   let fileData;
 
   try {

--- a/packages/apply-release-plan/src/test-utils/get-changelog-entry-with-git-hash.ts
+++ b/packages/apply-release-plan/src/test-utils/get-changelog-entry-with-git-hash.ts
@@ -38,20 +38,20 @@ export default async function defaultChangelogGetter(
   relevantChangesets: RelevantChangesets,
   options: { cwd: string },
 ) {
-  let { cwd } = options;
+  const { cwd } = options;
 
   // First, we construct the release lines, summaries of changesets that caused us to be released
-  let majorReleaseLines = await getReleaseLines(
+  const majorReleaseLines = await getReleaseLines(
     relevantChangesets,
     "major",
     cwd,
   );
-  let minorReleaseLines = await getReleaseLines(
+  const minorReleaseLines = await getReleaseLines(
     relevantChangesets,
     "minor",
     cwd,
   );
-  let patchReleaseLines = await getReleaseLines(
+  const patchReleaseLines = await getReleaseLines(
     relevantChangesets,
     "patch",
     cwd,

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -43,14 +43,14 @@ export default function versionPackage(
     snapshot?: string | boolean | undefined;
   },
 ) {
-  let { newVersion, packageJson } = release;
+  const { newVersion, packageJson } = release;
 
   packageJson.version = newVersion;
 
-  for (let depType of DEPENDENCY_TYPES) {
-    let deps = packageJson[depType];
+  for (const depType of DEPENDENCY_TYPES) {
+    const deps = packageJson[depType];
     if (deps) {
-      for (let { name, version, oldVersion, type, dir } of versionsToUpdate) {
+      for (const { name, version, oldVersion, type, dir } of versionsToUpdate) {
         let depCurrentVersion = deps[name];
         if (
           !depCurrentVersion ||

--- a/packages/assemble-release-plan/src/apply-links.ts
+++ b/packages/assemble-release-plan/src/apply-links.ts
@@ -22,9 +22,9 @@ export default function applyLinks(
   let updated = false;
 
   // We do this for each set of linked packages
-  for (let linkedPackages of linked) {
+  for (const linkedPackages of linked) {
     // First we filter down to all the relevant releases for one set of linked packages
-    let releasingLinkedPackages = [...releases.values()].filter(
+    const releasingLinkedPackages = [...releases.values()].filter(
       (release) =>
         linkedPackages.includes(release.name) && release.type !== "none",
     );
@@ -33,14 +33,14 @@ export default function applyLinks(
     // not need one, as they only have workspace based packages
     if (releasingLinkedPackages.length === 0) continue;
 
-    let highestReleaseType = getHighestReleaseType(releasingLinkedPackages);
-    let highestVersion = getCurrentHighestVersion(
+    const highestReleaseType = getHighestReleaseType(releasingLinkedPackages);
+    const highestVersion = getCurrentHighestVersion(
       linkedPackages,
       packagesByName,
     );
 
     // Finally, we update the packages so all of them are on the highest version
-    for (let linkedPackage of releasingLinkedPackages) {
+    for (const linkedPackage of releasingLinkedPackages) {
       if (linkedPackage.type !== highestReleaseType) {
         updated = true;
         linkedPackage.type = highestReleaseType;

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -42,7 +42,7 @@ export default function determineDependents({
 }): boolean {
   let updated = false;
   // NOTE this is intended to be called recursively
-  let pkgsToSearch = [...releases.values()];
+  const pkgsToSearch = [...releases.values()];
 
   while (pkgsToSearch.length > 0) {
     // nextRelease is our dependency, think of it as "avatar"
@@ -163,7 +163,7 @@ export default function determineDependents({
 
           pkgsToSearch.push(existing);
         } else {
-          let newDependent: InternalRelease = {
+          const newDependent: InternalRelease = {
             name,
             type,
             oldVersion: pkgJSON.version,

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -11,7 +11,7 @@ export default function flattenReleases(
   packagesByName: Map<string, Package>,
   config: Config,
 ): Map<string, InternalRelease> {
-  let releases: Map<string, InternalRelease> = new Map();
+  const releases: Map<string, InternalRelease> = new Map();
 
   changesets.forEach((changeset) => {
     changeset.releases
@@ -29,7 +29,7 @@ export default function flattenReleases(
         });
       })
       .forEach(({ name, type }) => {
-        let pkg = mapGetOrThrowInternal(
+        const pkg = mapGetOrThrowInternal(
           packagesByName,
           name,
           `Couldn't find package named "${name}" listed in changeset "${changeset.id}"`,

--- a/packages/assemble-release-plan/src/increment.ts
+++ b/packages/assemble-release-plan/src/increment.ts
@@ -12,7 +12,7 @@ export function incrementVersion(
 
   let version = semverInc(release.oldVersion, release.type)!;
   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
-    let preVersion = mapGetOrThrowInternal(
+    const preVersion = mapGetOrThrowInternal(
       preInfo.preVersions,
       release.name,
       `preVersion for ${release.name} does not exist when preState is defined`,

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -15,7 +15,7 @@ describe("assemble-release-plan", () => {
   });
 
   it("should assemble release plan for basic setup", () => {
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -33,7 +33,7 @@ describe("assemble-release-plan", () => {
   });
 
   it("should assemble release plan for basic setup with snapshot", () => {
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -48,7 +48,7 @@ describe("assemble-release-plan", () => {
   });
 
   it("should assemble release plan for basic setup with snapshot and tag", () => {
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -72,7 +72,7 @@ describe("assemble-release-plan", () => {
       ],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -95,7 +95,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -133,7 +133,7 @@ describe("assemble-release-plan", () => {
       ],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -161,7 +161,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -179,7 +179,7 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-a", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -198,7 +198,7 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -220,7 +220,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -240,7 +240,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       {
@@ -265,7 +265,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       {
@@ -295,7 +295,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -319,7 +319,7 @@ describe("assemble-release-plan", () => {
       ],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -342,7 +342,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-b", type: "none" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -362,7 +362,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -380,7 +380,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -398,7 +398,7 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "minor" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -547,7 +547,7 @@ describe("assemble-release-plan", () => {
     setup.updateDevDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -590,7 +590,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-a", type: "minor" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -615,7 +615,7 @@ describe("assemble-release-plan", () => {
 
       setup.updatePackage("pkg-c", "2.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -648,7 +648,7 @@ describe("assemble-release-plan", () => {
 
       setup.updateDependency("pkg-c", "pkg-a", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -683,7 +683,7 @@ describe("assemble-release-plan", () => {
 
       setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -707,7 +707,7 @@ describe("assemble-release-plan", () => {
       expect(releases[3].newVersion).toEqual("1.1.0");
     });
     it("should return an empty release array when no changes will occur", () => {
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         [],
         setup.packages,
         {
@@ -731,7 +731,7 @@ describe("assemble-release-plan", () => {
         releases: [{ type: "minor", name: "pkg-a" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -765,7 +765,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-b", type: "major" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -790,7 +790,7 @@ describe("assemble-release-plan", () => {
 
       setup.updatePackage("pkg-c", "2.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -823,7 +823,7 @@ describe("assemble-release-plan", () => {
 
       setup.updateDependency("pkg-c", "pkg-a", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -843,7 +843,7 @@ describe("assemble-release-plan", () => {
       expect(releases[3].newVersion).toEqual("1.1.0");
     });
     it("should return an empty release array when no changes will occur", () => {
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         [],
         setup.packages,
         {
@@ -866,7 +866,7 @@ describe("assemble-release-plan", () => {
         releases: [{ type: "minor", name: "pkg-c" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1029,7 +1029,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-b", type: "none" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         defaultConfig,
@@ -1049,7 +1049,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-b", type: "none" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         defaultConfig,
@@ -1065,7 +1065,7 @@ describe("assemble-release-plan", () => {
     it("should assemble release plan with workspace:* dependencies", () => {
       setup.updateDependency("pkg-b", "pkg-a", "workspace:*");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         defaultConfig,
@@ -1085,7 +1085,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-b", type: "none" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         defaultConfig,
@@ -1101,7 +1101,7 @@ describe("assemble-release-plan", () => {
     it("should assemble release plan with workspace path dependencies", () => {
       setup.updateDependency("pkg-b", "pkg-a", "workspace:packages/pkg-a");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         defaultConfig,
@@ -1120,7 +1120,7 @@ describe("assemble-release-plan", () => {
     it("should bump a direct dependent when a dependency package gets bumped", () => {
       setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1144,7 +1144,7 @@ describe("assemble-release-plan", () => {
       setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
       setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1173,7 +1173,7 @@ describe("assemble-release-plan", () => {
         releases: [{ name: "pkg-c", type: "none" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1197,7 +1197,7 @@ describe("assemble-release-plan", () => {
       setup.updateDevDependency("pkg-b", "pkg-a", "^1.0.0");
       setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1233,7 +1233,7 @@ describe("version update thoroughness", () => {
   });
 
   it("should patch a single pinned dependent", () => {
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1251,7 +1251,7 @@ describe("version update thoroughness", () => {
       releases: [{ name: "pkg-a", type: "minor" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1272,7 +1272,7 @@ describe("version update thoroughness", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1301,7 +1301,7 @@ describe("bumping peerDeps", () => {
   it("should patch a pinned peerDep", () => {
     setup.updatePeerDependency("pkg-b", "pkg-a", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1322,7 +1322,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "none" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1336,7 +1336,7 @@ describe("bumping peerDeps", () => {
   it("should not bump the dependent when bumping a tilde peerDep by a patch", () => {
     setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1354,7 +1354,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "minor" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1374,7 +1374,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1395,7 +1395,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "none" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1409,7 +1409,7 @@ describe("bumping peerDeps", () => {
   it("should not bump dependent when bumping caret peerDep by patch", () => {
     setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1427,7 +1427,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "minor" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1447,7 +1447,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "major" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1469,7 +1469,7 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "minor" }],
     });
 
-    let { releases } = assembleReleasePlan(
+    const { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
       defaultConfig,
@@ -1498,7 +1498,7 @@ describe("bumping peerDeps", () => {
         id: "anyway-the-windblows",
         releases: [{ name: "pkg-a", type: "minor" }],
       });
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {
@@ -1522,7 +1522,7 @@ describe("bumping peerDeps", () => {
         releases: [{ name: "pkg-a", type: "minor" }],
       });
 
-      let { releases } = assembleReleasePlan(
+      const { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
         {

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -25,7 +25,7 @@ type SnapshotReleaseParameters = {
 };
 
 function getPreVersion(version: string) {
-  let parsed = semverParse(version)!;
+  const parsed = semverParse(version)!;
   let preVersion =
     parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
   if (typeof preVersion !== "number") {
@@ -39,7 +39,7 @@ function getSnapshotSuffix(
   template: Config["snapshot"]["prereleaseTemplate"],
   snapshotParameters: SnapshotReleaseParameters,
 ): string {
-  let snapshotRefDate = new Date();
+  const snapshotRefDate = new Date();
 
   const placeholderValues = {
     commit: snapshotParameters.commit,
@@ -131,7 +131,7 @@ function assembleReleasePlan(
   // snapshot: { tag: "canary" }    ->  --snapshot canary
   snapshot?: SnapshotReleaseParameters,
 ): ReleasePlan {
-  let packagesByName = new Map(
+  const packagesByName = new Map(
     packages.packages.map((x) => [x.packageJson.name, x]),
   );
 
@@ -147,13 +147,13 @@ function assembleReleasePlan(
   // releases is, at this point a list of all packages we are going to releases,
   // flattened down to one release per package, having a reference back to their
   // changesets, and with a calculated new versions
-  let releases = flattenReleases(relevantChangesets, packagesByName, config);
+  const releases = flattenReleases(relevantChangesets, packagesByName, config);
 
   // Unlike the config/CLI validation graphs, this graph intentionally includes
   // devDependencies. While devDeps don't cause version bumps (determineDependents
   // assigns type "none"), they must appear in the release plan so that
   // apply-release-plan can update their version ranges in package.json.
-  let dependencyGraph = getDependentsGraph(packages, {
+  const dependencyGraph = getDependentsGraph(packages, {
     bumpVersionsWithWorkspaceProtocolOnly:
       config.bumpVersionsWithWorkspaceProtocolOnly,
   });
@@ -161,7 +161,7 @@ function assembleReleasePlan(
   let releasesValidated = false;
   while (releasesValidated === false) {
     // The map passed in to determineDependents will be mutated
-    let dependentAdded = determineDependents({
+    const dependentAdded = determineDependents({
       releases,
       packagesByName,
       rootDir: packages.rootDir,
@@ -171,19 +171,19 @@ function assembleReleasePlan(
     });
 
     // `releases` might get mutated here
-    let fixedConstraintUpdated = matchFixedConstraint(
+    const fixedConstraintUpdated = matchFixedConstraint(
       releases,
       packagesByName,
       config,
     );
-    let linksUpdated = applyLinks(releases, packagesByName, config.linked);
+    const linksUpdated = applyLinks(releases, packagesByName, config.linked);
 
     releasesValidated =
       !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
   }
 
   if (preInfo?.state.mode === "exit") {
-    for (let pkg of packages.packages) {
+    for (const pkg of packages.packages) {
       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
       // we want to give it a patch release.
       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
@@ -274,7 +274,7 @@ function getRelevantChangesets(
   }
 
   if (preState && preState.mode !== "exit") {
-    let usedChangesetIds = new Set(preState.changesets);
+    const usedChangesetIds = new Set(preState.changesets);
     return changesets.filter(
       (changeset) => !usedChangesetIds.has(changeset.id),
     );
@@ -289,7 +289,7 @@ function getHighestPreVersion(
   packagesByName: Map<string, Package>,
 ): number {
   let highestPreVersion = 0;
-  for (let pkgName of packageGroup) {
+  for (const pkgName of packageGroup) {
     const pkg = mapGetOrThrowInternal(
       packagesByName,
       pkgName,
@@ -315,7 +315,7 @@ function getPreInfo(
     return;
   }
 
-  let updatedPreState = {
+  const updatedPreState = {
     ...preState,
     changesets: changesets.map((changeset) => changeset.id),
     initialVersions: {
@@ -331,7 +331,7 @@ function getPreInfo(
   }
   // Populate preVersion
   // preVersion is the map between package name and its next pre version number.
-  let preVersions = new Map<string, number>();
+  const preVersions = new Map<string, number>();
   for (const [, pkg] of packagesByName) {
     if (
       shouldSkipPackage(pkg, {
@@ -346,23 +346,23 @@ function getPreInfo(
       getPreVersion(pkg.packageJson.version),
     );
   }
-  for (let fixedGroup of config.fixed) {
-    let highestPreVersion = getHighestPreVersion(
+  for (const fixedGroup of config.fixed) {
+    const highestPreVersion = getHighestPreVersion(
       "fixed",
       fixedGroup,
       packagesByName,
     );
-    for (let fixedPackage of fixedGroup) {
+    for (const fixedPackage of fixedGroup) {
       preVersions.set(fixedPackage, highestPreVersion);
     }
   }
-  for (let linkedGroup of config.linked) {
-    let highestPreVersion = getHighestPreVersion(
+  for (const linkedGroup of config.linked) {
+    const highestPreVersion = getHighestPreVersion(
       "linked",
       linkedGroup,
       packagesByName,
     );
-    for (let linkedPackage of linkedGroup) {
+    for (const linkedPackage of linkedGroup) {
       preVersions.set(linkedPackage, highestPreVersion);
     }
   }

--- a/packages/assemble-release-plan/src/match-fixed-constraint.ts
+++ b/packages/assemble-release-plan/src/match-fixed-constraint.ts
@@ -14,22 +14,22 @@ export default function matchFixedConstraint(
 ): boolean {
   let updated = false;
 
-  for (let fixedPackages of config.fixed) {
-    let releasingFixedPackages = [...releases.values()].filter(
+  for (const fixedPackages of config.fixed) {
+    const releasingFixedPackages = [...releases.values()].filter(
       (release) =>
         fixedPackages.includes(release.name) && release.type !== "none",
     );
 
     if (releasingFixedPackages.length === 0) continue;
 
-    let highestReleaseType = getHighestReleaseType(releasingFixedPackages);
-    let highestVersion = getCurrentHighestVersion(
+    const highestReleaseType = getHighestReleaseType(releasingFixedPackages);
+    const highestVersion = getCurrentHighestVersion(
       fixedPackages,
       packagesByName,
     );
 
     // Finally, we update the packages so all of them are on the highest version
-    for (let pkgName of fixedPackages) {
+    for (const pkgName of fixedPackages) {
       const pkg = mapGetOrThrowInternal(
         packagesByName,
         pkgName,
@@ -45,7 +45,7 @@ export default function matchFixedConstraint(
       ) {
         continue;
       }
-      let release = releases.get(pkgName);
+      const release = releases.get(pkgName);
 
       if (!release) {
         updated = true;

--- a/packages/assemble-release-plan/src/test-utils.ts
+++ b/packages/assemble-release-plan/src/test-utils.ts
@@ -29,9 +29,9 @@ function getChangeset(
     releases?: Array<Release>;
   } = {},
 ): NewChangeset {
-  let id = data.id || "strange-words-combine";
-  let summary = data.summary || "base summary whatever";
-  let releases = data.releases || [];
+  const id = data.id || "strange-words-combine";
+  const summary = data.summary || "base summary whatever";
+  const releases = data.releases || [];
   return {
     id,
     summary,
@@ -49,7 +49,7 @@ function getRelease({
   return { name, type };
 }
 
-let getSimpleSetup = () => ({
+const getSimpleSetup = () => ({
   packages: {
     rootPackage: {
       packageJson: {
@@ -72,7 +72,7 @@ class FakeFullState {
   changesets: NewChangeset[];
 
   constructor(custom?: { packages?: Packages; changesets?: NewChangeset[] }) {
-    let { packages, changesets } = { ...getSimpleSetup(), ...custom };
+    const { packages, changesets } = { ...getSimpleSetup(), ...custom };
     this.packages = packages;
     this.changesets = changesets;
   }
@@ -84,7 +84,7 @@ class FakeFullState {
       releases?: Array<Release>;
     } = {},
   ) {
-    let changeset = getChangeset(data);
+    const changeset = getChangeset(data);
     if (this.changesets.find((c) => c.id === changeset.id)) {
       throw new Error(
         `tried to add a second changeset with same id: ${changeset.id}`,
@@ -94,7 +94,7 @@ class FakeFullState {
   }
 
   updateDependency(pkgA: string, pkgB: string, versionRange: string) {
-    let pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
+    const pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
     if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.dependencies) {
       pkg.packageJson.dependencies = {};
@@ -102,7 +102,7 @@ class FakeFullState {
     pkg.packageJson.dependencies[pkgB] = versionRange;
   }
   updateDevDependency(pkgA: string, pkgB: string, versionRange: string) {
-    let pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
+    const pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
     if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.devDependencies) {
       pkg.packageJson.devDependencies = {};
@@ -110,7 +110,7 @@ class FakeFullState {
     pkg.packageJson.devDependencies[pkgB] = versionRange;
   }
   updatePeerDependency(pkgA: string, pkgB: string, versionRange: string) {
-    let pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
+    const pkg = this.packages.packages.find((a) => a.packageJson.name === pkgA);
     if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.peerDependencies) {
       pkg.packageJson.peerDependencies = {};
@@ -119,7 +119,7 @@ class FakeFullState {
   }
 
   addPackage(name: string, version: string) {
-    let pkg = getPackage({ name, version });
+    const pkg = getPackage({ name, version });
     if (
       this.packages.packages.find(
         (c) => c.packageJson.name === pkg.packageJson.name,
@@ -132,7 +132,7 @@ class FakeFullState {
     this.packages.packages.push(pkg);
   }
   updatePackage(name: string, version: string) {
-    let pkg = this.packages.packages.find((c) => c.packageJson.name === name);
+    const pkg = this.packages.packages.find((c) => c.packageJson.name === name);
     if (!pkg) {
       throw new Error(
         `could not update package ${name} because it doesn't exist - try addWorskpace`,

--- a/packages/assemble-release-plan/src/utils.ts
+++ b/packages/assemble-release-plan/src/utils.ts
@@ -14,7 +14,7 @@ export function getHighestReleaseType(
 
   let highestReleaseType: VersionType = "none";
 
-  for (let release of releases) {
+  for (const release of releases) {
     switch (release.type) {
       case "major":
         return "major";
@@ -38,8 +38,8 @@ export function getCurrentHighestVersion(
 ): string {
   let highestVersion: string | undefined;
 
-  for (let pkgName of packageGroup) {
-    let pkg = mapGetOrThrowInternal(
+  for (const pkgName of packageGroup) {
+    const pkg = mapGetOrThrowInternal(
       packagesByName,
       pkgName,
       `We were unable to version for package group: ${pkgName} in package group: ${packageGroup.toString()}`,

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -59,7 +59,7 @@ const changelogFunctions: ChangelogFunctions = {
       await Promise.all(
         changesets.map(async (cs) => {
           if (cs.commit) {
-            let { links } = await getInfo({
+            const { links } = await getInfo({
               repo: options.repo,
               commit: cs.commit,
             });
@@ -87,11 +87,11 @@ const changelogFunctions: ChangelogFunctions = {
 
     let prFromSummary: number | undefined;
     let commitFromSummary: string | undefined;
-    let usersFromSummary: string[] = [];
+    const usersFromSummary: string[] = [];
 
     const replacedChangelog = changeset.summary
       .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
-        let num = Number(pr);
+        const num = Number(pr);
         if (!isNaN(num)) prFromSummary = num;
         return "";
       })
@@ -126,7 +126,7 @@ const changelogFunctions: ChangelogFunctions = {
       }
       const commitToFetchFrom = commitFromSummary || changeset.commit;
       if (commitToFetchFrom) {
-        let { links } = await getInfo({
+        const { links } = await getInfo({
           repo: options.repo,
           commit: commitToFetchFrom,
         });

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -26,8 +26,8 @@ const mockUserResponses = (mockResponses: {
   summary?: string;
 }) => {
   const summary = mockResponses.summary || "summary message mock";
-  let majorReleases: Array<string> = [];
-  let minorReleases: Array<string> = [];
+  const majorReleases: Array<string> = [];
+  const minorReleases: Array<string> = [];
   Object.entries(mockResponses.releases).forEach(([pkgName, type]) => {
     if (type === "major") {
       majorReleases.push(pkgName);
@@ -36,7 +36,7 @@ const mockUserResponses = (mockResponses: {
     }
   });
   let callCount = 0;
-  let returnValues = [
+  const returnValues = [
     Object.keys(mockResponses.releases),
     majorReleases,
     minorReleases,
@@ -48,7 +48,7 @@ const mockUserResponses = (mockResponses: {
     return returnValues[callCount++];
   });
 
-  let confirmAnswers: Record<string, boolean> = {
+  const confirmAnswers: Record<string, boolean> = {
     "Is this your desired changeset?": true,
   };
 
@@ -165,7 +165,7 @@ describe("Add command", () => {
     const summary = "summary message mock";
     mockedUtils.askList.mockResolvedValueOnce("minor");
 
-    let confirmAnswers: Record<string, boolean> = {
+    const confirmAnswers: Record<string, boolean> = {
       "Is this your desired changeset?": true,
     };
     mockedUtils.askQuestion.mockResolvedValue("");

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -21,7 +21,7 @@ async function confirmMajorRelease(pkgJSON: PackageJSON) {
       ),
     );
 
-    let shouldReleaseFirstMajor = await cli.askConfirm(
+    const shouldReleaseFirstMajor = await cli.askConfirm(
       bold(
         `Are you sure you want to release the ${red(
           "first major version",
@@ -118,11 +118,11 @@ export default async function createChangeset(
       allPackages,
     );
 
-    let pkgJsonsByName = getPkgJsonsByName(allPackages);
+    const pkgJsonsByName = getPkgJsonsByName(allPackages);
 
-    let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
+    const pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
 
-    let pkgsThatShouldBeMajorBumped = (
+    const pkgsThatShouldBeMajorBumped = (
       await cli.askCheckboxPlus(
         bold(`Which packages should have a ${red("major")} bump?`),
         [
@@ -157,9 +157,9 @@ export default async function createChangeset(
       // for packages that are under v1, we want to make sure major releases are intended,
       // as some repo-wide sweeping changes have mistakenly release first majors
       // of packages.
-      let pkgJson = pkgJsonsByName.get(pkgName)!;
+      const pkgJson = pkgJsonsByName.get(pkgName)!;
 
-      let shouldReleaseFirstMajor = await confirmMajorRelease(pkgJson);
+      const shouldReleaseFirstMajor = await confirmMajorRelease(pkgJson);
       if (shouldReleaseFirstMajor) {
         pkgsLeftToGetBumpTypeFor.delete(pkgName);
 
@@ -168,7 +168,7 @@ export default async function createChangeset(
     }
 
     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
-      let pkgsThatShouldBeMinorBumped = (
+      const pkgsThatShouldBeMinorBumped = (
         await cli.askCheckboxPlus(
           bold(`Which packages should have a ${green("minor")} bump?`),
           [
@@ -222,15 +222,15 @@ export default async function createChangeset(
       }
     }
   } else {
-    let pkg = allPackages[0];
-    let type = await cli.askList(
+    const pkg = allPackages[0];
+    const type = await cli.askList(
       `What kind of change is this for ${green(
         pkg.packageJson.name,
       )}? (current version is ${pkg.packageJson.version})`,
       ["patch", "minor", "major"],
     );
     if (type === "major") {
-      let shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
+      const shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
       if (!shouldReleaseAsMajor) {
         throw new ExitError(1);
       }

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -114,7 +114,7 @@ export default async function add(
       );
     }
 
-    let hasMajorChange = [...newChangeset.releases].find(
+    const hasMajorChange = [...newChangeset.releases].find(
       (c) => c.type === "major",
     );
 

--- a/packages/cli/src/commands/publish/__tests__/index.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/index.test.ts
@@ -5,8 +5,8 @@ import * as path from "path";
 import type { Config } from "@changesets/types";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 
-let changelogPath = path.resolve(import.meta.dirname, "../../changelog");
-let modifiedDefaultConfig: Config = {
+const changelogPath = path.resolve(import.meta.dirname, "../../changelog");
+const modifiedDefaultConfig: Config = {
   ...defaultConfig,
   changelog: [changelogPath, null],
 };

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -13,11 +13,11 @@ function logReleases(pkgs: Array<{ name: string; newVersion: string }>) {
   log(mappedPkgs);
 }
 
-let importantSeparator = pc.red(
+const importantSeparator = pc.red(
   "===============================IMPORTANT!===============================",
 );
 
-let importantEnd = pc.red(
+const importantEnd = pc.red(
   "----------------------------------------------------------------------",
 );
 
@@ -44,7 +44,7 @@ export default async function publish(
   config: Config,
 ) {
   const releaseTag = tag && tag.length > 0 ? tag : undefined;
-  let preState = await readPreState(cwd);
+  const preState = await readPreState(cwd);
 
   if (releaseTag && preState && preState.mode === "pre") {
     error("Releasing under custom tag is not allowed in pre mode");

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -87,9 +87,9 @@ async function getPublishTool(
   const pm = await detect({ cwd });
   if (!pm || pm.name !== "pnpm") return { name: "npm" };
   try {
-    let result = await exec("pnpm", ["--version"], { nodeOptions: { cwd } });
-    let version = result.stdout.toString().trim();
-    let parsed = semverParse(version);
+    const result = await exec("pnpm", ["--version"], { nodeOptions: { cwd } });
+    const version = result.stdout.toString().trim();
+    const parsed = semverParse(version);
     return {
       name: "pnpm",
       shouldAddNoGitChecks:
@@ -110,7 +110,7 @@ export async function getTokenIsRequired() {
   const envOverride = {
     [scope ? `npm_config_${scope}:registry` : "npm_config_registry"]: registry,
   };
-  let result = await exec("npm", ["profile", "get", "--json"], {
+  const result = await exec("npm", ["profile", "get", "--json"], {
     nodeOptions: { env: Object.assign({}, process.env, envOverride) },
   });
   if (result.exitCode !== 0) {
@@ -120,7 +120,7 @@ export async function getTokenIsRequired() {
     );
     return false;
   }
-  let json = jsonParse(result.stdout.toString());
+  const json = jsonParse(result.stdout.toString());
   if (json.error || !json.tfa || !json.tfa.mode) {
     return false;
   }
@@ -194,7 +194,7 @@ export function getPackageInfo(packageJson: PackageJSON) {
 }
 
 export async function infoAllow404(packageJson: PackageJSON) {
-  let pkgInfo = await getPackageInfo(packageJson);
+  const pkgInfo = await getPackageInfo(packageJson);
   if (pkgInfo.error?.code === "E404") {
     warn(`Received 404 for npm info ${pc.cyan(`"${packageJson.name}"`)}`);
     return { published: false, pkgInfo: {} };
@@ -303,7 +303,7 @@ async function internalPublish(
     publishFlags.push("--otp", twoFactorState.token);
   }
 
-  let { exitCode, stdout, stderr } =
+  const { exitCode, stdout, stderr } =
     publishTool.name === "pnpm"
       ? await exec("pnpm", ["publish", ...publishFlags], {
           nodeOptions: {
@@ -323,7 +323,7 @@ async function internalPublish(
     // - output of those lifecycle scripts can contain JSON
     // - npm7 has switched to printing `--json` errors to stderr (https://github.com/npm/cli/commit/1dbf0f9bb26ba70f4c6d0a807701d7652c31d7d4)
     // Note that the `--json` output is always printed at the end so this should work
-    let json =
+    const json =
       getLastJsonObjectFromString(stderr.toString()) ||
       getLastJsonObjectFromString(stdout.toString());
 

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -115,7 +115,7 @@ export default async function publishPackages({
 
   return Promise.all(
     unpublishedPackagesInfo.map((pkgInfo) => {
-      let pkg = packagesByName.get(pkgInfo.name)!;
+      const pkg = packagesByName.get(pkgInfo.name)!;
       return publishAPackage(
         pkg,
         access,

--- a/packages/cli/src/commands/status/__tests__/status.test.ts
+++ b/packages/cli/src/commands/status/__tests__/status.test.ts
@@ -297,7 +297,7 @@ describe("status", () => {
     expect(process.exit).not.toHaveBeenCalled();
   });
 
-  it.skip("should respect the verbose flag", () => false);
+  it.todo("should respect the verbose flag", () => false);
 
   it("should respect the output flag", async () => {
     const cwd = await gitdir({

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -13,11 +13,11 @@ import { readPreState } from "@changesets/pre";
 import { ExitError } from "@changesets/errors";
 import { getCommitFunctions } from "../../commit/getCommitFunctions.ts";
 
-let importantSeparator = pc.red(
+const importantSeparator = pc.red(
   "===============================IMPORTANT!===============================",
 );
 
-let importantEnd = pc.red(
+const importantEnd = pc.red(
   "----------------------------------------------------------------------",
 );
 
@@ -81,7 +81,7 @@ export default async function version(
 
   const contextDir = path.dirname(fileURLToPath(import.meta.url));
 
-  let [...touchedFiles] = await applyReleasePlan(
+  const [...touchedFiles] = await applyReleasePlan(
     releasePlan,
     packages,
     releaseConfig,

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -26,12 +26,12 @@ import {
 import pre from "../pre/index.ts";
 import version from "./index.ts";
 
-let modifiedDefaultConfig: Config = {
+const modifiedDefaultConfig: Config = {
   ...defaultConfig,
   changelog: ["@changesets/cli/changelog", null],
 };
 
-let defaultOptions = {
+const defaultOptions = {
   snapshot: undefined,
 };
 
@@ -455,7 +455,7 @@ Awesome feature, hidden behind a feature flag
 
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -1050,7 +1050,7 @@ describe("workspace range", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -1096,7 +1096,7 @@ describe("workspace range", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -1142,7 +1142,7 @@ describe("workspace range", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -1188,7 +1188,7 @@ describe("workspace range", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -1366,7 +1366,7 @@ describe("workspace range", () => {
 
 describe("same package in different dependency types", () => {
   it("should update different range types correctly", async () => {
-    let cwd = await testdir({
+    const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
         name: "root-pkg",
@@ -1403,7 +1403,7 @@ describe("same package in different dependency types", () => {
 
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = (await getPackages(cwd))!;
+    const packages = (await getPackages(cwd))!;
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         devDependencies: {
@@ -2640,7 +2640,7 @@ describe("pre", () => {
   });
   // https://github.com/changesets/changesets/pull/382#discussion_r434434182
   it("should bump patch version for packages that had prereleases, but caret dependencies are still in range", async () => {
-    let cwd = await testdir({
+    const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
         name: "root-pkg",
@@ -2838,7 +2838,7 @@ describe("pre", () => {
   });
 
   it("should not bump packages through devDependencies", async () => {
-    let cwd = await testdir({
+    const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
         name: "root-pkg",
@@ -2867,7 +2867,7 @@ describe("pre", () => {
 
     await pre(cwd, { command: "enter", tag: "next" });
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    const packages = (await getPackages(cwd))!;
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2922,7 +2922,7 @@ describe("pre", () => {
       ...modifiedDefaultConfig,
       ignore: ["pkg-a"],
     });
-    let packages = (await getPackages(cwd))!;
+    const packages = (await getPackages(cwd))!;
 
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
@@ -2967,7 +2967,7 @@ describe("pre", () => {
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -3292,7 +3292,7 @@ describe("pre", () => {
       cwd,
     );
     await version(cwd, defaultOptions, modifiedDefaultConfig);
-    let packages = (await getPackages(cwd))!;
+    const packages = (await getPackages(cwd))!;
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -3334,7 +3334,7 @@ describe("pre", () => {
         version: true,
       },
     });
-    let packages = (await getPackages(cwd))!;
+    const packages = (await getPackages(cwd))!;
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",
@@ -3346,7 +3346,7 @@ describe("pre", () => {
 
   describe("linked", () => {
     it("should work with linked", async () => {
-      let linkedConfig = {
+      const linkedConfig = {
         ...modifiedDefaultConfig,
         linked: [["pkg-a", "pkg-b"]],
       };
@@ -3455,11 +3455,11 @@ describe("pre", () => {
     });
 
     it("should use the highest bump type between all prereleases for a linked package when versioning a dependent package", async () => {
-      let linkedConfig = {
+      const linkedConfig = {
         ...modifiedDefaultConfig,
         linked: [["pkg-a", "pkg-b"]],
       };
-      let cwd = await testdir({
+      const cwd = await testdir({
         "package.json": JSON.stringify({
           private: true,
           workspaces: ["packages/*"],
@@ -3535,11 +3535,11 @@ describe("pre", () => {
       ]);
     });
     it("should not bump a linked package if its linked devDep gets released", async () => {
-      let linkedConfig = {
+      const linkedConfig = {
         ...modifiedDefaultConfig,
         linked: [["pkg-a", "pkg-b"]],
       };
-      let cwd = await testdir({
+      const cwd = await testdir({
         "package.json": JSON.stringify({
           private: true,
           workspaces: ["packages/*"],
@@ -3565,7 +3565,7 @@ describe("pre", () => {
         cwd,
       );
       await version(cwd, defaultOptions, linkedConfig);
-      let packages = (await getPackages(cwd))!;
+      const packages = (await getPackages(cwd))!;
 
       expect(packages.packages.map((x) => x.packageJson)).toEqual([
         {
@@ -3619,7 +3619,7 @@ Nice simple summary, much wow
       },
     });
 
-    let packages = await getPackages(cwd);
+    const packages = await getPackages(cwd);
     expect(packages.packages.map((x) => x.packageJson)).toEqual([
       {
         name: "pkg-a",

--- a/packages/cli/src/commit/commit.test.ts
+++ b/packages/cli/src/commit/commit.test.ts
@@ -18,7 +18,7 @@ const simpleChangeset2: NewChangeset = {
   id: "abc123fh",
 };
 
-let simpleReleasePlan: ReleasePlan = {
+const simpleReleasePlan: ReleasePlan = {
   changesets: [simpleChangeset],
   releases: [
     {
@@ -32,7 +32,7 @@ let simpleReleasePlan: ReleasePlan = {
   preState: undefined,
 };
 
-let secondReleasePlan: ReleasePlan = {
+const secondReleasePlan: ReleasePlan = {
   changesets: [simpleChangeset, simpleChangeset2],
   releases: [
     {
@@ -122,7 +122,7 @@ describe("defaultCommitFunctions", () => {
   });
 
   it("should handle a multiple releases from one changeset", async () => {
-    let releasePlan: ReleasePlan = {
+    const releasePlan: ReleasePlan = {
       changesets: [simpleChangeset, simpleChangeset2],
       releases: [
         {

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -16,8 +16,8 @@ export async function getCommitFunctions(
   if (!commit) {
     return [commitFunctions, null];
   }
-  let commitOpts: any = commit[1];
-  let changesetPath = path.join(cwd, ".changeset");
+  const commitOpts: any = commit[1];
+  const changesetPath = path.join(cwd, ".changeset");
   let commitPath;
 
   try {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -64,7 +64,7 @@ export async function run(
   try {
     config = await read(packages.rootDir, packages);
   } catch (e) {
-    let oldConfigExists = await fs
+    const oldConfigExists = await fs
       .access(path.resolve(packages.rootDir, ".changeset/config.js"))
       .then(
         () => true,
@@ -125,7 +125,7 @@ export async function run(
         }
 
         // Validate that items in ignoreArrayFromCmd are valid project names
-        let pkgNames = new Set(
+        const pkgNames = new Set(
           packages.packages.map(({ packageJson }) => packageJson.name),
         );
 
@@ -226,14 +226,14 @@ export async function run(
       }
       case "pre": {
         validateCommandFlags("pre", flags);
-        let command = input[1];
+        const command = input[1];
         if (command !== "enter" && command !== "exit") {
           error(
             "`enter`, `exit` or `snapshot` must be passed after prerelease",
           );
           throw new ExitError(1);
         }
-        let tag = input[2];
+        const tag = input[2];
         if (command === "enter" && typeof tag !== "string") {
           error(`A tag must be passed when using prerelease enter`);
           throw new ExitError(1);

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -41,7 +41,7 @@ const serialId: () => number = (function () {
 
 const limit = Math.max(process.stdout.rows - 5, 10);
 
-let cancelFlow = () => {
+const cancelFlow = () => {
   success("Cancelled... 👋 ");
   process.exit();
 };

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -25,7 +25,7 @@ type CorrectCase = {
   output: Config;
 };
 
-let defaultPackages: Packages = {
+const defaultPackages: Packages = {
   rootPackage: {
     packageJson: { name: "", version: "" },
     dir: "/",
@@ -44,13 +44,13 @@ const withPackages = (pkgNames: string[]) => ({
 });
 
 test("read reads the config", async () => {
-  let cwd = await testdir({
+  const cwd = await testdir({
     ".changeset/config.json": JSON.stringify({
       changelog: false,
       commit: true,
     }),
   });
-  let config = await read(cwd, {
+  const config = await read(cwd, {
     ...defaultPackages,
     rootDir: cwd,
     rootPackage: { ...defaultPackages.rootPackage!, dir: cwd },
@@ -83,7 +83,7 @@ test("read reads the config", async () => {
 });
 
 test("read can read config based on the passed in `cwd`", async () => {
-  let cwd = await testdir({
+  const cwd = await testdir({
     ".changeset/config.json": JSON.stringify({
       changelog: false,
       commit: true,
@@ -93,7 +93,7 @@ test("read can read config based on the passed in `cwd`", async () => {
       version: "0.0.0",
     }),
   });
-  let config = await read(cwd);
+  const config = await read(cwd);
 
   expect(config).toEqual({
     fixed: [],
@@ -196,7 +196,7 @@ it(
   }),
 );
 
-let defaults: Config = {
+const defaults: Config = {
   fixed: [],
   linked: [],
   changelog: ["@changesets/cli/changelog", null],
@@ -219,7 +219,7 @@ let defaults: Config = {
   bumpVersionsWithWorkspaceProtocolOnly: false,
 };
 
-let correctCases: Record<string, CorrectCase> = {
+const correctCases: Record<string, CorrectCase> = {
   defaults: {
     input: {},
     output: defaults,
@@ -479,7 +479,7 @@ describe("parse", () => {
   });
 });
 
-let unsafeParse = parse as any;
+const unsafeParse = parse as any;
 
 describe("parser errors", () => {
   test("changelog invalid value", () => {
@@ -670,7 +670,7 @@ describe("parser errors", () => {
     });
   });
   test("access private warns and sets to restricted", () => {
-    let config = unsafeParse({ access: "private" }, defaultPackages);
+    const config = unsafeParse({ access: "private" }, defaultPackages);
     expect(config).toEqual(defaults);
     expect(logger.warn).toBeCalledWith(
       'The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".',

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -20,7 +20,7 @@ import path from "path";
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
 
-export let defaultWrittenConfig = {
+export const defaultWrittenConfig = {
   $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
   changelog: "@changesets/cli/changelog",
   commit: false,
@@ -97,9 +97,9 @@ function isArray<T>(
   return Array.isArray(arg);
 }
 
-export let read = async (cwd: string, packages?: Packages) => {
+export const read = async (cwd: string, packages?: Packages) => {
   packages ??= await getPackages(cwd);
-  let json = JSON.parse(
+  const json = JSON.parse(
     await fs.readFile(
       path.join(packages?.rootDir, ".changeset", "config.json"),
       "utf8",
@@ -108,9 +108,9 @@ export let read = async (cwd: string, packages?: Packages) => {
   return parse(json, packages);
 };
 
-export let parse = (json: WrittenConfig, packages: Packages): Config => {
-  let messages = [];
-  let pkgNames: readonly string[] = packages.packages.map(
+export const parse = (json: WrittenConfig, packages: Packages): Config => {
+  const messages = [];
+  const pkgNames: readonly string[] = packages.packages.map(
     ({ packageJson }) => packageJson.name,
   );
 
@@ -196,7 +196,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     );
   }
 
-  let fixed: string[][] = [];
+  const fixed: string[][] = [];
   if (json.fixed !== undefined) {
     if (!havePackageGroupsCorrectShape(json.fixed)) {
       messages.push(
@@ -207,10 +207,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         )} when the only valid values are undefined or an array of arrays of package names`,
       );
     } else {
-      let foundPkgNames = new Set<string>();
-      let duplicatedPkgNames = new Set<string>();
+      const foundPkgNames = new Set<string>();
+      const duplicatedPkgNames = new Set<string>();
 
-      for (let fixedGroup of json.fixed) {
+      for (const fixedGroup of json.fixed) {
         messages.push(
           ...getUnmatchedPatterns(fixedGroup, pkgNames).map(
             (pkgOrGlob) =>
@@ -221,7 +221,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         const expandedFixedGroup = globMatch(pkgNames, fixedGroup);
         fixed.push(expandedFixedGroup);
 
-        for (let fixedPkgName of expandedFixedGroup) {
+        for (const fixedPkgName of expandedFixedGroup) {
           if (foundPkgNames.has(fixedPkgName)) {
             duplicatedPkgNames.add(fixedPkgName);
           }
@@ -239,7 +239,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     }
   }
 
-  let linked: string[][] = [];
+  const linked: string[][] = [];
   if (json.linked !== undefined) {
     if (!havePackageGroupsCorrectShape(json.linked)) {
       messages.push(
@@ -250,10 +250,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         )} when the only valid values are undefined or an array of arrays of package names`,
       );
     } else {
-      let foundPkgNames = new Set<string>();
-      let duplicatedPkgNames = new Set<string>();
+      const foundPkgNames = new Set<string>();
+      const duplicatedPkgNames = new Set<string>();
 
-      for (let linkedGroup of json.linked) {
+      for (const linkedGroup of json.linked) {
         messages.push(
           ...getUnmatchedPatterns(linkedGroup, pkgNames).map(
             (pkgOrGlob) =>
@@ -261,10 +261,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           ),
         );
 
-        let expandedLinkedGroup = globMatch(pkgNames, linkedGroup);
+        const expandedLinkedGroup = globMatch(pkgNames, linkedGroup);
         linked.push(expandedLinkedGroup);
 
-        for (let linkedPkgName of expandedLinkedGroup) {
+        for (const linkedPkgName of expandedLinkedGroup) {
           if (foundPkgNames.has(linkedPkgName)) {
             duplicatedPkgNames.add(linkedPkgName);
           }
@@ -509,7 +509,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
     );
   }
 
-  let config: Config = {
+  const config: Config = {
     changelog: getNormalizedChangelogOption(
       json.changelog === undefined
         ? defaultWrittenConfig.changelog
@@ -610,7 +610,7 @@ function globMatch(
   });
 }
 
-let fakePackage: Package = {
+const fakePackage: Package = {
   dir: "",
   packageJson: {
     name: "",
@@ -618,7 +618,7 @@ let fakePackage: Package = {
   },
 };
 
-export let defaultConfig = parse(defaultWrittenConfig, {
+export const defaultConfig = parse(defaultWrittenConfig, {
   tool: { type: "root" },
   rootDir: fakePackage.dir,
   rootPackage: fakePackage,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -592,6 +592,10 @@ function globMatch(
 
   const matchers = patterns.map((p) => picomatch(p, undefined, true));
   return paths.filter((path) => {
+    if (path.includes("\\")) {
+      path = path.replace(/\\/g, "/");
+    }
+
     let passed = false;
     for (const matcher of matchers) {
       if (!passed) {

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -98,6 +98,7 @@ export default function getDependencyGraph(
       ignoreDevDependencies,
     );
 
+    // eslint-disable-next-line prefer-const
     for (let [depName, depRange] of allDependencies) {
       const match = packagesByName[depName];
       if (!match) continue;

--- a/packages/get-github-info/src/index.test.ts
+++ b/packages/get-github-info/src/index.test.ts
@@ -97,7 +97,7 @@ test("associated with multiple PRs with only one merged", async () => {
       }),
     );
 
-  let result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
+  const result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
   expect(result).toMatchObject({ pull: 1613, user: "Andarist" });
 
   expect(await prettier.format(githubQuery, { parser: "graphql" }))
@@ -213,7 +213,7 @@ test("associated with multiple PRs with multiple merged gets the one that was me
       }),
     );
 
-  let result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
+  const result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
   expect(result).toMatchObject({ pull: 1613, user: "Andarist" });
 
   expect(await prettier.format(githubQuery, { parser: "graphql" }))
@@ -293,7 +293,7 @@ test("gets the author of the associated pull request if it exists rather than th
       }),
     );
 
-  let result = await getInfo({
+  const result = await getInfo({
     commit: "c7e9c69",
     repo: "JedWatson/react-select",
   });
@@ -391,7 +391,7 @@ test("associated with multiple PRs with only one merged 2", async () => {
       }),
     );
 
-  let result = await getInfoFromPullRequest({
+  const result = await getInfoFromPullRequest({
     pull: 1613,
     repo: "emotion-js/emotion",
   });
@@ -476,7 +476,7 @@ test("uses custom GITHUB_GRAPHQL_URL when set", async () => {
         }),
       );
 
-    let result = await getInfo({
+    const result = await getInfo({
       commit: "a085003",
       repo: "emotion-js/emotion",
     });

--- a/packages/get-github-info/src/index.test.ts
+++ b/packages/get-github-info/src/index.test.ts
@@ -97,7 +97,10 @@ test("associated with multiple PRs with only one merged", async () => {
       }),
     );
 
-  const result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
+  const result = await getInfo({
+    commit: "a085003",
+    repo: "emotion-js/emotion",
+  });
   expect(result).toMatchObject({ pull: 1613, user: "Andarist" });
 
   expect(await prettier.format(githubQuery, { parser: "graphql" }))
@@ -213,7 +216,10 @@ test("associated with multiple PRs with multiple merged gets the one that was me
       }),
     );
 
-  const result = await getInfo({ commit: "a085003", repo: "emotion-js/emotion" });
+  const result = await getInfo({
+    commit: "a085003",
+    repo: "emotion-js/emotion",
+  });
   expect(result).toMatchObject({ pull: 1613, user: "Andarist" });
 
   expect(await prettier.format(githubQuery, { parser: "graphql" }))

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -121,7 +121,7 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
         )} with \`read:user\` and \`repo:status\` permissions and add it as the GITHUB_TOKEN environment variable`,
     );
   }
-  let repos: ReposWithCommitsAndPRsToFetch = {};
+  const repos: ReposWithCommitsAndPRsToFetch = {};
   requests.forEach(({ repo, ...data }) => {
     if (repos[repo] === undefined) {
       repos[repo] = [];
@@ -170,12 +170,12 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     );
   }
 
-  let cleanedData: Record<
+  const cleanedData: Record<
     string,
     { commit: Record<string, any>; pull: Record<string, any> }
   > = {};
   Object.keys(repos).forEach((repo, index) => {
-    let output: { commit: Record<string, any>; pull: Record<string, any> } = {
+    const output: { commit: Record<string, any>; pull: Record<string, any> } = {
       commit: {},
       pull: {},
     };
@@ -233,7 +233,7 @@ export async function getInfo(request: {
     user = data.author.user;
   }
 
-  let associatedPullRequest =
+  const associatedPullRequest =
     data.associatedPullRequests &&
     data.associatedPullRequests.nodes &&
     data.associatedPullRequests.nodes.length
@@ -297,9 +297,9 @@ export async function getInfoFromPullRequest(request: {
   }
 
   const data = await GHDataLoader.load({ kind: "pull", ...request });
-  let user = data?.author;
+  const user = data?.author;
 
-  let commit = data?.mergeCommit;
+  const commit = data?.mergeCommit;
 
   return {
     user: user ? user.login : null,

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -100,7 +100,7 @@ export async function getCommitsThatAddFiles(
 
     // To collect commits without parents (usually because they're absent from
     // a shallow clone).
-    let commitsWithMissingParents = [];
+    const commitsWithMissingParents = [];
 
     for (const info of commitInfos) {
       if (info.commitSha) {
@@ -246,7 +246,7 @@ export async function getChangedChangesetFilesSinceRef({
       },
     );
 
-    let tester = /.changeset\/[^/]+\.md$/;
+    const tester = /.changeset\/[^/]+\.md$/;
 
     const files = cmd.stdout
       .toString()

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -344,6 +344,10 @@ function globMatchSome(
 
   const matchers = patterns.map((p) => picomatch(p, undefined, true));
   return paths.some((path) => {
+    if (path.includes("\\")) {
+      path = path.replace(/\\/g, "/");
+    }
+
     let passed = false;
     for (const matcher of matchers) {
       if (!passed) {

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -8,7 +8,7 @@ describe("@changesets/logger", () => {
     `(${logMessageOne})\\s(${logMessageTwo})`,
   );
   describe("log", () => {
-    let originalConsoleLog = console.log;
+    const originalConsoleLog = console.log;
     beforeEach(() => {
       console.log = vi.fn();
     });
@@ -23,7 +23,7 @@ describe("@changesets/logger", () => {
     });
   });
   describe("error", () => {
-    let originalConsoleError = console.error;
+    const originalConsoleError = console.error;
     beforeEach(() => {
       console.error = vi.fn();
     });
@@ -38,7 +38,7 @@ describe("@changesets/logger", () => {
     });
   });
   describe("info", () => {
-    let originalConsoleInfo = console.info;
+    const originalConsoleInfo = console.info;
     beforeEach(() => {
       console.info = vi.fn();
     });
@@ -54,7 +54,7 @@ describe("@changesets/logger", () => {
   });
 
   describe("warn", () => {
-    let originalConsoleWarn = console.warn;
+    const originalConsoleWarn = console.warn;
     beforeEach(() => {
       console.warn = vi.fn();
     });
@@ -70,7 +70,7 @@ describe("@changesets/logger", () => {
   });
 
   describe("success", () => {
-    let originalConsoleLog = console.log;
+    const originalConsoleLog = console.log;
     beforeEach(() => {
       console.log = vi.fn();
     });

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 import pc from "picocolors";
 import util from "util";
 
-export const prefix = "🦋 ";
+export const prefix: string = "🦋 ";
 
 function format(args: Array<any>, customPrefix?: string) {
   const fullPrefix =

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,10 +1,10 @@
 import pc from "picocolors";
 import util from "util";
 
-export let prefix = "🦋 ";
+export const prefix = "🦋 ";
 
 function format(args: Array<any>, customPrefix?: string) {
-  let fullPrefix =
+  const fullPrefix =
     prefix + (customPrefix === undefined ? "" : " " + customPrefix);
   return (
     fullPrefix +

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -71,8 +71,8 @@ export default function parseChangesetFile(contents: string): {
         `Received content:\n${truncate(trimmedContents)}`,
     );
   }
-  let [, roughReleases, roughSummary] = execResult;
-  let summary = roughSummary.trim();
+  const [, roughReleases, roughSummary] = execResult;
+  const summary = roughSummary.trim();
 
   let releases: Release[];
   let yamlStuff: Record<string, VersionType> | undefined;

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -15,11 +15,11 @@ async function outputFile(filePath: string, content: string) {
 export async function readPreState(
   rootDir: string,
 ): Promise<PreState | undefined> {
-  let preStatePath = path.resolve(rootDir, ".changeset", "pre.json");
+  const preStatePath = path.resolve(rootDir, ".changeset", "pre.json");
   // TODO: verify that the pre state isn't broken
   let preState: PreState | undefined;
   try {
-    let contents = await fs.readFile(preStatePath, "utf8");
+    const contents = await fs.readFile(preStatePath, "utf8");
     try {
       preState = JSON.parse(contents);
     } catch (err) {
@@ -37,9 +37,9 @@ export async function readPreState(
 }
 
 export async function exitPre(rootDir: string) {
-  let preStatePath = path.resolve(rootDir, ".changeset", "pre.json");
+  const preStatePath = path.resolve(rootDir, ".changeset", "pre.json");
   // TODO: verify that the pre state isn't broken
-  let preState = await readPreState(rootDir);
+  const preState = await readPreState(rootDir);
 
   if (preState === undefined) {
     throw new PreExitButNotInPreModeError();
@@ -52,20 +52,20 @@ export async function exitPre(rootDir: string) {
 }
 
 export async function enterPre(rootDir: string, tag: string) {
-  let packages = await getPackages(rootDir);
-  let preStatePath = path.resolve(packages.rootDir, ".changeset", "pre.json");
-  let preState: PreState | undefined = await readPreState(packages.rootDir);
+  const packages = await getPackages(rootDir);
+  const preStatePath = path.resolve(packages.rootDir, ".changeset", "pre.json");
+  const preState: PreState | undefined = await readPreState(packages.rootDir);
   // can't reenter if pre mode still exists, but we should allow exited pre mode to be reentered
   if (preState?.mode === "pre") {
     throw new PreEnterButInPreModeError();
   }
-  let newPreState: PreState = {
+  const newPreState: PreState = {
     mode: "pre",
     tag,
     initialVersions: {},
     changesets: preState?.changesets ?? [],
   };
-  for (let pkg of packages.packages) {
+  for (const pkg of packages.packages) {
     newPreState.initialVersions[pkg.packageJson.name] = pkg.packageJson.version;
   }
   await outputFile(preStatePath, JSON.stringify(newPreState, null, 2) + "\n");

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -22,7 +22,7 @@ export default async function getChangesets(
   rootDir: string,
   sinceRef?: string,
 ): Promise<Array<NewChangeset>> {
-  let changesetBase = path.join(rootDir, ".changeset");
+  const changesetBase = path.join(rootDir, ".changeset");
   let contents: string[];
   try {
     contents = await fs.readdir(changesetBase);
@@ -43,7 +43,7 @@ export default async function getChangesets(
     );
   }
 
-  let changesets = contents.filter(
+  const changesets = contents.filter(
     (file) =>
       !file.startsWith(".") &&
       file.endsWith(".md") &&

--- a/packages/release-utils/src/gitUtils.ts
+++ b/packages/release-utils/src/gitUtils.ts
@@ -36,11 +36,11 @@ export const switchToMaybeExistingBranch = async (
   branch: string,
   cwd: string,
 ) => {
-  let { stderr } = await exec("git", ["checkout", branch], {
+  const { stderr } = await exec("git", ["checkout", branch], {
     nodeOptions: { cwd },
     throwOnError: false,
   });
-  let isCreatingBranch = !stderr
+  const isCreatingBranch = !stderr
     .toString()
     .includes(`Switched to a new branch '${branch}'`);
   if (isCreatingBranch) {

--- a/packages/release-utils/src/readChangesetState.ts
+++ b/packages/release-utils/src/readChangesetState.ts
@@ -10,13 +10,13 @@ export type ChangesetState = {
 export async function readChangesetState(
   cwd: string = process.cwd(),
 ): Promise<ChangesetState> {
-  let preState = await readPreState(cwd);
-  let isInPreMode = preState !== undefined && preState.mode === "pre";
+  const preState = await readPreState(cwd);
+  const isInPreMode = preState !== undefined && preState.mode === "pre";
 
   let changesets = await readChangesets(cwd);
 
   if (isInPreMode && preState !== undefined) {
-    let changesetsToFilter = new Set(preState.changesets);
+    const changesetsToFilter = new Set(preState.changesets);
     changesets = changesets.filter((x) => !changesetsToFilter.has(x.id));
   }
 

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -158,7 +158,7 @@ describe("version", () => {
     expect(changedPackages).toEqual([
       {
         dir: path.join(clone, "packages", "pkg-a"),
-        relativeDir: "packages/pkg-a",
+        relativeDir: path.join("packages", "pkg-a"),
         packageJson: {
           name: "pkg-a",
           version: "1.1.0",
@@ -169,7 +169,7 @@ describe("version", () => {
       },
       {
         dir: path.join(clone, "packages", "pkg-b"),
-        relativeDir: "packages/pkg-b",
+        relativeDir: path.join("packages", "pkg-b"),
         packageJson: { name: "pkg-b", version: "1.1.0" },
       },
     ]);
@@ -275,7 +275,7 @@ describe("version", () => {
     expect(changedPackages).toEqual([
       {
         dir: path.join(clone, "packages", "pkg-a"),
-        relativeDir: "packages/pkg-a",
+        relativeDir: path.join("packages", "pkg-a"),
         packageJson: {
           name: "pkg-a",
           version: "1.1.0",
@@ -329,7 +329,7 @@ describe("version", () => {
     expect(changedPackages).toEqual([
       {
         dir: path.join(clone, "packages", "pkg-b"),
-        relativeDir: "packages/pkg-b",
+        relativeDir: path.join("packages", "pkg-b"),
         packageJson: { name: "pkg-b", version: "1.1.0" },
       },
     ]);

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -33,7 +33,7 @@ async function setupRepoAndClone(cwd: string) {
   const mainBranch = await getCurrentBranch(cwd);
 
   // Make a 1-commit-deep shallow clone of this repo
-  let clone = await testdir();
+  const clone = await testdir();
   await exec(
     "git",
     // Note: a file:// URL is needed in order to make a shallow clone of
@@ -288,7 +288,7 @@ describe("version", () => {
   });
 
   it("doesn't include ignored package that got a dependency update in returned versions", async () => {
-    let cwd = await testdir({
+    const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
         name: "root-pkg",
@@ -325,7 +325,7 @@ describe("version", () => {
 
     await linkNodeModules(clone);
 
-    let { changedPackages } = await runVersion({ cwd: clone });
+    const { changedPackages } = await runVersion({ cwd: clone });
     expect(changedPackages).toEqual([
       {
         dir: path.join(clone, "packages", "pkg-b"),
@@ -350,7 +350,7 @@ describe("publish", () => {
 
     await linkNodeModules(clone);
 
-    let result = await runPublish({
+    const result = await runPublish({
       command: "node",
       args: [
         "--experimental-strip-types",
@@ -364,7 +364,7 @@ describe("publish", () => {
       published: true,
       publishedPackages: [{ name: "single-package", version: "1.0.0" }],
     });
-    let tagsResult = await exec("git", ["tag"], { nodeOptions: { cwd } });
+    const tagsResult = await exec("git", ["tag"], { nodeOptions: { cwd } });
     expect(tagsResult.stdout.trim()).toEqual("v1.0.0");
   });
 
@@ -394,7 +394,7 @@ describe("publish", () => {
 
     await linkNodeModules(clone);
 
-    let result = await runPublish({
+    const result = await runPublish({
       command: "node",
       args: [
         "--experimental-strip-types",
@@ -411,7 +411,7 @@ describe("publish", () => {
         { name: "pkg-b", version: "1.0.0" },
       ],
     });
-    let tagsResult = await exec("git", ["tag"], { nodeOptions: { cwd } });
+    const tagsResult = await exec("git", ["tag"], { nodeOptions: { cwd } });
     expect(tagsResult.stdout.trim()).toEqual("pkg-a@1.0.0\npkg-b@1.0.0");
   });
 });

--- a/packages/release-utils/src/run.ts
+++ b/packages/release-utils/src/run.ts
@@ -46,7 +46,9 @@ export async function runPublish({
 
   if (tool.type !== "root") {
     const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/;
-    const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
+    const packagesByName = new Map(
+      packages.map((x) => [x.packageJson.name, x]),
+    );
 
     for (const line of changesetPublishOutput.split("\n")) {
       const match = line.match(newTagRegex);

--- a/packages/release-utils/src/run.ts
+++ b/packages/release-utils/src/run.ts
@@ -32,7 +32,7 @@ export async function runPublish({
   args = [],
   cwd = process.cwd(),
 }: PublishOptions): Promise<PublishResult> {
-  let branch = await gitUtils.getCurrentBranch(cwd);
+  const branch = await gitUtils.getCurrentBranch(cwd);
 
   const { stdout: changesetPublishOutput } = await exec(command, args, {
     nodeOptions: { cwd },
@@ -41,20 +41,20 @@ export async function runPublish({
   await gitUtils.pullBranch(branch, cwd);
   await gitUtils.push(branch, { includeTags: true, cwd });
 
-  let { packages, tool } = await getPackages(cwd);
-  let releasedPackages: Package[] = [];
+  const { packages, tool } = await getPackages(cwd);
+  const releasedPackages: Package[] = [];
 
   if (tool.type !== "root") {
-    let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/;
-    let packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
+    const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@(\S+)/;
+    const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
 
-    for (let line of changesetPublishOutput.split("\n")) {
-      let match = line.match(newTagRegex);
+    for (const line of changesetPublishOutput.split("\n")) {
+      const match = line.match(newTagRegex);
       if (match === null) {
         continue;
       }
-      let pkgName = match[1];
-      let pkg = packagesByName.get(pkgName);
+      const pkgName = match[1];
+      const pkg = packagesByName.get(pkgName);
       if (pkg === undefined) {
         throw new Error(
           `Package "${pkgName}" not found.` +
@@ -70,11 +70,11 @@ export async function runPublish({
           "This is probably a bug in the action, please open an issue",
       );
     }
-    let pkg = packages[0];
-    let newTagRegex = /New tag:/;
+    const pkg = packages[0];
+    const newTagRegex = /New tag:/;
 
-    for (let line of changesetPublishOutput.split("\n")) {
-      let match = line.match(newTagRegex);
+    for (const line of changesetPublishOutput.split("\n")) {
+      const match = line.match(newTagRegex);
 
       if (match) {
         releasedPackages.push(pkg);
@@ -107,19 +107,19 @@ export async function runVersion({
   cwd = process.cwd(),
   commitMessage = "Version Packages",
 }: VersionOptions) {
-  let branch = await gitUtils.getCurrentBranch(cwd);
-  let versionBranch = `changeset-release/${branch}`;
-  let { preState } = await readChangesetState(cwd);
+  const branch = await gitUtils.getCurrentBranch(cwd);
+  const versionBranch = `changeset-release/${branch}`;
+  const { preState } = await readChangesetState(cwd);
 
   await gitUtils.switchToMaybeExistingBranch(versionBranch, cwd);
   await gitUtils.reset("HEAD", undefined, cwd);
 
-  let versionsByDirectory = await getVersionsByDirectory(cwd);
+  const versionsByDirectory = await getVersionsByDirectory(cwd);
 
   if (script) {
     await exec(script, [], { nodeOptions: { cwd } });
   } else {
-    let changesetsCliPkgJsonPath = require.resolve(
+    const changesetsCliPkgJsonPath = require.resolve(
       "@changesets/cli/package.json",
       {
         paths: [cwd],
@@ -140,7 +140,7 @@ export async function runVersion({
     await exec("node", args, { nodeOptions: { cwd } });
   }
 
-  let changedPackages = await getChangedPackages(cwd, versionsByDirectory);
+  const changedPackages = await getChangedPackages(cwd, versionsByDirectory);
 
   // project with `commit: true` setting could have already committed files
   if (!(await gitUtils.checkIfClean(cwd))) {

--- a/packages/release-utils/src/utils.test.ts
+++ b/packages/release-utils/src/utils.test.ts
@@ -5,7 +5,7 @@ import {
   sortChangelogEntries,
 } from "./utils.ts";
 
-let changelog = `# @keystone-alpha/email
+const changelog = `# @keystone-alpha/email
 
 ## 3.0.1
 
@@ -74,19 +74,19 @@ let changelog = `# @keystone-alpha/email
 
 describe("getChangelogEntry", () => {
   test("it works", () => {
-    let entry = getChangelogEntry(changelog, "3.0.0");
+    const entry = getChangelogEntry(changelog, "3.0.0");
     expect(entry.content).toMatchSnapshot();
     expect(entry.highestLevel).toBe(BumpLevels.major);
   });
 
   test("it works again!", () => {
-    let entry = getChangelogEntry(changelog, "3.0.1");
+    const entry = getChangelogEntry(changelog, "3.0.1");
     expect(entry.content).toMatchSnapshot();
     expect(entry.highestLevel).toBe(BumpLevels.patch);
   });
 
   test("it sorts the things right", () => {
-    let things = [
+    const things = [
       {
         name: "a",
         highestLevel: BumpLevels.major,

--- a/packages/release-utils/src/utils.ts
+++ b/packages/release-utils/src/utils.ts
@@ -12,7 +12,7 @@ export const BumpLevels = {
 } as const;
 
 export async function getVersionsByDirectory(cwd: string) {
-  let { packages } = await getPackages(cwd);
+  const { packages } = await getPackages(cwd);
   return new Map(packages.map((x) => [x.dir, x.packageJson.version]));
 }
 
@@ -20,10 +20,10 @@ export async function getChangedPackages(
   cwd: string,
   previousVersions: Map<string, string>,
 ) {
-  let { packages } = await getPackages(cwd);
-  let changedPackages = new Set<Package>();
+  const { packages } = await getPackages(cwd);
+  const changedPackages = new Set<Package>();
 
-  for (let pkg of packages) {
+  for (const pkg of packages) {
     const previousVersion = previousVersions.get(pkg.dir);
     if (previousVersion !== pkg.packageJson.version) {
       changedPackages.add(pkg);
@@ -34,11 +34,11 @@ export async function getChangedPackages(
 }
 
 export function getChangelogEntry(changelog: string, version: string) {
-  let ast = stringToMdast(changelog);
+  const ast = stringToMdast(changelog);
 
   let highestLevel: number = BumpLevels.dep;
 
-  let nodes = ast.children;
+  const nodes = ast.children;
   let headingStartInfo:
     | {
         index: number;
@@ -48,12 +48,12 @@ export function getChangelogEntry(changelog: string, version: string) {
   let endIndex: number | undefined;
 
   for (let i = 0; i < nodes.length; i++) {
-    let node = nodes[i];
+    const node = nodes[i];
     if (node.type === "heading") {
-      let stringified: string = mdastNodeToString(node);
-      let match = stringified.toLowerCase().match(/(major|minor|patch)/);
+      const stringified: string = mdastNodeToString(node);
+      const match = stringified.toLowerCase().match(/(major|minor|patch)/);
       if (match !== null) {
-        let level = BumpLevels[match[0] as "major" | "minor" | "patch"];
+        const level = BumpLevels[match[0] as "major" | "minor" | "patch"];
         highestLevel = Math.max(level, highestLevel);
       }
       if (headingStartInfo === undefined && stringified === version) {

--- a/scripts/test-utils/src/index.test.ts
+++ b/scripts/test-utils/src/index.test.ts
@@ -5,7 +5,7 @@ import { log } from "@changesets/logger";
 describe("temporarilySilenceLogs", () => {
   silenceLogsInBlock();
   describe("log", () => {
-    let originalConsoleLog = console.log;
+    const originalConsoleLog = console.log;
     beforeEach(() => {
       console.log = vi.fn();
     });

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -18,7 +18,7 @@ export const mockedLogger: PartialMockMethods<
 vi.mock(import("@changesets/logger"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
-    prefix: mod.prefix as "🦋 ",
+    prefix: mod.prefix,
     error: (...args) => (mockedLogger.error ?? mod.error)(...args),
     info: (...args) => (mockedLogger.info ?? mod.info)(...args),
     log: (...args) => (mockedLogger.log ?? mod.log)(...args),

--- a/scripts/test-utils/src/index.ts
+++ b/scripts/test-utils/src/index.ts
@@ -18,7 +18,7 @@ export const mockedLogger: PartialMockMethods<
 vi.mock(import("@changesets/logger"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
-    prefix: mod.prefix,
+    prefix: mod.prefix as "🦋 ",
     error: (...args) => (mockedLogger.error ?? mod.error)(...args),
     info: (...args) => (mockedLogger.info ?? mod.info)(...args),
     log: (...args) => (mockedLogger.log ?? mod.log)(...args),


### PR DESCRIPTION
converts all `let`s to `consts` that can be

also fixes all tests that were broken on windows
