### PR TITLE
fix: allow unmatched ignore globs

### DIFF
--- a/.changeset/quiet-globs-ignore.md
+++ b/.changeset/quiet-globs-ignore.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Allow unmatched glob patterns in the `ignore` config option.

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -718,11 +718,9 @@ describe("parser errors", () => {
     `);
   });
   test("ignore package that does not exist (using glob expressions)", () => {
-    expect(() => unsafeParse({ ignore: ["pkg-*"] }, defaultPackages))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Some errors occurred when validating the changesets config:
-      The package or glob expression "pkg-*" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch"
-    `);
+    expect(unsafeParse({ ignore: ["pkg-*"] }, defaultPackages)).toEqual(
+      defaults
+    );
   });
   test("ignore missing dependent packages", async () => {
     expect(() =>

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -68,6 +68,15 @@ function getUnmatchedPatterns(
   );
 }
 
+function getUnmatchedPackageNames(
+  listOfPackageNamesOrGlob: readonly string[],
+  pkgNames: readonly string[]
+): string[] {
+  return getUnmatchedPatterns(listOfPackageNamesOrGlob, pkgNames).filter(
+    (pkgNameOrGlob) => !micromatch.scan(pkgNameOrGlob).isGlob
+  );
+}
+
 const havePackageGroupsCorrectShape = (
   pkgGroups: ReadonlyArray<PackageGroup>
 ) => {
@@ -360,7 +369,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       );
     } else {
       messages.push(
-        ...getUnmatchedPatterns(json.ignore, pkgNames).map(
+        ...getUnmatchedPackageNames(json.ignore, pkgNames).map(
           (pkgOrGlob) =>
             `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch`
         )


### PR DESCRIPTION
Fixes #1794.

## Summary
- allow unmatched glob expressions in the `ignore` config option
- keep exact missing package names as validation errors
- add a regression test for an unmatched ignore glob expanding to an empty ignore list
- add a changeset for `@changesets/config`

This supports generated package folders such as `prisma-client-*` that may exist locally after install/postinstall but not in a release automation checkout.

## Verification
- `yarn jest packages/config/src/index.test.ts --runInBand`
- `yarn types:check`
- `yarn eslint packages/config/src/index.ts packages/config/src/index.test.ts --ext .ts`
- `yarn prettier --check packages/config/src/index.ts packages/config/src/index.test.ts .changeset/quiet-globs-ignore.md`
