### PR TITLE
improve workflows, add zizmor linting

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -17,7 +17,8 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.skip-cache != 'true' && 'yarn' }}
+        package-manager-cache: ${{ inputs.skip-cache != 'true' }}
+        cache: ${{ inputs.skip-cache != 'true' && 'yarn' || '' }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -4,7 +4,11 @@ inputs:
   node-version:
     description: "Node.js version"
     required: false
-    default: 20
+    default: "20"
+  skip-cache:
+    description: "Whether to skip the cache"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -13,7 +17,7 @@ runs:
       uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
       with:
         node-version: ${{ inputs.node-version }}
-        cache: yarn
+        cache: ${{ inputs.skip-cache != 'true' && 'yarn' }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.skip-cache != 'true' && 'yarn' }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn jest --ci --color --runInBand --coverage --reporters=default --reporters=jest-junit
 
       - name: Upload coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
-  queue: max
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,20 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/ci-setup
 
       - name: Check Git version
@@ -38,7 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/ci-setup
 
       - name: Typecheck
@@ -49,7 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/ci-setup
 
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 permissions: {} # each job should define its own permission explicitly
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,9 @@ on:
       - main
       - next
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions: {} # each job should define its own permission explicitly
 
@@ -48,7 +50,10 @@ jobs:
       contents: write # to create release (changesets/action)
       id-token: write # to use OpenID Connect token for trusted publishing (changesets/action)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/ci-setup
         with:
           node-version: 24

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,18 @@ jobs:
       issues: write # to post issue comments (changesets/action)
       pull-requests: write # to create pull request (changesets/action)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/ci-setup
+        with:
+          skip-cache: true # avoid cache poisoning attacks
 
       - name: Create or update release pull request
         id: changesets
         # https://github.com/changesets/action
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: yarn version-packages
 
@@ -47,10 +52,11 @@ jobs:
       - uses: ./.github/actions/ci-setup
         with:
           node-version: 24
+          skip-cache: true # avoid cache poisoning attacks
 
       - name: Publish to npm
         # https://github.com/changesets/action
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   lint-workflows:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main, next]
+    paths: [.github/workflows/*]
+  pull_request:
+    paths: [.github/workflows/*]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-workflows:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # only required in private repos
+      actions: read # only required in private repos
+      security-events: write # allow writing security events
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
+          annotations: true
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,9 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
-  queue: max
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
 
 jobs:
   lint-workflows:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
     paths: [.github/workflows/*]
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
- disables caching as discussed [in discord](https://discord.com/channels/1499011163705573470/1503666590707744778)
- adds [zizmor](https://docs.zizmor.sh/) for linting the workflows for issues
  - applies all the recommendations from it
- updates the codecov action to the latest version

will fix `next` when we merge `main` into it:

- `download-dist` should default to false

---

for whatever reason `package-manager-cache` does not override `cache` (despite being the more specific option), meaning logic for what we pass to the action has to be ridiculous