### PR TITLE
Refactor consistent pattern for `@changesets/changelog-git` and `@changesets/cli/commit`

### DIFF
--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -1,54 +1,38 @@
-import type {
-  NewChangesetWithCommit,
-  VersionType,
-  ChangelogFunctions,
-  ModCompWithPackage,
-} from "@changesets/types";
+import type { ChangelogFunctions } from "@changesets/types";
 
-const getReleaseLine = (
-  changeset: NewChangesetWithCommit,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _type: VersionType,
-): string => {
-  const [firstLine, ...futureLines] = changeset.summary
-    .split("\n")
-    .map((l) => l.trimEnd());
+const changelogFunctions: ChangelogFunctions = {
+  getReleaseLine: (changeset) => {
+    const [firstLine, ...futureLines] = changeset.summary
+      .split("\n")
+      .map((l) => l.trimEnd());
 
-  let returnVal = `- ${
-    changeset.commit ? `${changeset.commit.slice(0, 7)}: ` : ""
-  }${firstLine}`;
+    let returnVal = `- ${
+      changeset.commit ? `${changeset.commit.slice(0, 7)}: ` : ""
+    }${firstLine}`;
 
-  if (futureLines.length > 0) {
-    returnVal += `\n${futureLines.map((l) => `  ${l}`).join("\n")}`;
-  }
+    if (futureLines.length > 0) {
+      returnVal += `\n${futureLines.map((l) => `  ${l}`).join("\n")}`;
+    }
 
-  return returnVal;
-};
+    return returnVal;
+  },
+  getDependencyReleaseLine: (changesets, dependenciesUpdated) => {
+    if (dependenciesUpdated.length === 0) return "";
 
-const getDependencyReleaseLine = (
-  changesets: NewChangesetWithCommit[],
-  dependenciesUpdated: ModCompWithPackage[],
-): string => {
-  if (dependenciesUpdated.length === 0) return "";
+    const changesetLinks = changesets.map(
+      (changeset) =>
+        `- Updated dependencies${
+          changeset.commit ? ` [${changeset.commit.slice(0, 7)}]` : ""
+        }`,
+    );
 
-  const changesetLinks = changesets.map(
-    (changeset) =>
-      `- Updated dependencies${
-        changeset.commit ? ` [${changeset.commit.slice(0, 7)}]` : ""
-      }`,
-  );
+    const updatedDependenciesList = dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+    );
 
-  const updatedDependenciesList = dependenciesUpdated.map(
-    (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
-  );
-
-  return [...changesetLinks, ...updatedDependenciesList].join("\n");
-};
-
-const defaultChangelogFunctions: Required<ChangelogFunctions> = {
-  getReleaseLine,
-  getDependencyReleaseLine,
+    return [...changesetLinks, ...updatedDependenciesList].join("\n");
+  },
 };
 
 // ChangelogFunctions require a default export
-export default defaultChangelogFunctions;
+export default changelogFunctions;

--- a/packages/cli/src/commit/index.ts
+++ b/packages/cli/src/commit/index.ts
@@ -1,45 +1,31 @@
-import type {
-  Changeset,
-  CommitFunctions,
-  ReleasePlan,
-} from "@changesets/types";
+import type { CommitFunctions } from "@changesets/types";
 
 type SkipCI = boolean | "add" | "version";
 
-const getAddMessage: CommitFunctions["getAddMessage"] = (
-  changeset: Changeset,
-  options: { skipCI?: SkipCI } | null,
-): string => {
-  const skipCI = options?.skipCI === "add" || options?.skipCI === true;
-  const skipMsg = skipCI ? `\n\n[skip ci]\n` : "";
-  return `docs(changeset): ${changeset.summary}${skipMsg}`;
-};
+const commitFunctions: CommitFunctions = {
+  getAddMessage: (changeset, options: { skipCI?: SkipCI } | null) => {
+    const skipCI = options?.skipCI === "add" || options?.skipCI === true;
+    const skipMsg = skipCI ? `\n\n[skip ci]\n` : "";
+    return `docs(changeset): ${changeset.summary}${skipMsg}`;
+  },
+  getVersionMessage: (releasePlan, options: { skipCI?: SkipCI } | null) => {
+    const skipCI = options?.skipCI === "version" || options?.skipCI === true;
+    const publishableReleases = releasePlan.releases.filter(
+      (release) => release.type !== "none",
+    );
+    const numPackagesReleased = publishableReleases.length;
 
-const getVersionMessage: CommitFunctions["getVersionMessage"] = (
-  releasePlan: ReleasePlan,
-  options: { skipCI?: SkipCI } | null,
-): string => {
-  const skipCI = options?.skipCI === "version" || options?.skipCI === true;
-  const publishableReleases = releasePlan.releases.filter(
-    (release) => release.type !== "none",
-  );
-  const numPackagesReleased = publishableReleases.length;
+    const releasesLines = publishableReleases
+      .map((release) => `  ${release.name}@${release.newVersion}`)
+      .join("\n");
 
-  const releasesLines = publishableReleases
-    .map((release) => `  ${release.name}@${release.newVersion}`)
-    .join("\n");
-
-  return `RELEASING: Releasing ${numPackagesReleased} package(s)
+    return `RELEASING: Releasing ${numPackagesReleased} package(s)
 
 Releases:
 ${releasesLines}
 ${skipCI ? `\n[skip ci]\n` : ""}`;
-};
-
-const defaultCommitFunctions: Required<CommitFunctions> = {
-  getAddMessage,
-  getVersionMessage,
+  },
 };
 
 // CommitFunctions require a default export
-export default defaultCommitFunctions;
+export default commitFunctions;

--- a/packages/cli/src/commit/index.ts
+++ b/packages/cli/src/commit/index.ts
@@ -2,7 +2,7 @@ import type { CommitFunctions } from "@changesets/types";
 
 type SkipCI = boolean | "add" | "version";
 
-const commitFunctions: CommitFunctions = {
+const commitFunctions: Required<CommitFunctions> = {
   getAddMessage: (changeset, options: { skipCI?: SkipCI } | null) => {
     const skipCI = options?.skipCI === "add" || options?.skipCI === true;
     const skipMsg = skipCI ? `\n\n[skip ci]\n` : "";


### PR DESCRIPTION


So similar to https://github.com/changesets/changesets/blob/c60ca1632a08eaa2b8ed3af074f05bc3dc14cca8/packages/changelog-github/src/index.ts#L45

It's easier to review with whitespace diff disabled