### PR TITLE
Remove `@changesets/get-version-range-type` dependency

### DIFF
--- a/.changeset/silly-bushes-hang.md
+++ b/.changeset/silly-bushes-hang.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+Remove `@changesets/get-version-range-type` dependency

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@changesets/config": "workspace:^",
     "@changesets/format": "^0.1.0",
-    "@changesets/get-version-range-type": "workspace:^",
     "@changesets/git": "workspace:^",
     "@changesets/should-skip-package": "workspace:^",
     "@changesets/types": "workspace:^",

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -1,4 +1,3 @@
-import { getVersionRangeType } from "@changesets/get-version-range-type";
 import type {
   ComprehensiveRelease,
   PackageJSON,
@@ -117,4 +116,15 @@ export function versionPackage(
   }
 
   return { ...release, packageJson };
+}
+
+function getVersionRangeType(
+  versionRange: string,
+): "^" | "~" | ">=" | "<=" | ">" | "" {
+  if (versionRange.charAt(0) === "^") return "^";
+  if (versionRange.charAt(0) === "~") return "~";
+  if (versionRange.startsWith(">=")) return ">=";
+  if (versionRange.startsWith("<=")) return "<=";
+  if (versionRange.charAt(0) === ">") return ">";
+  return "";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@changesets/format':
         specifier: ^0.1.0
         version: 0.1.0
-      '@changesets/get-version-range-type':
-        specifier: workspace:^
-        version: link:../get-version-range-type
       '@changesets/git':
         specifier: workspace:^
         version: link:../git


### PR DESCRIPTION
I feel like this function is too simple to be in its own package. And it's only used once.

We can phase out / delete the package later.