### PR TITLE
perf: replace picocolors with node:util styletext

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "baseBranch": "next",
   "commit": false,
   "access": "public",
-  "ignore": ["@changesets/test-utils"],
+  "ignore": ["@changesets/test-utils", "@changesets/color"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   }

--- a/.changeset/tough-balloons-buy.md
+++ b/.changeset/tough-balloons-buy.md
@@ -1,0 +1,8 @@
+---
+"@changesets/cli": patch
+"@changesets/get-dependents-graph": patch
+"@changesets/logger": patch
+"@changesets/read": patch
+---
+
+perf: replace picocolors with node:util styletext

--- a/.changeset/tough-balloons-buy.md
+++ b/.changeset/tough-balloons-buy.md
@@ -5,4 +5,4 @@
 "@changesets/read": patch
 ---
 
-perf: replace picocolors with node:util styletext
+Replace `picocolors` with `node:util`'s `styleText`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,12 +52,12 @@
     "launch-editor": "^2.13.2",
     "mri": "^1.2.0",
     "package-manager-detector": "^1.1.0",
-    "picocolors": "^1.1.0",
     "semver": "^7.5.3",
     "tinyexec": "^1.0.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "workspace:*",
+    "@changesets/color": "workspace:^",
     "@changesets/parse": "workspace:*",
     "@changesets/test-utils": "workspace:*",
     "@types/semver": "^7.7.1",

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -1,7 +1,7 @@
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import type { Package, PackageJSON, Release } from "@changesets/types";
 import { log } from "@clack/prompts";
-import pc from "picocolors";
 import semverLt from "semver/functions/lt.js";
 import { askWithEditor } from "../../utils/askWithEditor.ts";
 import * as cli from "../../utils/cli-utilities.ts";
@@ -11,13 +11,13 @@ async function confirmMajorRelease({ name, version }: PackageJSON) {
   if (semverLt(version, "1.0.0")) {
     importantWarning(
       `
-The ${pc.red("major")} version of ${pc.blue(name)} will be its ${pc.red("first major release")} (1.0.0).
-If you are unsure if this is correct, contact the package's maintainers ${pc.red("before committing this changeset")}.   
+The ${color.red("major")} version of ${color.blue(name)} will be its ${color.red("first major release")} (1.0.0).
+If you are unsure if this is correct, contact the package's maintainers ${color.red("before committing this changeset")}.   
       `,
     );
 
     return cli.askConfirm(
-      `Are you sure you want to release the ${pc.red("first major version")} of ${name}?`,
+      `Are you sure you want to release the ${color.red("first major version")} of ${name}?`,
     );
   }
   return true;
@@ -73,7 +73,7 @@ function getPkgJsonsByName(packages: Array<Package>) {
 }
 
 function formatPkgNameAndVersion(pkgName: string, version: string) {
-  return `${pc.bold(pkgName)}@${pc.bold(version)}`;
+  return `${color.bold(pkgName)}@${color.bold(version)}`;
 }
 
 export async function createChangeset(
@@ -95,8 +95,8 @@ export async function createChangeset(
     const pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
 
     const pkgsThatShouldBeMajorBumped = await cli.askMultiselect<string>(
-      pc.bold(
-        `Which packages should have a ${pc.red("major")} ${pc.gray(`(${pc.red("X")}.X.X)`)} bump?`,
+      color.bold(
+        `Which packages should have a ${color.red("major")} ${color.gray(`(${color.red("X")}.X.X)`)} bump?`,
       ),
       {
         "all packages": packagesToRelease.map((pkgName) => ({
@@ -125,8 +125,8 @@ export async function createChangeset(
 
     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
       const pkgsThatShouldBeMinorBumped = await cli.askMultiselect(
-        pc.bold(
-          `Which packages should have a ${pc.green("minor")} ${pc.gray(`(X.${pc.green("X")}.X)`)} bump?`,
+        color.bold(
+          `Which packages should have a ${color.green("minor")} ${color.gray(`(X.${color.green("X")}.X)`)} bump?`,
         ),
         {
           "all packages": [...pkgsLeftToGetBumpTypeFor].map((pkgName) => ({
@@ -152,8 +152,8 @@ export async function createChangeset(
       );
       log.info(
         `
-The following packages will be ${pc.blue("patch")} ${pc.gray(`(X.X.${pc.blue("X")})`)} bumped:
-${pc.gray(patchBumpedPackages.join(", "))}
+The following packages will be ${color.blue("patch")} ${color.gray(`(X.X.${color.blue("X")})`)} bumped:
+${color.gray(patchBumpedPackages.join(", "))}
         `.trim(),
       );
 
@@ -164,7 +164,7 @@ ${pc.gray(patchBumpedPackages.join(", "))}
   } else {
     const pkg = allPackages[0];
     const type = await cli.askList(
-      `What kind of change is this for ${pc.blue(pkg.packageJson.name)}? ${pc.gray(`(current version is ${pkg.packageJson.version})`)}`,
+      `What kind of change is this for ${color.blue(pkg.packageJson.name)}? ${color.gray(`(current version is ${pkg.packageJson.version})`)}`,
       ["patch", "minor", "major"],
     );
     if (type === "major") {
@@ -203,7 +203,7 @@ ${pc.gray(patchBumpedPackages.join(", "))}
       }
     } catch {
       summary = await cli.askQuestion(
-        `${pc.red(
+        `${color.red(
           "An error happened using external editor. Please type your summary here:",
         )}`,
         { notEmpty: true },

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import type { Package, PackageJSON, Release } from "@changesets/types";
 import { log } from "@clack/prompts";
@@ -11,13 +11,13 @@ async function confirmMajorRelease({ name, version }: PackageJSON) {
   if (semverLt(version, "1.0.0")) {
     importantWarning(
       `
-The ${color.red("major")} version of ${color.blue(name)} will be its ${color.red("first major release")} (1.0.0).
-If you are unsure if this is correct, contact the package's maintainers ${color.red("before committing this changeset")}.   
+The ${c.red("major")} version of ${c.blue(name)} will be its ${c.red("first major release")} (1.0.0).
+If you are unsure if this is correct, contact the package's maintainers ${c.red("before committing this changeset")}.
       `,
     );
 
     return cli.askConfirm(
-      `Are you sure you want to release the ${color.red("first major version")} of ${name}?`,
+      `Are you sure you want to release the ${c.red("first major version")} of ${name}?`,
     );
   }
   return true;
@@ -73,7 +73,7 @@ function getPkgJsonsByName(packages: Array<Package>) {
 }
 
 function formatPkgNameAndVersion(pkgName: string, version: string) {
-  return `${color.bold(pkgName)}@${color.bold(version)}`;
+  return `${c.bold(pkgName)}@${c.bold(version)}`;
 }
 
 export async function createChangeset(
@@ -95,8 +95,8 @@ export async function createChangeset(
     const pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
 
     const pkgsThatShouldBeMajorBumped = await cli.askMultiselect<string>(
-      color.bold(
-        `Which packages should have a ${color.red("major")} ${color.gray(`(${color.red("X")}.X.X)`)} bump?`,
+      c.bold(
+        `Which packages should have a ${c.red("major")} ${c.gray(`(${c.red("X")}.X.X)`)} bump?`,
       ),
       {
         "all packages": packagesToRelease.map((pkgName) => ({
@@ -125,8 +125,8 @@ export async function createChangeset(
 
     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
       const pkgsThatShouldBeMinorBumped = await cli.askMultiselect(
-        color.bold(
-          `Which packages should have a ${color.green("minor")} ${color.gray(`(X.${color.green("X")}.X)`)} bump?`,
+        c.bold(
+          `Which packages should have a ${c.green("minor")} ${c.gray(`(X.${c.green("X")}.X)`)} bump?`,
         ),
         {
           "all packages": [...pkgsLeftToGetBumpTypeFor].map((pkgName) => ({
@@ -152,8 +152,8 @@ export async function createChangeset(
       );
       log.info(
         `
-The following packages will be ${color.blue("patch")} ${color.gray(`(X.X.${color.blue("X")})`)} bumped:
-${color.gray(patchBumpedPackages.join(", "))}
+The following packages will be ${c.blue("patch")} ${c.gray(`(X.X.${c.blue("X")})`)} bumped:
+${c.gray(patchBumpedPackages.join(", "))}
         `.trim(),
       );
 
@@ -164,7 +164,7 @@ ${color.gray(patchBumpedPackages.join(", "))}
   } else {
     const pkg = allPackages[0];
     const type = await cli.askList(
-      `What kind of change is this for ${color.blue(pkg.packageJson.name)}? ${color.gray(`(current version is ${pkg.packageJson.version})`)}`,
+      `What kind of change is this for ${c.blue(pkg.packageJson.name)}? ${c.gray(`(current version is ${pkg.packageJson.version})`)}`,
       ["patch", "minor", "major"],
     );
     if (type === "major") {
@@ -203,7 +203,7 @@ ${color.gray(patchBumpedPackages.join(", "))}
       }
     } catch {
       summary = await cli.askQuestion(
-        `${color.red(
+        `${c.red(
           "An error happened using external editor. Please type your summary here:",
         )}`,
         { notEmpty: true },

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
@@ -46,8 +46,8 @@ export async function add(
     log.error(
       `
 No versionable packages found
-  ${color.italic("Ensure the packages to version are not ignored by the config")}
-  ${color.italic("Ensure that relevant package.json files have a `version` field")}
+  ${c.italic("Ensure the packages to version are not ignored by the config")}
+  ${c.italic("Ensure that relevant package.json files have a `version` field")}
 `.trim(),
     );
     throw new ExitError(1);
@@ -111,11 +111,11 @@ ${(error as Error).toString()}
       await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
       await git.commit(await getAddMessage(newChangeset, commitOpts), cwd);
       finalLogMessageLines.push(
-        color.green(`${empty ? "Empty " : ""}Changeset added and committed!`),
+        c.green(`${empty ? "Empty " : ""}Changeset added and committed!`),
       );
     } else {
       finalLogMessageLines.push(
-        color.green(
+        c.green(
           `${empty ? "Empty " : ""}Changeset added - you can now commit it!`,
         ),
       );
@@ -136,7 +136,7 @@ This Changeset includes a major change and we STRONGLY recommend adding more inf
       );
     } else {
       finalLogMessageLines.push(
-        color.green(
+        c.green(
           "If you want to modify or expand on the changeset summary, you can find it here:",
         ),
       );
@@ -146,7 +146,7 @@ This Changeset includes a major change and we STRONGLY recommend adding more inf
       process.cwd(),
       path.join(changesetBase, `${changesetID}.md`),
     );
-    finalLogMessageLines.push(color.blue(changesetPath));
+    finalLogMessageLines.push(c.blue(changesetPath));
 
     log.success(finalLogMessageLines.join("\n"));
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
@@ -8,7 +9,6 @@ import { writeChangeset } from "@changesets/write";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
 import launchEditor from "launch-editor";
-import pc from "picocolors";
 import { getCommitFunctions } from "../../commit/getCommitFunctions.ts";
 import * as cli from "../../utils/cli-utilities.ts";
 import { importantWarning } from "../../utils/cli-utilities.ts";
@@ -46,8 +46,8 @@ export async function add(
     log.error(
       `
 No versionable packages found
-  ${pc.italic("Ensure the packages to version are not ignored by the config")}
-  ${pc.italic("Ensure that relevant package.json files have a `version` field")}
+  ${color.italic("Ensure the packages to version are not ignored by the config")}
+  ${color.italic("Ensure that relevant package.json files have a `version` field")}
 `.trim(),
     );
     throw new ExitError(1);
@@ -111,11 +111,11 @@ ${(error as Error).toString()}
       await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
       await git.commit(await getAddMessage(newChangeset, commitOpts), cwd);
       finalLogMessageLines.push(
-        pc.green(`${empty ? "Empty " : ""}Changeset added and committed!`),
+        color.green(`${empty ? "Empty " : ""}Changeset added and committed!`),
       );
     } else {
       finalLogMessageLines.push(
-        pc.green(
+        color.green(
           `${empty ? "Empty " : ""}Changeset added - you can now commit it!`,
         ),
       );
@@ -136,7 +136,7 @@ This Changeset includes a major change and we STRONGLY recommend adding more inf
       );
     } else {
       finalLogMessageLines.push(
-        pc.green(
+        color.green(
           "If you want to modify or expand on the changeset summary, you can find it here:",
         ),
       );
@@ -146,7 +146,7 @@ This Changeset includes a major change and we STRONGLY recommend adding more inf
       process.cwd(),
       path.join(changesetBase, `${changesetID}.md`),
     );
-    finalLogMessageLines.push(pc.blue(changesetPath));
+    finalLogMessageLines.push(color.blue(changesetPath));
 
     log.success(finalLogMessageLines.join("\n"));
 

--- a/packages/cli/src/commands/add/messages.ts
+++ b/packages/cli/src/commands/add/messages.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import type { Release, VersionType } from "@changesets/types";
 import { log } from "@clack/prompts";
 
@@ -19,23 +19,23 @@ export function printConfirmationMessage(
   const minorReleases = getReleasesOfType("minor");
   const patchReleases = getReleasesOfType("patch");
 
-  let msg = color.bold("Summary of changesets:");
+  let msg = c.bold("Summary of changesets:");
   if (majorReleases.length > 0) {
-    msg += `\n${color.bold(color.red("major"))}:  ${majorReleases.join(", ")}`;
+    msg += `\n${c.bold(c.red("major"))}:  ${majorReleases.join(", ")}`;
   }
   if (minorReleases.length > 0) {
-    msg += `\n${color.bold(color.green("minor"))}:  ${minorReleases.join(", ")}`;
+    msg += `\n${c.bold(c.green("minor"))}:  ${minorReleases.join(", ")}`;
   }
   if (patchReleases.length > 0) {
-    msg += `\n${color.bold(color.blue("patch"))}:  ${patchReleases.join(", ")}`;
+    msg += `\n${c.bold(c.blue("patch"))}:  ${patchReleases.join(", ")}`;
   }
   log.success(msg);
 
   if (repoHasMultiplePackages) {
     log.info(
       `
-Note: All packages that depend on these whose required versions 
-will be incompatible will also be ${color.blue("patch")} bumped
+Note: All packages that depend on these whose required versions
+will be incompatible will also be ${c.blue("patch")} bumped
 when this changeset is applied.
       `.trim(),
     );

--- a/packages/cli/src/commands/add/messages.ts
+++ b/packages/cli/src/commands/add/messages.ts
@@ -1,6 +1,6 @@
+import color from "@changesets/color";
 import type { Release, VersionType } from "@changesets/types";
 import { log } from "@clack/prompts";
-import pc from "picocolors";
 
 export function printConfirmationMessage(
   changeset: {
@@ -19,15 +19,15 @@ export function printConfirmationMessage(
   const minorReleases = getReleasesOfType("minor");
   const patchReleases = getReleasesOfType("patch");
 
-  let msg = pc.bold("Summary of changesets:");
+  let msg = color.bold("Summary of changesets:");
   if (majorReleases.length > 0) {
-    msg += `\n${pc.bold(pc.red("major"))}:  ${majorReleases.join(", ")}`;
+    msg += `\n${color.bold(color.red("major"))}:  ${majorReleases.join(", ")}`;
   }
   if (minorReleases.length > 0) {
-    msg += `\n${pc.bold(pc.green("minor"))}:  ${minorReleases.join(", ")}`;
+    msg += `\n${color.bold(color.green("minor"))}:  ${minorReleases.join(", ")}`;
   }
   if (patchReleases.length > 0) {
-    msg += `\n${pc.bold(pc.blue("patch"))}:  ${patchReleases.join(", ")}`;
+    msg += `\n${color.bold(color.blue("patch"))}:  ${patchReleases.join(", ")}`;
   }
   log.success(msg);
 
@@ -35,7 +35,7 @@ export function printConfirmationMessage(
     log.info(
       `
 Note: All packages that depend on these whose required versions 
-will be incompatible will also be ${pc.blue("patch")} bumped
+will be incompatible will also be ${color.blue("patch")} bumped
 when this changeset is applied.
       `.trim(),
     );

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -2,9 +2,9 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import color from "@changesets/color";
 import { defaultWrittenConfig } from "@changesets/config";
 import { log } from "@clack/prompts";
-import pc from "picocolors";
 
 const pkgPath = path.dirname(
   fileURLToPath(import.meta.resolve("@changesets/cli/package.json")),
@@ -20,7 +20,7 @@ export async function init(cwd: string) {
       log.success(
         `
 It looks like you don't have a config file
-The default config file will be written to ${pc.blue(".changeset/config.json")}
+The default config file will be written to ${color.blue(".changeset/config.json")}
         `.trim(),
       );
 
@@ -30,7 +30,7 @@ The default config file will be written to ${pc.blue(".changeset/config.json")}
       );
     } else {
       log.success(
-        `It looks like you already have ${pc.green("Changesets")} initialized.\nYou should be able to run changeset commands no problems.`,
+        `It looks like you already have ${color.green("Changesets")} initialized.\nYou should be able to run changeset commands no problems.`,
       );
     }
   } else {
@@ -44,11 +44,11 @@ The default config file will be written to ${pc.blue(".changeset/config.json")}
 
     log.success(
       `
-Thanks for choosing ${pc.green("Changesets")} to help manage your versioning and publishing.
+Thanks for choosing ${color.green("Changesets")} to help manage your versioning and publishing.
 You should be set up to start using changesets now!
 We have created a \`.changeset\` folder, and a couple of files to help you out:
-- ${pc.blue(".changeset/config.json")} with the default config options
-- ${pc.blue(".changeset/README.md")} with information about using changesets
+- ${color.blue(".changeset/config.json")} with the default config options
+- ${color.blue(".changeset/README.md")} with information about using changesets
       `.trim(),
     );
   }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { defaultWrittenConfig } from "@changesets/config";
 import { log } from "@clack/prompts";
 
@@ -20,7 +20,7 @@ export async function init(cwd: string) {
       log.success(
         `
 It looks like you don't have a config file
-The default config file will be written to ${color.blue(".changeset/config.json")}
+The default config file will be written to ${c.blue(".changeset/config.json")}
         `.trim(),
       );
 
@@ -30,7 +30,7 @@ The default config file will be written to ${color.blue(".changeset/config.json"
       );
     } else {
       log.success(
-        `It looks like you already have ${color.green("Changesets")} initialized.\nYou should be able to run changeset commands no problems.`,
+        `It looks like you already have ${c.green("Changesets")} initialized.\nYou should be able to run changeset commands no problems.`,
       );
     }
   } else {
@@ -44,11 +44,11 @@ The default config file will be written to ${color.blue(".changeset/config.json"
 
     log.success(
       `
-Thanks for choosing ${color.green("Changesets")} to help manage your versioning and publishing.
+Thanks for choosing ${c.green("Changesets")} to help manage your versioning and publishing.
 You should be set up to start using changesets now!
 We have created a \`.changeset\` folder, and a couple of files to help you out:
-- ${color.blue(".changeset/config.json")} with the default config options
-- ${color.blue(".changeset/README.md")} with information about using changesets
+- ${c.blue(".changeset/config.json")} with the default config options
+- ${c.blue(".changeset/README.md")} with information about using changesets
       `.trim(),
     );
   }

--- a/packages/cli/src/commands/pre/index.ts
+++ b/packages/cli/src/commands/pre/index.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import {
   PreExitButNotInPreModeError,
   PreEnterButInPreModeError,
@@ -18,16 +18,16 @@ export async function pre(
       await enterPre(rootDir, options.tag);
       log.success(
         `
-Entered pre mode with tag ${color.green(options.tag)}!
-Run ${color.cyan("changeset version")} to version packages with prerelease versions.
+Entered pre mode with tag ${c.green(options.tag)}!
+Run ${c.cyan("changeset version")} to version packages with prerelease versions.
         `.trim(),
       );
     } catch (err) {
       if (err instanceof PreEnterButInPreModeError) {
         log.error(
           `
-${color.cyan("changeset pre enter")} cannot be run when in pre mode.
-If you're trying to exit pre mode, run ${color.cyan("changeset pre exit")}.
+${c.cyan("changeset pre enter")} cannot be run when in pre mode.
+If you're trying to exit pre mode, run ${c.cyan("changeset pre exit")}.
           `.trim(),
         );
         throw new ExitError(1);
@@ -40,15 +40,15 @@ If you're trying to exit pre mode, run ${color.cyan("changeset pre exit")}.
       log.success(
         `
 Exited pre mode!
-Run ${color.cyan("changeset version")} to version packages with normal versions.
+Run ${c.cyan("changeset version")} to version packages with normal versions.
         `.trim(),
       );
     } catch (err) {
       if (err instanceof PreExitButNotInPreModeError) {
         log.error(
           `
-${color.cyan("changeset pre exit")} can only be run when in pre mode!
-If you're trying to enter pre mode, run ${color.cyan("changeset pre enter")}.
+${c.cyan("changeset pre exit")} can only be run when in pre mode!
+If you're trying to enter pre mode, run ${c.cyan("changeset pre enter")}.
           `.trim(),
         );
         throw new ExitError(1);

--- a/packages/cli/src/commands/pre/index.ts
+++ b/packages/cli/src/commands/pre/index.ts
@@ -1,3 +1,4 @@
+import color from "@changesets/color";
 import {
   PreExitButNotInPreModeError,
   PreEnterButInPreModeError,
@@ -5,7 +6,6 @@ import {
 } from "@changesets/errors";
 import { exitPre, enterPre } from "@changesets/pre";
 import { log } from "@clack/prompts";
-import pc from "picocolors";
 
 export async function pre(
   rootDir: string,
@@ -18,16 +18,16 @@ export async function pre(
       await enterPre(rootDir, options.tag);
       log.success(
         `
-Entered pre mode with tag ${pc.green(options.tag)}!
-Run ${pc.cyan("changeset version")} to version packages with prerelease versions.
+Entered pre mode with tag ${color.green(options.tag)}!
+Run ${color.cyan("changeset version")} to version packages with prerelease versions.
         `.trim(),
       );
     } catch (err) {
       if (err instanceof PreEnterButInPreModeError) {
         log.error(
           `
-${pc.cyan("changeset pre enter")} cannot be run when in pre mode.
-If you're trying to exit pre mode, run ${pc.cyan("changeset pre exit")}.
+${color.cyan("changeset pre enter")} cannot be run when in pre mode.
+If you're trying to exit pre mode, run ${color.cyan("changeset pre exit")}.
           `.trim(),
         );
         throw new ExitError(1);
@@ -40,15 +40,15 @@ If you're trying to exit pre mode, run ${pc.cyan("changeset pre exit")}.
       log.success(
         `
 Exited pre mode!
-Run ${pc.cyan("changeset version")} to version packages with normal versions.
+Run ${color.cyan("changeset version")} to version packages with normal versions.
         `.trim(),
       );
     } catch (err) {
       if (err instanceof PreExitButNotInPreModeError) {
         log.error(
           `
-${pc.cyan("changeset pre exit")} can only be run when in pre mode!
-If you're trying to enter pre mode, run ${pc.cyan("changeset pre enter")}.
+${color.cyan("changeset pre exit")} can only be run when in pre mode!
+If you're trying to enter pre mode, run ${color.cyan("changeset pre enter")}.
           `.trim(),
         );
         throw new ExitError(1);

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -1,21 +1,21 @@
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
 import type { Config, PreState } from "@changesets/types";
 import { log, spinner } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
-import pc from "picocolors";
 import { importantWarning } from "../../utils/cli-utilities.ts";
 import { getUntaggedPackages } from "../../utils/getUntaggedPackages.ts";
 import { publishPackages } from "./publishPackages.ts";
 
 function formatPackageList(
   pkgs: Array<{ name: string; newVersion: string }>,
-  versionColor = pc.green,
+  versionColor = color.green,
 ) {
   return pkgs
     .toSorted((a, b) => a.name.localeCompare(b.name))
-    .map((p) => `${pc.blueBright(p.name)}@${versionColor(p.newVersion)}`)
+    .map((p) => `${color.blueBright(p.name)}@${versionColor(p.newVersion)}`)
     .join("\n");
 }
 
@@ -23,8 +23,8 @@ function showNonLatestTagWarning(tag?: string, preState?: PreState) {
   if (preState) {
     importantWarning(
       `
-You are in prerelease mode, so packages will be published to the ${pc.cyan(preState.tag)} npm tag,
-${pc.red("except")} for packages that have not had normal releases, which will be published to ${pc.cyan("latest")}.
+You are in prerelease mode, so packages will be published to the ${color.cyan(preState.tag)} npm tag,
+${color.red("except")} for packages that have not had normal releases, which will be published to ${color.cyan("latest")}.
       `,
     );
   } else if (tag !== "latest") {
@@ -44,7 +44,7 @@ export async function publish(
     log.error(
       `
 Releasing under custom tag is not allowed in pre mode!
-To resolve this exit the pre mode by running ${pc.cyan("changeset pre exit")}.
+To resolve this exit the pre mode by running ${color.cyan("changeset pre exit")}.
       `.trim(),
     );
     throw new ExitError(1);
@@ -113,7 +113,7 @@ ${formatPackageList(successfulNpmPublishes)}
     log.success(
       `
 Found untagged packages:
-${formatPackageList(untaggedPrivatePackageReleases, pc.yellowBright)}
+${formatPackageList(untaggedPrivatePackageReleases, color.yellowBright)}
       `.trim(),
     );
 
@@ -131,7 +131,7 @@ ${formatPackageList(untaggedPrivatePackageReleases, pc.yellowBright)}
     log.error(
       `
 Some packages failed to publish:
-${formatPackageList(unsuccessfulNpmPublishes, pc.red)}
+${formatPackageList(unsuccessfulNpmPublishes, color.red)}
       `.trim(),
     );
     throw new ExitError(1);

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
@@ -11,11 +11,11 @@ import { publishPackages } from "./publishPackages.ts";
 
 function formatPackageList(
   pkgs: Array<{ name: string; newVersion: string }>,
-  versionColor = color.green,
+  versionColor = c.green,
 ) {
   return pkgs
     .toSorted((a, b) => a.name.localeCompare(b.name))
-    .map((p) => `${color.blueBright(p.name)}@${versionColor(p.newVersion)}`)
+    .map((p) => `${c.blueBright(p.name)}@${versionColor(p.newVersion)}`)
     .join("\n");
 }
 
@@ -23,8 +23,8 @@ function showNonLatestTagWarning(tag?: string, preState?: PreState) {
   if (preState) {
     importantWarning(
       `
-You are in prerelease mode, so packages will be published to the ${color.cyan(preState.tag)} npm tag,
-${color.red("except")} for packages that have not had normal releases, which will be published to ${color.cyan("latest")}.
+You are in prerelease mode, so packages will be published to the ${c.cyan(preState.tag)} npm tag,
+${c.red("except")} for packages that have not had normal releases, which will be published to ${c.cyan("latest")}.
       `,
     );
   } else if (tag !== "latest") {
@@ -44,7 +44,7 @@ export async function publish(
     log.error(
       `
 Releasing under custom tag is not allowed in pre mode!
-To resolve this exit the pre mode by running ${color.cyan("changeset pre exit")}.
+To resolve this exit the pre mode by running ${c.cyan("changeset pre exit")}.
       `.trim(),
     );
     throw new ExitError(1);
@@ -113,7 +113,7 @@ ${formatPackageList(successfulNpmPublishes)}
     log.success(
       `
 Found untagged packages:
-${formatPackageList(untaggedPrivatePackageReleases, color.yellowBright)}
+${formatPackageList(untaggedPrivatePackageReleases, c.yellowBright)}
       `.trim(),
     );
 
@@ -131,7 +131,7 @@ ${formatPackageList(untaggedPrivatePackageReleases, color.yellowBright)}
     log.error(
       `
 Some packages failed to publish:
-${formatPackageList(unsuccessfulNpmPublishes, color.red)}
+${formatPackageList(unsuccessfulNpmPublishes, c.red)}
       `.trim(),
     );
     throw new ExitError(1);

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import type { AccessType, PackageJSON } from "@changesets/types";
 import { log } from "@clack/prompts";
@@ -195,13 +195,13 @@ export function getPackageInfo(packageJson: PackageJSON) {
 export async function infoAllow404(packageJson: PackageJSON) {
   const pkgInfo = await getPackageInfo(packageJson);
   if (pkgInfo.error?.code === "E404") {
-    log.warn(`Received 404 for ${color.cyan(`npm info ${packageJson.name}`)}`);
+    log.warn(`Received 404 for ${c.cyan(`npm info ${packageJson.name}`)}`);
     return { published: false, pkgInfo: {} };
   }
   if (pkgInfo.error) {
     log.error(
       `
-Received an unknown error code: ${pkgInfo.error.code} for ${color.cyan(`npm info ${packageJson.name}`)}
+Received an unknown error code: ${pkgInfo.error.code} for ${c.cyan(`npm info ${packageJson.name}`)}
 ${pkgInfo.error.summary}${pkgInfo.error.detail ? `\n${pkgInfo.error.detail}` : ""}
       `.trim(),
     );

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -1,8 +1,8 @@
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import type { AccessType, PackageJSON } from "@changesets/types";
 import { log } from "@clack/prompts";
 import { detect } from "package-manager-detector";
-import pc from "picocolors";
 import semverParse from "semver/functions/parse.js";
 import { exec } from "tinyexec";
 import { createPromiseQueue } from "../../utils/createPromiseQueue.ts";
@@ -195,13 +195,13 @@ export function getPackageInfo(packageJson: PackageJSON) {
 export async function infoAllow404(packageJson: PackageJSON) {
   const pkgInfo = await getPackageInfo(packageJson);
   if (pkgInfo.error?.code === "E404") {
-    log.warn(`Received 404 for ${pc.cyan(`npm info ${packageJson.name}`)}`);
+    log.warn(`Received 404 for ${color.cyan(`npm info ${packageJson.name}`)}`);
     return { published: false, pkgInfo: {} };
   }
   if (pkgInfo.error) {
     log.error(
       `
-Received an unknown error code: ${pkgInfo.error.code} for ${pc.cyan(`npm info ${packageJson.name}`)}
+Received an unknown error code: ${pkgInfo.error.code} for ${color.cyan(`npm info ${packageJson.name}`)}
 ${pkgInfo.error.summary}${pkgInfo.error.detail ? `\n${pkgInfo.error.detail}` : ""}
       `.trim(),
     );

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
+import color from "@changesets/color";
 import type { AccessType, Package, PreState } from "@changesets/types";
 import { log, progress } from "@clack/prompts";
-import pc from "picocolors";
 import semverParse from "semver/functions/parse.js";
 import type { TwoFactorState } from "../../utils/types.ts";
 import {
@@ -139,7 +139,7 @@ export async function publishPackages({
       publishPromises.map(async (publishPromise) => {
         const result = await publishPromise;
         log.success(
-          `Published ${pc.blue(result.name)}@${pc.green(result.newVersion)}!`,
+          `Published ${color.blue(result.name)}@${color.green(result.newVersion)}!`,
         );
         return result;
       }),
@@ -215,10 +215,10 @@ async function getUnpublishedPackages(
     const { name, publishedState, localVersion, publishedVersions } = pkgInfo;
     if (!publishedVersions.includes(localVersion)) {
       packagesToPublish.push(pkgInfo);
-      previewLines.push(`${pc.blue(name)}@${pc.green(localVersion)}`);
+      previewLines.push(`${color.blue(name)}@${color.green(localVersion)}`);
       if (preState != null && publishedState === "only-pre") {
         previewLines.push(
-          `${pc.gray("└")} will be published to ${pc.cyan("latest")} rather than ${pc.cyan(preState.tag)} as it will be its first published version.`,
+          `${color.gray("└")} will be published to ${color.cyan("latest")} rather than ${color.cyan(preState.tag)} as it will be its first published version.`,
         );
       }
     } else {
@@ -231,7 +231,7 @@ async function getUnpublishedPackages(
       `
 These packages will be published as they were not found on npm:
 ${previewLines.join("\n")}
-${pc.gray(`${alreadyPublishedCount} packages are already published.`)}
+${color.gray(`${alreadyPublishedCount} packages are already published.`)}
       `.trim(),
     );
   }

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import type { AccessType, Package, PreState } from "@changesets/types";
 import { log, progress } from "@clack/prompts";
 import semverParse from "semver/functions/parse.js";
@@ -139,7 +139,7 @@ export async function publishPackages({
       publishPromises.map(async (publishPromise) => {
         const result = await publishPromise;
         log.success(
-          `Published ${color.blue(result.name)}@${color.green(result.newVersion)}!`,
+          `Published ${c.blue(result.name)}@${c.green(result.newVersion)}!`,
         );
         return result;
       }),
@@ -215,10 +215,10 @@ async function getUnpublishedPackages(
     const { name, publishedState, localVersion, publishedVersions } = pkgInfo;
     if (!publishedVersions.includes(localVersion)) {
       packagesToPublish.push(pkgInfo);
-      previewLines.push(`${color.blue(name)}@${color.green(localVersion)}`);
+      previewLines.push(`${c.blue(name)}@${c.green(localVersion)}`);
       if (preState != null && publishedState === "only-pre") {
         previewLines.push(
-          `${color.gray("└")} will be published to ${color.cyan("latest")} rather than ${color.cyan(preState.tag)} as it will be its first published version.`,
+          `${c.gray("└")} will be published to ${c.cyan("latest")} rather than ${c.cyan(preState.tag)} as it will be its first published version.`,
         );
       }
     } else {
@@ -231,7 +231,7 @@ async function getUnpublishedPackages(
       `
 These packages will be published as they were not found on npm:
 ${previewLines.join("\n")}
-${color.gray(`${alreadyPublishedCount} packages are already published.`)}
+${c.gray(`${alreadyPublishedCount} packages are already published.`)}
       `.trim(),
     );
   }

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import { getReleasePlan } from "@changesets/get-release-plan";
 import type { ComprehensiveRelease, Config } from "@changesets/types";
 import { log } from "@clack/prompts";
-import pc from "picocolors";
 import { getVersionableChangedPackages } from "../../utils/versionablePackages.ts";
 
 export async function status(
@@ -29,8 +29,8 @@ export async function status(
   if (changedPackages.length > 0 && releasePlan.changesets.length === 0) {
     log.error(
       `
-Some packages have been changed but no changesets were found. Run ${pc.cyan("changeset add")} to resolve this error.
-If this change doesn't need a release, run ${pc.cyan("changeset add --empty")}.
+Some packages have been changed but no changesets were found. Run ${color.cyan("changeset add")} to resolve this error.
+If this change doesn't need a release, run ${color.cyan("changeset add --empty")}.
       `.trim(),
     );
     throw new ExitError(1);
@@ -62,9 +62,9 @@ ${printPackageList(releases, verbose)}
 }
 
 const typeColors = {
-  major: pc.red,
-  minor: pc.green,
-  patch: pc.blue,
+  major: color.red,
+  minor: color.green,
+  patch: color.blue,
 } as const;
 
 function printPackageList(releases: ComprehensiveRelease[], verbose?: boolean) {
@@ -85,12 +85,14 @@ function printPackageList(releases: ComprehensiveRelease[], verbose?: boolean) {
       const lines = [`- ${typeColors[type](type)}`];
 
       releases.forEach(({ name, newVersion, changesets }) => {
-        const addedLineIndex = lines.push(`  - ${pc.cyan(name)}`) - 1;
+        const addedLineIndex = lines.push(`  - ${color.cyan(name)}`) - 1;
 
         if (verbose) {
-          lines[addedLineIndex] += ` -> ${pc.green(newVersion)}`;
+          lines[addedLineIndex] += ` -> ${color.green(newVersion)}`;
           lines.push(
-            ...changesets.map((c) => `    - ${pc.blue(`.changeset/${c}.md`)}`),
+            ...changesets.map(
+              (c) => `    - ${color.blue(`.changeset/${c}.md`)}`,
+            ),
           );
         }
       });

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import { getReleasePlan } from "@changesets/get-release-plan";
 import type { ComprehensiveRelease, Config } from "@changesets/types";
@@ -29,8 +29,8 @@ export async function status(
   if (changedPackages.length > 0 && releasePlan.changesets.length === 0) {
     log.error(
       `
-Some packages have been changed but no changesets were found. Run ${color.cyan("changeset add")} to resolve this error.
-If this change doesn't need a release, run ${color.cyan("changeset add --empty")}.
+Some packages have been changed but no changesets were found. Run ${c.cyan("changeset add")} to resolve this error.
+If this change doesn't need a release, run ${c.cyan("changeset add --empty")}.
       `.trim(),
     );
     throw new ExitError(1);
@@ -62,9 +62,9 @@ ${printPackageList(releases, verbose)}
 }
 
 const typeColors = {
-  major: color.red,
-  minor: color.green,
-  patch: color.blue,
+  major: c.red,
+  minor: c.green,
+  patch: c.blue,
 } as const;
 
 function printPackageList(releases: ComprehensiveRelease[], verbose?: boolean) {
@@ -85,14 +85,12 @@ function printPackageList(releases: ComprehensiveRelease[], verbose?: boolean) {
       const lines = [`- ${typeColors[type](type)}`];
 
       releases.forEach(({ name, newVersion, changesets }) => {
-        const addedLineIndex = lines.push(`  - ${color.cyan(name)}`) - 1;
+        const addedLineIndex = lines.push(`  - ${c.cyan(name)}`) - 1;
 
         if (verbose) {
-          lines[addedLineIndex] += ` -> ${color.green(newVersion)}`;
+          lines[addedLineIndex] += ` -> ${c.green(newVersion)}`;
           lines.push(
-            ...changesets.map(
-              (c) => `    - ${color.blue(`.changeset/${c}.md`)}`,
-            ),
+            ...changesets.map((c) => `    - ${c.blue(`.changeset/${c}.md`)}`),
           );
         }
       });

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,9 +1,9 @@
+import color from "@changesets/color";
 import * as git from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 import type { Config } from "@changesets/types";
 import { log, progress } from "@clack/prompts";
 import { getPackages, type Tool } from "@manypkg/get-packages";
-import pc from "picocolors";
 import { getUntaggedPackages } from "../../utils/getUntaggedPackages.ts";
 
 function buildTag(tool: Tool, pkg: { name: string; newVersion: string }) {
@@ -17,8 +17,8 @@ function buildTagMessage(
   pkg: { name: string; newVersion: string },
 ) {
   return tool.type !== "root"
-    ? `${pc.blue(pkg.name)}@${pc.green(pkg.newVersion)}`
-    : pc.cyan(`v${pkg.newVersion}`);
+    ? `${color.blue(pkg.name)}@${color.green(pkg.newVersion)}`
+    : color.cyan(`v${pkg.newVersion}`);
 }
 
 export async function tag(cwd: string, config: Config) {

--- a/packages/cli/src/commands/tag/index.ts
+++ b/packages/cli/src/commands/tag/index.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import * as git from "@changesets/git";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 import type { Config } from "@changesets/types";
@@ -17,8 +17,8 @@ function buildTagMessage(
   pkg: { name: string; newVersion: string },
 ) {
   return tool.type !== "root"
-    ? `${color.blue(pkg.name)}@${color.green(pkg.newVersion)}`
-    : color.cyan(`v${pkg.newVersion}`);
+    ? `${c.blue(pkg.name)}@${c.green(pkg.newVersion)}`
+    : c.cyan(`v${pkg.newVersion}`);
 }
 
 export async function tag(cwd: string, config: Config) {

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { applyReleasePlan } from "@changesets/apply-release-plan";
 import { assembleReleasePlan } from "@changesets/assemble-release-plan";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
@@ -33,7 +33,7 @@ export async function version(
       log.error(
         `
 Snapshot release is not allowed in pre mode.
-To resolve this exit the pre mode by running ${color.cyan("changeset pre exit")}.
+To resolve this exit the pre mode by running ${c.cyan("changeset pre exit")}.
         `.trim(),
       );
       throw new ExitError(1);
@@ -41,8 +41,8 @@ To resolve this exit the pre mode by running ${color.cyan("changeset pre exit")}
       importantWarning(
         `
 You are in prerelease mode!
-If you meant to do a normal release you should revert these changes and run ${color.cyan("changeset pre exit")}.
-You can then run ${color.cyan("changeset version")} again to do a normal release.
+If you meant to do a normal release you should revert these changes and run ${c.cyan("changeset pre exit")}.
+You can then run ${c.cyan("changeset version")} again to do a normal release.
         `,
       );
     }

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { applyReleasePlan } from "@changesets/apply-release-plan";
 import { assembleReleasePlan } from "@changesets/assemble-release-plan";
+import color from "@changesets/color";
 import { ExitError } from "@changesets/errors";
 import * as git from "@changesets/git";
 import { readPreState } from "@changesets/pre";
@@ -9,7 +10,6 @@ import { readChangesets } from "@changesets/read";
 import type { Config } from "@changesets/types";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
-import pc from "picocolors";
 import { getCommitFunctions } from "../../commit/getCommitFunctions.ts";
 import { importantWarning } from "../../utils/cli-utilities.ts";
 
@@ -33,7 +33,7 @@ export async function version(
       log.error(
         `
 Snapshot release is not allowed in pre mode.
-To resolve this exit the pre mode by running ${pc.cyan("changeset pre exit")}.
+To resolve this exit the pre mode by running ${color.cyan("changeset pre exit")}.
         `.trim(),
       );
       throw new ExitError(1);
@@ -41,8 +41,8 @@ To resolve this exit the pre mode by running ${pc.cyan("changeset pre exit")}.
       importantWarning(
         `
 You are in prerelease mode!
-If you meant to do a normal release you should revert these changes and run ${pc.cyan("changeset pre exit")}.
-You can then run ${pc.cyan("changeset version")} again to do a normal release.
+If you meant to do a normal release you should revert these changes and run ${color.cyan("changeset pre exit")}.
+You can then run ${color.cyan("changeset version")} again to do a normal release.
         `,
       );
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import { format } from "node:util";
 // this requires that the package is built _after_ bumping versions before publishing
 import manifest from "@changesets/cli/package.json" with { type: "json" };
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { ExitError, InternalError } from "@changesets/errors";
 import { intro, log, outro } from "@clack/prompts";
 import mri from "mri";
@@ -108,11 +108,11 @@ ${format(err).replace(process.cwd().replace(/\\/g, "/"), "<cwd>")}
   }
 
   if (err instanceof ExitError) {
-    outro(color.red(`🦋 Exited with code ${err.code}`));
+    outro(c.red(`🦋 Exited with code ${err.code}`));
     return process.exit(err.code);
   }
 
   log.error(err.stack);
-  outro(color.red("🦋 Exited with code 1"));
+  outro(c.red("🦋 Exited with code 1"));
   process.exit(1);
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,10 @@
 import { format } from "node:util";
 // this requires that the package is built _after_ bumping versions before publishing
 import manifest from "@changesets/cli/package.json" with { type: "json" };
+import color from "@changesets/color";
 import { ExitError, InternalError } from "@changesets/errors";
 import { intro, log, outro } from "@clack/prompts";
 import mri from "mri";
-import pc from "picocolors";
 import { COMMAND_HELP } from "./help.ts";
 import { run } from "./run.ts";
 
@@ -108,11 +108,11 @@ ${format(err).replace(process.cwd().replace(/\\/g, "/"), "<cwd>")}
   }
 
   if (err instanceof ExitError) {
-    outro(pc.red(`🦋 Exited with code ${err.code}`));
+    outro(color.red(`🦋 Exited with code ${err.code}`));
     return process.exit(err.code);
   }
 
   log.error(err.stack);
-  outro(pc.red("🦋 Exited with code 1"));
+  outro(color.red("🦋 Exited with code 1"));
   process.exit(1);
 });

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import { read } from "@changesets/config";
 import { ExitError } from "@changesets/errors";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
@@ -26,7 +26,7 @@ function validateCommandFlags(
   if (unknownFlags.length > 0) {
     log.error(
       `
-Unknown flag${unknownFlags.length > 1 ? "s" : ""} for ${color.cyan(command)}: ${unknownFlags.map((flag) => `--${flag}`).join(", ")}
+Unknown flag${unknownFlags.length > 1 ? "s" : ""} for ${c.cyan(command)}: ${unknownFlags.map((flag) => `--${flag}`).join(", ")}
 Usage: changeset ${COMMAND_HELP[command]}
       `.trim(),
     );
@@ -53,7 +53,7 @@ export async function run(
     log.error(
       `
 There is no .changeset folder.
-If this is the first time ${color.green("Changesets")} have been used in this project, run ${color.cyan("changeset init")} to get set up.
+If this is the first time ${c.green("Changesets")} have been used in this project, run ${c.cyan("changeset init")} to get set up.
 If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration.
       `.trim(),
     );
@@ -108,7 +108,7 @@ If you expected there to be changesets, you should check git history for when th
         for (const pkgName of ignoreArrayFromCmd || []) {
           if (!pkgNames.has(pkgName)) {
             messages.push(
-              `The package ${color.blue(pkgName)} is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`,
+              `The package ${c.blue(pkgName)} is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`,
             );
           }
         }
@@ -163,7 +163,7 @@ If you expected there to be changesets, you should check git history for when th
               })
             ) {
               messages.push(
-                `The package ${color.blue(dependent)} depends on the skipped package ${color.blue(skippedPackage)} (either by \`ignore\` option or by \`privatePackages.version\`), but ${color.blue(dependent)} is not being skipped. Please pass ${color.blue(dependent)} to the ${color.cyan("--ignore")} flag.`,
+                `The package ${c.blue(dependent)} depends on the skipped package ${c.blue(skippedPackage)} (either by \`ignore\` option or by \`privatePackages.version\`), but ${c.blue(dependent)} is not being skipped. Please pass ${c.blue(dependent)} to the ${c.cyan("--ignore")} flag.`,
               );
             }
           }
@@ -204,7 +204,7 @@ If you expected there to be changesets, you should check git history for when th
         const command = input[1];
         if (command !== "enter" && command !== "exit") {
           log.error(
-            `${color.cyan("enter")}, ${color.cyan("exit")} or ${color.cyan("snapshot")} must be passed after prerelease`,
+            `${c.cyan("enter")}, ${c.cyan("exit")} or ${c.cyan("snapshot")} must be passed after prerelease`,
           );
           throw new ExitError(1);
         }
@@ -219,8 +219,8 @@ If you expected there to be changesets, you should check git history for when th
       case "bump": {
         log.error(
           `
-In version 2 of changesets, ${color.red("bump")} has been renamed to ${color.cyan("version")} - see our changelog for an explanation
-To fix this, use ${color.cyan("changeset version")} instead, and update any scripts that use changesets
+In version 2 of changesets, ${c.red("bump")} has been renamed to ${c.cyan("version")} - see our changelog for an explanation
+To fix this, use ${c.cyan("changeset version")} instead, and update any scripts that use changesets
           `.trim(),
         );
         throw new ExitError(1);
@@ -228,14 +228,14 @@ To fix this, use ${color.cyan("changeset version")} instead, and update any scri
       case "release": {
         log.error(
           `
-In version 2 of changesets, ${color.red("release")} has been renamed to ${color.cyan("publish")} - see our changelog for an explanation
-To fix this, use ${color.cyan("changeset publish")} instead, and update any scripts that use changesets
+In version 2 of changesets, ${c.red("release")} has been renamed to ${c.cyan("publish")} - see our changelog for an explanation
+To fix this, use ${c.cyan("changeset publish")} instead, and update any scripts that use changesets
           `.trim(),
         );
         throw new ExitError(1);
       }
       default: {
-        log.error(`Unknown command: ${color.red(input[0])}`);
+        log.error(`Unknown command: ${c.red(input[0])}`);
         throw new ExitError(1);
       }
     }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import color from "@changesets/color";
 import { read } from "@changesets/config";
 import { ExitError } from "@changesets/errors";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
 import { shouldSkipPackage } from "@changesets/should-skip-package";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
-import pc from "picocolors";
 import { add } from "./commands/add/index.ts";
 import { init } from "./commands/init/index.ts";
 import { pre } from "./commands/pre/index.ts";
@@ -26,7 +26,7 @@ function validateCommandFlags(
   if (unknownFlags.length > 0) {
     log.error(
       `
-Unknown flag${unknownFlags.length > 1 ? "s" : ""} for ${pc.cyan(command)}: ${unknownFlags.map((flag) => `--${flag}`).join(", ")}
+Unknown flag${unknownFlags.length > 1 ? "s" : ""} for ${color.cyan(command)}: ${unknownFlags.map((flag) => `--${flag}`).join(", ")}
 Usage: changeset ${COMMAND_HELP[command]}
       `.trim(),
     );
@@ -53,7 +53,7 @@ export async function run(
     log.error(
       `
 There is no .changeset folder.
-If this is the first time ${pc.green("Changesets")} have been used in this project, run ${pc.cyan("changeset init")} to get set up.
+If this is the first time ${color.green("Changesets")} have been used in this project, run ${color.cyan("changeset init")} to get set up.
 If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration.
       `.trim(),
     );
@@ -108,7 +108,7 @@ If you expected there to be changesets, you should check git history for when th
         for (const pkgName of ignoreArrayFromCmd || []) {
           if (!pkgNames.has(pkgName)) {
             messages.push(
-              `The package ${pc.blue(pkgName)} is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`,
+              `The package ${color.blue(pkgName)} is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`,
             );
           }
         }
@@ -163,7 +163,7 @@ If you expected there to be changesets, you should check git history for when th
               })
             ) {
               messages.push(
-                `The package ${pc.blue(dependent)} depends on the skipped package ${pc.blue(skippedPackage)} (either by \`ignore\` option or by \`privatePackages.version\`), but ${pc.blue(dependent)} is not being skipped. Please pass ${pc.blue(dependent)} to the ${pc.cyan("--ignore")} flag.`,
+                `The package ${color.blue(dependent)} depends on the skipped package ${color.blue(skippedPackage)} (either by \`ignore\` option or by \`privatePackages.version\`), but ${color.blue(dependent)} is not being skipped. Please pass ${color.blue(dependent)} to the ${color.cyan("--ignore")} flag.`,
               );
             }
           }
@@ -204,7 +204,7 @@ If you expected there to be changesets, you should check git history for when th
         const command = input[1];
         if (command !== "enter" && command !== "exit") {
           log.error(
-            `${pc.cyan("enter")}, ${pc.cyan("exit")} or ${pc.cyan("snapshot")} must be passed after prerelease`,
+            `${color.cyan("enter")}, ${color.cyan("exit")} or ${color.cyan("snapshot")} must be passed after prerelease`,
           );
           throw new ExitError(1);
         }
@@ -219,8 +219,8 @@ If you expected there to be changesets, you should check git history for when th
       case "bump": {
         log.error(
           `
-In version 2 of changesets, ${pc.red("bump")} has been renamed to ${pc.cyan("version")} - see our changelog for an explanation
-To fix this, use ${pc.cyan("changeset version")} instead, and update any scripts that use changesets
+In version 2 of changesets, ${color.red("bump")} has been renamed to ${color.cyan("version")} - see our changelog for an explanation
+To fix this, use ${color.cyan("changeset version")} instead, and update any scripts that use changesets
           `.trim(),
         );
         throw new ExitError(1);
@@ -228,14 +228,14 @@ To fix this, use ${pc.cyan("changeset version")} instead, and update any scripts
       case "release": {
         log.error(
           `
-In version 2 of changesets, ${pc.red("release")} has been renamed to ${pc.cyan("publish")} - see our changelog for an explanation
-To fix this, use ${pc.cyan("changeset publish")} instead, and update any scripts that use changesets
+In version 2 of changesets, ${color.red("release")} has been renamed to ${color.cyan("publish")} - see our changelog for an explanation
+To fix this, use ${color.cyan("changeset publish")} instead, and update any scripts that use changesets
           `.trim(),
         );
         throw new ExitError(1);
       }
       default: {
-        log.error(`Unknown command: ${pc.red(input[0])}`);
+        log.error(`Unknown command: ${color.red(input[0])}`);
         throw new ExitError(1);
       }
     }

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -1,4 +1,4 @@
-import color from "@changesets/color";
+import c from "@changesets/color";
 import {
   cancel,
   confirm,
@@ -21,7 +21,7 @@ async function cancelable<T>(task: () => Promise<T | symbol>) {
 }
 
 function importantWarning(message: string): void {
-  note(message.trim(), color.yellow("IMPORTANT"), { format: color.white });
+  note(message.trim(), c.yellow("IMPORTANT"), { format: c.white });
 }
 
 export type MultiselectOptions<Value> = Record<string, Option<Value>[]>;

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -1,3 +1,4 @@
+import color from "@changesets/color";
 import {
   cancel,
   confirm,
@@ -9,7 +10,6 @@ import {
   select,
   text,
 } from "@clack/prompts";
-import pc from "picocolors";
 
 async function cancelable<T>(task: () => Promise<T | symbol>) {
   const result = await task();
@@ -21,7 +21,7 @@ async function cancelable<T>(task: () => Promise<T | symbol>) {
 }
 
 function importantWarning(message: string): void {
-  note(message.trim(), pc.yellow("IMPORTANT"), { format: pc.white });
+  note(message.trim(), color.yellow("IMPORTANT"), { format: color.white });
 }
 
 export type MultiselectOptions<Value> = Record<string, Option<Value>[]>;

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@changesets/color",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": "^22.11 || ^24 || >=26"
+  }
+}

--- a/packages/color/src/index.ts
+++ b/packages/color/src/index.ts
@@ -8,7 +8,7 @@ type ColorProxy = Record<Color, (text: string) => string>;
 
 export default new Proxy({} as ColorProxy, {
   get(target, color: Color) {
-    target[color] ??= (text) => styleText(color, text)
+    target[color] ??= (text) => styleText(color, text);
     return target[color];
   },
 });

--- a/packages/color/src/index.ts
+++ b/packages/color/src/index.ts
@@ -1,0 +1,13 @@
+// supported and working as expected in Node 22.08+
+// https://nodejs.org/docs/latest-v22.x/api/util.html#utilstyletextformat-text-options
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+import { styleText } from "node:util";
+
+type Color = Exclude<Parameters<typeof styleText>[0], Array<unknown>>;
+type ColorProxy = Record<Color, (text: string) => string>;
+
+export default new Proxy({} as ColorProxy, {
+  get(_, color: Color) {
+    return (text: string) => styleText(color, text);
+  },
+});

--- a/packages/color/src/index.ts
+++ b/packages/color/src/index.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { styleText } from "node:util";
 
-type Color = Exclude<Parameters<typeof styleText>[0], Array<unknown>>;
+type Color = Extract<Parameters<typeof styleText>[0], string>;
 type ColorProxy = Record<Color, (text: string) => string>;
 
 export default new Proxy({} as ColorProxy, {

--- a/packages/color/src/index.ts
+++ b/packages/color/src/index.ts
@@ -7,7 +7,8 @@ type Color = Exclude<Parameters<typeof styleText>[0], Array<unknown>>;
 type ColorProxy = Record<Color, (text: string) => string>;
 
 export default new Proxy({} as ColorProxy, {
-  get(_, color: Color) {
-    return (text: string) => styleText(color, text);
+  get(target, color: Color) {
+    target[color] ??= (text) => styleText(color, text)
+    return target[color];
   },
 });

--- a/packages/get-dependents-graph/package.json
+++ b/packages/get-dependents-graph/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@changesets/types": "workspace:^",
-    "picocolors": "^1.1.0",
     "semver": "^7.5.3"
   },
   "devDependencies": {
+    "@changesets/color": "workspace:^",
     "@changesets/test-utils": "workspace:*",
     "vitest": "^4.1.5"
   },

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import color from "@changesets/color";
+import c from "@changesets/color";
 import type { Package, Packages, PackageJSON } from "@changesets/types";
 import Range from "semver/classes/range.js";
 
@@ -123,7 +123,7 @@ export function getDependencyGraph(
           valid = false;
           // TODO: replace with returning errors/warnings
           console.error(
-            `Package ${color.blue(name)} must depend on the current version of ${color.blue(depName)}: ${color.green(expected)} vs ${color.red(rawDepRange)}`,
+            `Package ${c.blue(name)} must depend on the current version of ${c.blue(depName)}: ${c.green(expected)} vs ${c.red(rawDepRange)}`,
           );
           continue;
         }
@@ -137,7 +137,7 @@ export function getDependencyGraph(
         valid = false;
         // TODO: replace with returning errors/warnings
         console.error(
-          `Package ${color.blue(name)} must depend on the current version of ${color.blue(depName)}: ${color.green(expected)} vs ${color.red(rawDepRange)}`,
+          `Package ${c.blue(name)} must depend on the current version of ${c.blue(depName)}: ${c.green(expected)} vs ${c.red(rawDepRange)}`,
         );
         continue;
       }

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
+import color from "@changesets/color";
 import type { Package, Packages, PackageJSON } from "@changesets/types";
-import pc from "picocolors";
 import Range from "semver/classes/range.js";
 
 const DEPENDENCY_TYPES = [
@@ -123,7 +123,7 @@ export function getDependencyGraph(
           valid = false;
           // TODO: replace with returning errors/warnings
           console.error(
-            `Package ${pc.blue(name)} must depend on the current version of ${pc.blue(depName)}: ${pc.green(expected)} vs ${pc.red(rawDepRange)}`,
+            `Package ${color.blue(name)} must depend on the current version of ${color.blue(depName)}: ${color.green(expected)} vs ${color.red(rawDepRange)}`,
           );
           continue;
         }
@@ -137,7 +137,7 @@ export function getDependencyGraph(
         valid = false;
         // TODO: replace with returning errors/warnings
         console.error(
-          `Package ${pc.blue(name)} must depend on the current version of ${pc.blue(depName)}: ${pc.green(expected)} vs ${pc.red(rawDepRange)}`,
+          `Package ${color.blue(name)} must depend on the current version of ${color.blue(depName)}: ${color.green(expected)} vs ${color.red(rawDepRange)}`,
         );
         continue;
       }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,10 +13,8 @@
     "url": "git+https://github.com/changesets/changesets.git",
     "directory": "packages/logger"
   },
-  "dependencies": {
-    "picocolors": "^1.1.0"
-  },
   "devDependencies": {
+    "@changesets/color": "workspace:^",
     "vitest": "^4.1.5"
   },
   "engines": {

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,5 @@
 import util from "node:util";
-import pc from "picocolors";
+import color from "@changesets/color";
 
 export const prefix: string = "🦋 ";
 
@@ -15,11 +15,11 @@ function format(args: Array<any>, customPrefix?: string) {
 }
 
 export function error(...args: Array<any>) {
-  console.error(format(args, pc.red("error")));
+  console.error(format(args, color.red("error")));
 }
 
 export function info(...args: Array<any>) {
-  console.info(format(args, pc.cyan("info")));
+  console.info(format(args, color.cyan("info")));
 }
 
 export function log(...args: Array<any>) {
@@ -27,9 +27,9 @@ export function log(...args: Array<any>) {
 }
 
 export function success(...args: Array<any>) {
-  console.log(format(args, pc.green("success")));
+  console.log(format(args, color.green("success")));
 }
 
 export function warn(...args: Array<any>) {
-  console.warn(format(args, pc.yellow("warn")));
+  console.warn(format(args, color.yellow("warn")));
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,5 @@
 import util from "node:util";
-import color from "@changesets/color";
+import c from "@changesets/color";
 
 export const prefix: string = "🦋 ";
 
@@ -15,11 +15,11 @@ function format(args: Array<any>, customPrefix?: string) {
 }
 
 export function error(...args: Array<any>) {
-  console.error(format(args, color.red("error")));
+  console.error(format(args, c.red("error")));
 }
 
 export function info(...args: Array<any>) {
-  console.info(format(args, color.cyan("info")));
+  console.info(format(args, c.cyan("info")));
 }
 
 export function log(...args: Array<any>) {
@@ -27,9 +27,9 @@ export function log(...args: Array<any>) {
 }
 
 export function success(...args: Array<any>) {
-  console.log(format(args, color.green("success")));
+  console.log(format(args, c.green("success")));
 }
 
 export function warn(...args: Array<any>) {
-  console.warn(format(args, color.yellow("warn")));
+  console.warn(format(args, c.yellow("warn")));
 }

--- a/packages/read/package.json
+++ b/packages/read/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@changesets/git": "workspace:^",
     "@changesets/parse": "workspace:^",
-    "@changesets/types": "workspace:^",
-    "picocolors": "^1.1.0"
+    "@changesets/types": "workspace:^"
   },
   "devDependencies": {
     "@changesets/test-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,6 @@ importers:
       package-manager-detector:
         specifier: ^1.1.0
         version: 1.6.0
-      picocolors:
-        specifier: ^1.1.0
-        version: 1.1.1
       semver:
         specifier: ^7.5.3
         version: 7.7.4
@@ -226,6 +223,9 @@ importers:
       '@changesets/changelog-github':
         specifier: workspace:*
         version: link:../changelog-github
+      '@changesets/color':
+        specifier: workspace:^
+        version: link:../color
       '@changesets/parse':
         specifier: workspace:*
         version: link:../parse
@@ -244,6 +244,8 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10)
+
+  packages/color: {}
 
   packages/config:
     dependencies:
@@ -286,13 +288,13 @@ importers:
       '@changesets/types':
         specifier: workspace:^
         version: link:../types
-      picocolors:
-        specifier: ^1.1.0
-        version: 1.1.1
       semver:
         specifier: ^7.5.3
         version: 7.7.4
     devDependencies:
+      '@changesets/color':
+        specifier: workspace:^
+        version: link:../color
       '@changesets/test-utils':
         specifier: workspace:*
         version: link:../../scripts/test-utils
@@ -365,11 +367,10 @@ importers:
         version: 4.0.3
 
   packages/logger:
-    dependencies:
-      picocolors:
-        specifier: ^1.1.0
-        version: 1.1.1
     devDependencies:
+      '@changesets/color':
+        specifier: workspace:^
+        version: link:../color
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10)
@@ -417,9 +418,6 @@ importers:
       '@changesets/types':
         specifier: workspace:^
         version: link:../types
-      picocolors:
-        specifier: ^1.1.0
-        version: 1.1.1
     devDependencies:
       '@changesets/test-utils':
         specifier: workspace:*


### PR DESCRIPTION
Closes #1949 

I added a new `@changesets/color` internal package which is a small proxy based wrapper over styleText [as suggested by bq](https://github.com/changesets/changesets/issues/1949#issuecomment-4368932727) - it's a dev dependency so it can be bundled as it's small and otherwise would almost defeat the point.