### PR TITLE
Remove unused dotenv dependency

### DIFF
--- a/packages/changelog-github/package.json
+++ b/packages/changelog-github/package.json
@@ -11,8 +11,7 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/changelog-github",
   "dependencies": {
     "@changesets/get-github-info": "workspace:^",
-    "@changesets/types": "workspace:^",
-    "dotenv": "^16.4.7"
+    "@changesets/types": "workspace:^"
   },
   "devDependencies": {
     "@changesets/parse": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       '@changesets/types':
         specifier: workspace:^
         version: link:../types
-      dotenv:
-        specifier: ^16.4.7
-        version: 16.6.1
     devDependencies:
       '@changesets/parse':
         specifier: workspace:*
@@ -1824,10 +1821,6 @@ packages:
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
@@ -4164,8 +4157,6 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-indent@7.0.2: {}
-
-  dotenv@16.6.1: {}
 
   electron-to-chromium@1.5.267: {}
 


### PR DESCRIPTION
Looks like I forgot to remove the dependency after https://github.com/changesets/changesets/pull/1947