### PR TITLE
Tweak add command cli styles

### DIFF
--- a/.changeset/curly-loops-crash.md
+++ b/.changeset/curly-loops-crash.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Enable guide line for `add` command and use box design for dependent patch bump note

--- a/packages/cli/src/commands/add/messages.ts
+++ b/packages/cli/src/commands/add/messages.ts
@@ -1,6 +1,6 @@
 import c from "@changesets/color";
 import type { Release, VersionType } from "@changesets/types";
-import { log } from "@clack/prompts";
+import { log, note } from "@clack/prompts";
 
 export function printConfirmationMessage(
   changeset: {
@@ -32,12 +32,10 @@ export function printConfirmationMessage(
   log.success(msg);
 
   if (repoHasMultiplePackages) {
-    log.info(
-      `
-Note: All packages that depend on these whose required versions
-will be incompatible will also be ${c.blue("patch")} bumped
-when this changeset is applied.
-      `.trim(),
+    note(
+      `All packages that depend on these whose required versions will be incompatible ` +
+        `will also be ${c.blue("patch")} bumped when this changeset is applied.`,
+      "NOTE",
     );
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,14 +6,19 @@ import { ExitError, InternalError } from "@changesets/errors";
 import { intro, log, outro, updateSettings } from "@clack/prompts";
 import { cli } from "./cli.ts";
 
-updateSettings({ withGuide: false });
-
 try {
   cli.parse(process.argv, { run: false });
 
+  const commandName = cli.matchedCommand?.name;
+
+  // Disable clack guide for non-interactive commands
+  if (commandName !== "add") {
+    updateSettings({ withGuide: false });
+  }
+
   // Do not show intro for --help and --version, which have no command name
   if (cli.matchedCommand?.name != null) {
-    intro(`🦋 changeset v${manifest.version}\n`);
+    intro(`🦋 changeset v${manifest.version}`);
   }
 
   await cli.runMatchedCommand();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,18 +6,19 @@ import { ExitError, InternalError } from "@changesets/errors";
 import { intro, log, outro, updateSettings } from "@clack/prompts";
 import { cli } from "./cli.ts";
 
+updateSettings({ withGuide: false });
+
 try {
   cli.parse(process.argv, { run: false });
 
   const commandName = cli.matchedCommand?.name;
 
-  // Disable clack guide for non-interactive commands
-  if (commandName !== "add") {
-    updateSettings({ withGuide: false });
+  // Enable clack guide for interactive commands
+  if (commandName === "add") {
+    updateSettings({ withGuide: true });
   }
-
-  // Do not show intro for --help and --version, which have no command name
-  if (cli.matchedCommand?.name != null) {
+  // Show intro when running a command, except for --help and --version (has no command name)
+  if (commandName != null) {
     intro(`🦋 changeset v${manifest.version}`);
   }
 


### PR DESCRIPTION
It's a bit hard to fix the spacing issue without the guide, but at the meantime the guide does look better in an interactive flow, so re-enabling it for now.

<img width="809" height="540" alt="image" src="https://github.com/user-attachments/assets/398420e1-8d3c-4733-b48a-7ccd56ef1951" />
