### PR TITLE
Temporarily disable codecov for next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
         if: matrix.node_version == 24
         run: node --run test -- --coverage
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        if: matrix.node_version == 24
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # - name: Upload coverage
+      #   uses: codecov/codecov-action@v4
+      #   if: matrix.node_version == 24
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
 
   typecheck:
     name: Typecheck


### PR DESCRIPTION
So that it stops reporting coverage issues and marking CI red, as things are moving a lot in the next branch.

I simply commented it out, but we could use a condition like this:

```yaml
if: matrix.node_version == 24 && !(
  (github.event_name == 'push' && github.ref == 'refs/heads/next') ||
  (github.event_name == 'merge_group' && github.ref == 'refs/heads/next') ||
  (github.event_name == 'pull_request' && github.base_ref == 'next')
)
```

If we'd like to, but it's a bit wordy.