### PR TITLE
Use stricter types for `CommitFunctions` and `ChangelogFunctions`

### DIFF
--- a/.changeset/cozy-knives-brake.md
+++ b/.changeset/cozy-knives-brake.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": major
+---
+
+Update the `opts` parameter for `CommitFunctions` and `ChangelogFunctions` to be `null | Record<string, unknown>` (stricter types) instead of `Record<string, unknown>` or `any`

--- a/.changeset/cozy-knives-brake.md
+++ b/.changeset/cozy-knives-brake.md
@@ -2,4 +2,4 @@
 "@changesets/types": major
 ---
 
-Update the `opts` parameter for `CommitFunctions` and `ChangelogFunctions` to be `null | Record<string, unknown>` (stricter types) instead of `Record<string, unknown>` or `any`
+Use stricter types for the options parameter for `CommitFunctions`, `ChangelogFunctions`, `Config` & `WrittenConfig`'s `commit` and `changelog` properties, to `Record<string, unknown>` (and may be nullable) instead of `any` or `Record<string, any>`

--- a/.changeset/cozy-knives-brake.md
+++ b/.changeset/cozy-knives-brake.md
@@ -2,4 +2,4 @@
 "@changesets/types": major
 ---
 
-Use stricter types for the options parameter for `CommitFunctions`, `ChangelogFunctions`, `Config` & `WrittenConfig`'s `commit` and `changelog` properties, to `Record<string, unknown>` (and may be nullable) instead of `any` or `Record<string, any>`
+Use stricter types for the options parameter for `CommitFunctions`, `ChangelogFunctions`, `Config` & `WrittenConfig`'s `commit` and `changelog` properties, to `null | Record<string, unknown>` instead of `any` or `Record<string, any>`

--- a/.changeset/huge-flowers-fall.md
+++ b/.changeset/huge-flowers-fall.md
@@ -1,0 +1,5 @@
+---
+"@changesets/changelog-github": patch
+---
+
+Improve type-check for options object

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -30,7 +30,7 @@ export async function getChangelogEntry(
   releases: ModCompWithPackage[],
   changesets: NewChangesetWithCommit[],
   changelogFuncs: ChangelogFunctions,
-  changelogOpts: any,
+  changelogOpts: null | Record<string, unknown>,
   {
     updateInternalDependencies,
     onlyUpdatePeerDependentsWhenOutOfRange,

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -51,7 +51,8 @@ const changelogFunctions: ChangelogFunctions = {
     dependenciesUpdated,
     options,
   ) => {
-    if (!options.repo) {
+    const repo = options?.repo;
+    if (!repo || typeof repo !== "string") {
       throw new Error(
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
       );
@@ -63,7 +64,7 @@ const changelogFunctions: ChangelogFunctions = {
         changesets.map(async (cs) => {
           if (cs.commit) {
             const { links } = await getInfo({
-              repo: options.repo,
+              repo,
               commit: cs.commit,
             });
             return links.commit;
@@ -81,12 +82,14 @@ const changelogFunctions: ChangelogFunctions = {
     return [changesetLink, ...updatedDepenenciesList].join("\n");
   },
   getReleaseLine: async (changeset, type, options) => {
-    const { GITHUB_SERVER_URL } = await readEnv();
-    if (!options || !options.repo) {
+    const repo = options?.repo;
+    if (!repo || typeof repo !== "string") {
       throw new Error(
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
       );
     }
+
+    const { GITHUB_SERVER_URL } = await readEnv();
 
     let prFromSummary: number | undefined;
     let commitFromSummary: string | undefined;
@@ -115,14 +118,14 @@ const changelogFunctions: ChangelogFunctions = {
     const links = await (async () => {
       if (prFromSummary != null) {
         let { links } = await getInfoFromPullRequest({
-          repo: options.repo,
+          repo,
           pull: prFromSummary,
         });
         if (commitFromSummary) {
           const shortCommitId = commitFromSummary.slice(0, 7);
           links = {
             ...links,
-            commit: `[\`${shortCommitId}\`](${GITHUB_SERVER_URL}/${options.repo}/commit/${commitFromSummary})`,
+            commit: `[\`${shortCommitId}\`](${GITHUB_SERVER_URL}/${repo}/commit/${commitFromSummary})`,
           };
         }
         return links;
@@ -130,7 +133,7 @@ const changelogFunctions: ChangelogFunctions = {
       const commitToFetchFrom = commitFromSummary || changeset.commit;
       if (commitToFetchFrom) {
         const { links } = await getInfo({
-          repo: options.repo,
+          repo,
           commit: commitToFetchFrom,
         });
         return links;
@@ -161,13 +164,13 @@ const changelogFunctions: ChangelogFunctions = {
 
     return `\n\n-${prefix ? `${prefix} -` : ""} ${linkifyIssueRefs(firstLine, {
       serverUrl: GITHUB_SERVER_URL,
-      repo: options.repo,
+      repo,
     })}\n${futureLines
       .map(
         (l) =>
           `  ${linkifyIssueRefs(l, {
             serverUrl: GITHUB_SERVER_URL,
-            repo: options.repo,
+            repo,
           })}`,
       )
       .join("\n")}`;

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -16,7 +16,7 @@ export async function getCommitFunctions(
   if (!commit) {
     return [commitFunctions, null];
   }
-  const commitOpts: Record<string, unknown> = commit[1];
+  const commitOpts = commit[1];
   const changesetPath = path.join(cwd, ".changeset");
   let commitPath;
 

--- a/packages/cli/src/commit/getCommitFunctions.ts
+++ b/packages/cli/src/commit/getCommitFunctions.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { CommitFunctions } from "@changesets/types";
+import type { CommitFunctions, Config } from "@changesets/types";
 import { resolve } from "import-meta-resolve";
 
 function importResolveFromDir(specifier: string, dir: string) {
@@ -8,15 +8,15 @@ function importResolveFromDir(specifier: string, dir: string) {
 }
 
 export async function getCommitFunctions(
-  commit: false | readonly [string, any],
+  commit: Config["commit"],
   cwd: string,
   contextDir: string,
-): Promise<[CommitFunctions, any]> {
+): Promise<[CommitFunctions, null | Record<string, unknown>]> {
   let commitFunctions: CommitFunctions = {};
   if (!commit) {
     return [commitFunctions, null];
   }
-  const commitOpts: any = commit[1];
+  const commitOpts: Record<string, unknown> = commit[1];
   const changesetPath = path.join(cwd, ".changeset");
   let commitPath;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,8 +67,8 @@ export interface PrivatePackages {
 }
 
 export type Config = {
-  changelog: false | readonly [string, Record<string, unknown>];
-  commit: false | readonly [string, Record<string, unknown>];
+  changelog: false | readonly [string, null | Record<string, unknown>];
+  commit: false | readonly [string, null | Record<string, unknown>];
   fixed: Fixed;
   linked: Linked;
   access: AccessType;
@@ -94,8 +94,11 @@ export type Config = {
 };
 
 export type WrittenConfig = {
-  changelog?: false | readonly [string, Record<string, unknown>] | string;
-  commit?: boolean | readonly [string, Record<string, unknown>] | string;
+  changelog?:
+    | false
+    | readonly [string, null | Record<string, unknown>]
+    | string;
+  commit?: boolean | readonly [string, null | Record<string, unknown>] | string;
   fixed?: Fixed;
   linked?: Linked;
   access?: AccessType | "private";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -135,13 +135,13 @@ export type ModCompWithPackage = ComprehensiveRelease & {
 export type GetReleaseLine = (
   changeset: NewChangesetWithCommit,
   type: VersionType,
-  changelogOpts: null | Record<string, any>,
+  changelogOpts: null | Record<string, unknown>,
 ) => MaybePromise<string>;
 
 export type GetDependencyReleaseLine = (
   changesets: NewChangesetWithCommit[],
   dependenciesUpdated: ModCompWithPackage[],
-  changelogOpts: any,
+  changelogOpts: null | Record<string, unknown>,
 ) => MaybePromise<string>;
 
 export type ChangelogFunctions = {
@@ -151,12 +151,12 @@ export type ChangelogFunctions = {
 
 export type GetAddMessage = (
   changeset: Changeset,
-  commitOptions: any,
+  commitOpts: null | Record<string, unknown>,
 ) => MaybePromise<string>;
 
 export type GetVersionMessage = (
   releasePlan: ReleasePlan,
-  commitOptions: any,
+  commitOpts: null | Record<string, unknown>,
 ) => MaybePromise<string>;
 
 export type CommitFunctions = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,8 +67,8 @@ export interface PrivatePackages {
 }
 
 export type Config = {
-  changelog: false | readonly [string, any];
-  commit: false | readonly [string, any];
+  changelog: false | readonly [string, Record<string, unknown>];
+  commit: false | readonly [string, Record<string, unknown>];
   fixed: Fixed;
   linked: Linked;
   access: AccessType;
@@ -94,8 +94,8 @@ export type Config = {
 };
 
 export type WrittenConfig = {
-  changelog?: false | readonly [string, any] | string;
-  commit?: boolean | readonly [string, any] | string;
+  changelog?: false | readonly [string, Record<string, unknown>] | string;
+  commit?: boolean | readonly [string, Record<string, unknown>] | string;
   fixed?: Fixed;
   linked?: Linked;
   access?: AccessType | "private";


### PR DESCRIPTION
fix #1722 

also in the valibot refactor the opts is also validated as `Record<string, unknown>`, so this matches it.