### PR TITLE
Validate snapshot prerelease versions

### DIFF
--- a/.changeset/snapshot-tag-validation.md
+++ b/.changeset/snapshot-tag-validation.md
@@ -1,0 +1,5 @@
+---
+"@changesets/assemble-release-plan": patch
+---
+
+Fail snapshot versioning early when a snapshot tag or prerelease template creates an invalid semver prerelease.

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -61,6 +61,22 @@ describe("assemble-release-plan", () => {
     expect(/0\.0\.0-foo-\d{14}/.test(releases[0].newVersion)).toBeTruthy();
   });
 
+  it("should throw when a snapshot tag creates an invalid prerelease version", () => {
+    expect(() =>
+      assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        defaultConfig,
+        undefined,
+        {
+          tag: "foo_bar",
+        }
+      )
+    ).toThrow(
+      /Failed to compose snapshot version: "foo_bar-\d{14}" is not a valid semver prerelease/
+    );
+  });
+
   it("should assemble release plan with multiple packages", () => {
     setup.addChangeset({
       id: "big-cats-delight",

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -61,7 +61,7 @@ describe("assemble-release-plan", () => {
     expect(/0\.0\.0-foo-\d{14}/.test(releases[0].newVersion)).toBeTruthy();
   });
 
-  it("should throw when a snapshot tag creates an invalid prerelease version", () => {
+  it("should throw when a snapshot tag is not a valid prerelease identifier", () => {
     expect(() =>
       assembleReleasePlan(
         setup.changesets,
@@ -73,7 +73,29 @@ describe("assemble-release-plan", () => {
         }
       )
     ).toThrow(
-      /Failed to compose snapshot version: "foo_bar-\d{14}" is not a valid semver prerelease/
+      /Failed to compose snapshot version: snapshot tag "foo_bar" is not a valid semver prerelease/
+    );
+  });
+
+  it("should throw when a snapshot prerelease template creates an invalid prerelease version", () => {
+    expect(() =>
+      assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          snapshot: {
+            ...defaultConfig.snapshot,
+            prereleaseTemplate: "foo_{datetime}",
+          },
+        },
+        undefined,
+        {
+          tag: undefined,
+        }
+      )
+    ).toThrow(
+      /Failed to compose snapshot version: snapshot\.prereleaseTemplate produced "foo_\d{14}", which is not a valid semver prerelease/
     );
   });
 

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -51,12 +51,25 @@ function getSnapshotSuffix(
       .replace(/[^\d]/g, ""),
   };
 
+  if (
+    placeholderValues.tag !== undefined &&
+    !isValidPrereleasePart(placeholderValues.tag)
+  ) {
+    throw new Error(
+      `Failed to compose snapshot version: snapshot tag "${placeholderValues.tag}" is not a valid semver prerelease.`
+    );
+  }
+
   // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
   // and the resulting version needs to be composed without a tag.
   if (!template) {
-    return [placeholderValues.tag, placeholderValues.datetime]
+    const snapshotSuffix = [placeholderValues.tag, placeholderValues.datetime]
       .filter(Boolean)
       .join("-");
+
+    validateSnapshotSuffixFromTemplate(snapshotSuffix);
+
+    return snapshotSuffix;
   }
 
   const placeholders = Object.keys(placeholderValues) as Array<
@@ -69,7 +82,7 @@ function getSnapshotSuffix(
     );
   }
 
-  return placeholders.reduce((prev, key) => {
+  const snapshotSuffix = placeholders.reduce((prev, key) => {
     return prev.replace(new RegExp(`\\{${key}\\}`, "g"), () => {
       const value = placeholderValues[key];
       if (value === undefined) {
@@ -81,12 +94,20 @@ function getSnapshotSuffix(
       return value;
     });
   }, template);
+
+  validateSnapshotSuffixFromTemplate(snapshotSuffix);
+
+  return snapshotSuffix;
 }
 
-function validateSnapshotSuffix(snapshotSuffix: string): void {
-  if (!semverValid(`0.0.0-${snapshotSuffix}`)) {
+function isValidPrereleasePart(value: string): boolean {
+  return semverValid(`0.0.0-${value}`) !== null;
+}
+
+function validateSnapshotSuffixFromTemplate(snapshotSuffix: string): void {
+  if (!isValidPrereleasePart(snapshotSuffix)) {
     throw new Error(
-      `Failed to compose snapshot version: "${snapshotSuffix}" is not a valid semver prerelease. Check the --snapshot tag and snapshot.prereleaseTemplate values.`
+      `Failed to compose snapshot version: snapshot.prereleaseTemplate produced "${snapshotSuffix}", which is not a valid semver prerelease.`
     );
   }
 }
@@ -259,9 +280,6 @@ function assembleReleasePlan(
       refinedConfig.snapshot.prereleaseTemplate,
       refinedSnapshot
     );
-  if (snapshotSuffix) {
-    validateSnapshotSuffix(snapshotSuffix);
-  }
 
   return {
     changesets: relevantChangesets,

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@changesets/types";
 import { Package, Packages } from "@manypkg/get-packages";
 import semverParse from "semver/functions/parse";
+import semverValid from "semver/functions/valid";
 import applyLinks from "./apply-links";
 import determineDependents from "./determine-dependents";
 import flattenReleases from "./flatten-releases";
@@ -80,6 +81,14 @@ function getSnapshotSuffix(
       return value;
     });
   }, template);
+}
+
+function validateSnapshotSuffix(snapshotSuffix: string): void {
+  if (!semverValid(`0.0.0-${snapshotSuffix}`)) {
+    throw new Error(
+      `Failed to compose snapshot version: "${snapshotSuffix}" is not a valid semver prerelease. Check the --snapshot tag and snapshot.prereleaseTemplate values.`
+    );
+  }
 }
 
 function getSnapshotVersion(
@@ -250,6 +259,9 @@ function assembleReleasePlan(
       refinedConfig.snapshot.prereleaseTemplate,
       refinedSnapshot
     );
+  if (snapshotSuffix) {
+    validateSnapshotSuffix(snapshotSuffix);
+  }
 
   return {
     changesets: relevantChangesets,

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { error } from "@changesets/logger";
 import { testdir } from "@changesets/test-utils";
 import add from "./commands/add";
+import version from "./commands/version";
 import { run } from "./run";
 import writeChangeset from "@changesets/write";
 
@@ -57,6 +58,33 @@ describe("cli", () => {
   });
 
   describe("version", () => {
+    it("should validate snapshot tags before running version", async () => {
+      (error as any).mockClear();
+      (version as any).mockClear();
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        ".changeset/config.json": JSON.stringify({}),
+      });
+
+      await expect(
+        run(["version"], { snapshot: "foo_bar" }, cwd)
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"The process exited with code: 1"`
+      );
+
+      expect(error).toHaveBeenCalledWith(
+        `The snapshot tag "foo_bar" passed to the \`--snapshot\` option is not a valid semver prerelease.`
+      );
+      expect(version).not.toHaveBeenCalled();
+    });
+
     it("should validate package name passed in from --ignore flag", async () => {
       const cwd = await testdir({
         "package.json": JSON.stringify({

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -7,6 +7,7 @@ import { Config } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
 import fs from "fs-extra";
 import path from "path";
+import semverValid from "semver/functions/valid";
 import add from "./commands/add";
 import init from "./commands/init";
 import pre from "./commands/pre";
@@ -32,6 +33,10 @@ function validateCommandFlags(
     error(`Usage: changeset ${COMMAND_HELP[command]}`);
     throw new ExitError(1);
   }
+}
+
+function isValidPrereleasePart(value: string): boolean {
+  return semverValid(`0.0.0-${value}`) !== null;
 }
 
 export async function run(
@@ -144,6 +149,12 @@ export async function run(
         );
 
         const messages = [];
+        if (typeof snapshot === "string" && !isValidPrereleasePart(snapshot)) {
+          messages.push(
+            `The snapshot tag "${snapshot}" passed to the \`--snapshot\` option is not a valid semver prerelease.`
+          );
+        }
+
         for (const pkgName of ignoreArrayFromCmd || []) {
           if (!pkgNames.has(pkgName)) {
             messages.push(

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,7 +31,8 @@
     "@changesets/types": "^6.1.0",
     "@manypkg/get-packages": "^1.1.3",
     "fs-extra": "^7.0.1",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@changesets/test-utils": "*",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -921,6 +921,22 @@ describe("parser errors", () => {
     `);
   });
 
+  test("snapshot.prereleaseTemplate invalid semver prerelease template", () => {
+    expect(() => {
+      unsafeParse(
+        {
+          snapshot: {
+            prereleaseTemplate: "foo_{datetime}",
+          },
+        },
+        defaultPackages
+      );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Some errors occurred when validating the changesets config:
+      The \`snapshot.prereleaseTemplate\` option is set as "foo_{datetime}" but it is not a valid semver prerelease template."
+    `);
+  });
+
   test("Experimental useCalculatedVersionForSnapshots non-boolean", () => {
     expect(() => {
       unsafeParse(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra";
 import path from "path";
 import micromatch from "micromatch";
+import semverValid from "semver/functions/valid";
 import { ValidationError } from "@changesets/errors";
 import { warn } from "@changesets/logger";
 import { Packages, getPackages } from "@manypkg/get-packages";
@@ -90,6 +91,31 @@ function isArray<T>(
     : readonly any[]
   : any[] {
   return Array.isArray(arg);
+}
+
+const snapshotPrereleaseTemplatePlaceholders = {
+  commit: "abcdef",
+  tag: "tag",
+  timestamp: "1639354050879",
+  datetime: "20211213000730",
+};
+
+function isValidSnapshotPrereleaseTemplate(template: string): boolean {
+  if (template === "") {
+    return true;
+  }
+
+  const placeholders = Object.keys(
+    snapshotPrereleaseTemplatePlaceholders
+  ) as Array<keyof typeof snapshotPrereleaseTemplatePlaceholders>;
+  const snapshotSuffix = placeholders.reduce((prev, key) => {
+    return prev.replace(
+      new RegExp(`\\{${key}\\}`, "g"),
+      snapshotPrereleaseTemplatePlaceholders[key]
+    );
+  }, template);
+
+  return semverValid(`0.0.0-${snapshotSuffix}`) !== null;
 }
 
 export let read = async (cwd: string, packages?: Packages) => {
@@ -459,6 +485,17 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           null,
           2
         )} when the only valid values are undefined, or a template string.`
+      );
+    } else if (
+      snapshot.prereleaseTemplate !== undefined &&
+      !isValidSnapshotPrereleaseTemplate(snapshot.prereleaseTemplate)
+    ) {
+      messages.push(
+        `The \`snapshot.prereleaseTemplate\` option is set as ${JSON.stringify(
+          snapshot.prereleaseTemplate,
+          null,
+          2
+        )} but it is not a valid semver prerelease template.`
       );
     }
   }


### PR DESCRIPTION
## Summary
- validate the composed snapshot prerelease before returning snapshot release versions
- fail early when `--snapshot` tags or snapshot prerelease templates create invalid semver, such as tags containing underscores
- add a regression test and release changeset for `@changesets/assemble-release-plan`

Fixes #419

## Testing
- `YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn jest packages/assemble-release-plan/src/index.test.ts --runInBand`
- `env -u NO_COLOR TERM=xterm-256color FORCE_COLOR=1 YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn jest --ci --color --runInBand`
- `YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn types:check`
- `YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn lint`
- `YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn format`
- `YARN_CACHE_FOLDER=/tmp/changesets-yarn-cache yarn build`
- `git diff --check`