### PR TITLE
Set typeMode in toJsonSchema

### DIFF
--- a/packages/config/scripts/generate-json-schema.ts
+++ b/packages/config/scripts/generate-json-schema.ts
@@ -14,6 +14,7 @@ export async function generateJsonSchema(write = true): Promise<string> {
 
   const schema = toJsonSchema(WrittenConfigSchema, {
     target: "draft-2020-12",
+    typeMode: "input",
     errorMode: "throw",
   });
   const schemaString = JSON.stringify(sortKeysInSchema(schema), null, 2);


### PR DESCRIPTION
Not that it changes anything now, but in case we refactor things in the future we don't have to debug that we forgot to set this config.