### PR TITLE
remove leftover `test-utils` references from changesets

### DIFF
--- a/.changeset/afraid-radios-fetch.md
+++ b/.changeset/afraid-radios-fetch.md
@@ -1,7 +1,6 @@
 ---
 "@changesets/apply-release-plan": patch
 "@changesets/release-utils": patch
-"@changesets/test-utils": patch
 "@changesets/config": patch
 "@changesets/write": patch
 "@changesets/read": patch

--- a/.changeset/thin-chicken-smell.md
+++ b/.changeset/thin-chicken-smell.md
@@ -1,7 +1,6 @@
 ---
 "@changesets/apply-release-plan": patch
 "@changesets/release-utils": patch
-"@changesets/test-utils": patch
 "@changesets/cli": patch
 "@changesets/git": patch
 ---


### PR DESCRIPTION
currently breaks `changeset version` because of the invalid state