### PR TITLE
refactor `flattenReleases` for readability and performance

### DIFF
--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -56,8 +56,6 @@ export function flattenReleases(
       }
 
       release.changesets.push(changeset.id);
-
-      releases.set(name, release);
     }
   }
 

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -55,9 +55,6 @@ export function flattenReleases(
         release.type = type;
       }
 
-      // Check whether the bumpType will change
-      // If the bumpType has changed recalc newVersion
-      // push new changeset to releases
       release.changesets.push(changeset.id);
 
       releases.set(name, release);

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -1,11 +1,28 @@
-// This function takes in changesets and returns one release per
-// package listed in the changesets
-
 import { shouldSkipPackage } from "@changesets/should-skip-package";
-import type { Config, NewChangeset, Package } from "@changesets/types";
+import type {
+  Config,
+  NewChangeset,
+  Package,
+  VersionType,
+} from "@changesets/types";
 import type { InternalRelease } from "./types.ts";
 import { mapGetOrThrowInternal } from "./utils.ts";
 
+const changeTypes = {
+  major: 3,
+  minor: 2,
+  patch: 1,
+  none: 0,
+} as const;
+
+const changeTypeIsBiggerThanPrevious = (
+  type: VersionType,
+  previous: VersionType,
+) => changeTypes[type] > changeTypes[previous];
+
+/**
+ * Flattens a list of changesets into a package->release-type map
+ */
 export function flattenReleases(
   changesets: NewChangeset[],
   packagesByName: Map<string, Package>,
@@ -13,52 +30,48 @@ export function flattenReleases(
 ): Map<string, InternalRelease> {
   const releases: Map<string, InternalRelease> = new Map();
 
-  changesets.forEach((changeset) => {
-    changeset.releases
+  // Iterate each changeset and its affected packages (`releases`)
+  for (const changeset of changesets) {
+    for (const { name, type } of changeset.releases) {
+      const pkg = mapGetOrThrowInternal(
+        packagesByName,
+        name,
+        `Couldn't find package named "${name}" listed in changeset "${changeset.id}"`,
+      );
+
       // Filter out skipped packages because they should not trigger a release
       // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
-      .filter(({ name }) => {
-        const pkg = mapGetOrThrowInternal(
-          packagesByName,
-          name,
-          `Couldn't find package named "${name}" listed in changeset "${changeset.id}"`,
-        );
-        return !shouldSkipPackage(pkg, {
-          ignore: config.ignore,
-          allowPrivatePackages: config.privatePackages.version,
-        });
-      })
-      .forEach(({ name, type }) => {
-        const pkg = mapGetOrThrowInternal(
-          packagesByName,
-          name,
-          `Couldn't find package named "${name}" listed in changeset "${changeset.id}"`,
-        );
-        let release = releases.get(name);
-        if (!release) {
-          release = {
-            name,
-            type,
-            oldVersion: pkg.packageJson.version,
-            changesets: [changeset.id],
-          };
-        } else {
-          if (
-            type === "major" ||
-            ((release.type === "patch" || release.type === "none") &&
-              (type === "minor" || type === "patch"))
-          ) {
-            release.type = type;
-          }
-          // Check whether the bumpType will change
-          // If the bumpType has changed recalc newVersion
-          // push new changeset to releases
-          release.changesets.push(changeset.id);
-        }
-
-        releases.set(name, release);
+      const packageIsSkipped = shouldSkipPackage(pkg, {
+        ignore: config.ignore,
+        allowPrivatePackages: config.privatePackages.version,
       });
-  });
+      if (packageIsSkipped) continue;
+
+      const release = releases.get(name);
+
+      if (release == null) {
+        releases.set(name, {
+          name,
+          type,
+          oldVersion: pkg.packageJson.version,
+          changesets: [changeset.id],
+        });
+
+        continue;
+      }
+
+      if (changeTypeIsBiggerThanPrevious(type, release.type)) {
+        release.type = type;
+      }
+
+      // Check whether the bumpType will change
+      // If the bumpType has changed recalc newVersion
+      // push new changeset to releases
+      release.changesets.push(changeset.id);
+
+      releases.set(name, release);
+    }
+  }
 
   return releases;
 }

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -1,10 +1,5 @@
 import { shouldSkipPackage } from "@changesets/should-skip-package";
-import type {
-  Config,
-  NewChangeset,
-  Package,
-  VersionType,
-} from "@changesets/types";
+import type { Config, NewChangeset, Package } from "@changesets/types";
 import type { InternalRelease } from "./types.ts";
 import { mapGetOrThrowInternal } from "./utils.ts";
 
@@ -14,11 +9,6 @@ const changeTypes = {
   patch: 1,
   none: 0,
 } as const;
-
-const changeTypeIsBiggerThanPrevious = (
-  type: VersionType,
-  previous: VersionType,
-) => changeTypes[type] > changeTypes[previous];
 
 /**
  * Flattens a list of changesets into a package->release-type map
@@ -41,11 +31,11 @@ export function flattenReleases(
 
       // Filter out skipped packages because they should not trigger a release
       // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
-      const packageIsSkipped = shouldSkipPackage(pkg, {
+      const isSkipped = shouldSkipPackage(pkg, {
         ignore: config.ignore,
         allowPrivatePackages: config.privatePackages.version,
       });
-      if (packageIsSkipped) continue;
+      if (isSkipped) continue;
 
       const release = releases.get(name);
 
@@ -60,7 +50,8 @@ export function flattenReleases(
         continue;
       }
 
-      if (changeTypeIsBiggerThanPrevious(type, release.type)) {
+      // if this changeset's type overrides the previous one
+      if (changeTypes[type] > changeTypes[release.type]) {
         release.type = type;
       }
 


### PR DESCRIPTION
done as part of the release plan tests cleanup

replaces `.filter().forEach()` loop with a single for-of for performance and readability, and restructures a little bit of code to make it more readable