### PR TITLE
chore: drop legacy default exports

### DIFF
--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -371,7 +371,3 @@ function getPreInfo(
     preVersions,
   };
 }
-
-/** @deprecated Use named export `assembleReleasePlan` instead */
-const assembleReleasePlanDefault = assembleReleasePlan;
-export default assembleReleasePlanDefault;

--- a/packages/changelog-github/src/index.test.ts
+++ b/packages/changelog-github/src/index.test.ts
@@ -1,4 +1,4 @@
-import parse from "@changesets/parse";
+import { parseChangesetFile as parse } from "@changesets/parse";
 import { describe, expect, it, test, vi } from "vitest";
 import changelogFunctions from "./index.ts";
 

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -3,7 +3,7 @@ import { stripVTControlCharacters } from "node:util";
 import { defaultConfig } from "@changesets/config";
 import * as git from "@changesets/git";
 import * as logger from "@changesets/logger";
-import getChangesets from "@changesets/read";
+import { readChangesets as getChangesets } from "@changesets/read";
 import { exec } from "tinyexec";
 import { describe, expect, it, vi } from "vitest";
 import * as utils from "../../../utils/cli-utilities.ts";

--- a/packages/get-release-plan/src/index.ts
+++ b/packages/get-release-plan/src/index.ts
@@ -18,7 +18,3 @@ export async function getReleasePlan(
 
   return assembleReleasePlan(changesets, packages, config, preState);
 }
-
-/** @deprecated Use named export `getReleasePlan` instead */
-const getReleasePlanDefault = getReleasePlan;
-export default getReleasePlanDefault;

--- a/packages/get-version-range-type/src/index.test.ts
+++ b/packages/get-version-range-type/src/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import getVersionRangeType from "./index.ts";
+import { getVersionRangeType } from "./index.ts";
 
 test.each([
   ["^1.0.0", "^"],

--- a/packages/get-version-range-type/src/index.ts
+++ b/packages/get-version-range-type/src/index.ts
@@ -8,7 +8,3 @@ export function getVersionRangeType(
   if (versionRange.charAt(0) === ">") return ">";
   return "";
 }
-
-/** @deprecated Use named export `getVersionRangeType` instead */
-const getVersionRangeTypeDefault = getVersionRangeType;
-export default getVersionRangeTypeDefault;

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -1,6 +1,6 @@
 import { outdent } from "outdent";
 import { describe, expect, it } from "vitest";
-import parse from "./index.ts";
+import { parseChangesetFile as parse } from "./index.ts";
 
 describe("parsing a changeset", () => {
   it("should parse a changeset", () => {

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -109,7 +109,3 @@ export function parseChangesetFile(contents: string): {
 
   return { releases, summary };
 }
-
-/** @deprecated Use named export `parseChangesetFile` instead */
-const parseChangesetFileDefault = parseChangesetFile;
-export default parseChangesetFileDefault;

--- a/packages/read/src/index.test.ts
+++ b/packages/read/src/index.test.ts
@@ -4,7 +4,7 @@ import { add } from "@changesets/git";
 import { gitdir, silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import { writeChangeset } from "@changesets/write";
 import { describe, expect, it } from "vitest";
-import read from "./index.ts";
+import { readChangesets as read } from "./index.ts";
 
 silenceLogsInBlock();
 

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -57,7 +57,3 @@ export async function readChangesets(
   });
   return await Promise.all(changesetContents);
 }
-
-/** @deprecated Use named export `readChangesets` instead */
-const readChangesetsDefault = readChangesets;
-export default readChangesetsDefault;

--- a/packages/write/src/index.test.ts
+++ b/packages/write/src/index.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import parse from "@changesets/parse";
+import { parseChangesetFile as parse } from "@changesets/parse";
 import { testdir } from "@changesets/test-utils";
 import { humanId } from "human-id";
 import { describe, expect, it, vi } from "vitest";
-import writeChangeset from "./index.ts";
+import { writeChangeset } from "./index.ts";
 
 vi.mock("human-id");
 const mockedHumanId = vi.mocked(humanId);

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -60,7 +60,3 @@ ${summary}
 
   return changesetID;
 }
-
-/** @deprecated Use named export `writeChangeset` instead */
-const writeChangesetDefault = writeChangeset;
-export default writeChangesetDefault;


### PR DESCRIPTION
Removes all legacy default exports. These should already be unused in
the wild and our own usage (especially as of this change).
