### PR TITLE
Call CI workflow before publish attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
   lint-workflows:
     name: Lint workflows
     runs-on: ubuntu-latest
-    permissions:
-      actions: read # only required in private repos
-      security-events: write # allow writing security events
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,7 +97,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: matrix.node_version == 24
+        if: matrix.node_version == 24 && github.event_name != 'workflow_call'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
   # merge queue is required so all commits on target branches trigger this workflow
   # despite lack of the push event trigger here

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,14 @@ jobs:
         with:
           version: pnpm version-packages
 
-  publish:
-    name: Publish
+  ci:
     if: needs.version.outputs.hasChangesets == 'false'
     needs: version
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    name: Publish
+    needs: ci
     runs-on: ubuntu-latest
     environment: npm
     timeout-minutes: 20

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
   ci:
     if: needs.version.outputs.hasChangesets == 'false'
     needs: version
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
 
   publish:


### PR DESCRIPTION
It always bothered me a little bit that the CI and publish workflows were disassociated from each other. This is mostly redundant now because only green PRs should end up on main/next and we have merge queues and all to verify that... but it's still kinda implicit.

Given the publish only happens from time to time, I think it would make sense to introduce this one extra re-verification step into the mix.