### PR TITLE
Fix publish git tag to default true

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -103,7 +103,11 @@ const tests: CommandTest[] = [
     cases: [
       {
         args: [],
-        options: {},
+        options: { gitTag: true },
+      },
+      {
+        args: ["--no-git-tag"],
+        options: { gitTag: false },
       },
       {
         args: ["--otp", "123456", "--tag", "beta", "--git-tag"],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -97,7 +97,7 @@ cli
   .example("  $ changeset publish --tag beta")
   .option("--otp <code>", "One time password for npm publish")
   .option("--tag <name>", "Publish with the given npm dist-tag")
-  .option("--git-tag", "Create a git tag for the release")
+  .option("--git-tag", "Create a git tag for the release", { default: true })
   .action(async (options) => {
     normalizeOptions(options);
     const { publish } = await import("./commands/publish/index.ts");

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -38,6 +38,7 @@ export interface PublishOptions {
   cwd?: string;
   otp?: string;
   tag?: string;
+  /** @default true */
   gitTag?: boolean;
 }
 
@@ -114,7 +115,7 @@ ${formatPackageList(successfulNpmPublishes)}
     // We create the tags after the push above so that we know that HEAD won't change and that pushing
     // won't suffer from a race condition if another merge happens in the mean time (pushing tags won't
     // fail if we are behind the base branch).
-    if (options?.gitTag) {
+    if (options?.gitTag ?? true) {
       const p = spinner();
       p.start(
         `Creating git tag${successfulNpmPublishes.length > 1 ? "s" : ""}...`,


### PR DESCRIPTION
No changesets since the PR that caused the issue hasn't been released yet.

I've updated tests to cover the CLI parsing case, but didn't add any tests for directly calling the publish command.