### PR TITLE
docs: intructions to mitigate GitHub Actions permissions issues

### DIFF
--- a/docs/automating-changesets.md
+++ b/docs/automating-changesets.md
@@ -38,10 +38,37 @@ In some cases, you may _want_ to merge a change without doing any releases (such
 
 ## How do I run the version and publish commands?
 
+### Automatic setup
+
 We have a [github action](https://github.com/changesets/action) that
 
 - creates a `version` PR, then keeps it up to date, recreating it when merged. This PR always has an up-to-date run of `changeset version`
 - Optionally allows you to do releases when changes are merged to the base branch.
+
+#### GitHub permissions issues
+
+You may encounter issues of changesets/action jobs failing for no reason and if that's the case, you can try the following steps :
+
+1. Add writing permissions for the GitHub access token used by the job that triggers changesets/action :
+
+```yml
+# In .github/workflows/release.yml or similar
+
+jobs:
+  release:
+    # ...
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # ...
+      - name: Create Release PR
+        uses: changesets/action@v1
+```
+
+2. In your GitHub repository's settings, go to `Code and automation > Actions > General` and enable the option `Allow GitHub Actions to create and approve pull requests` at the end.
+
+### Manual setup
 
 If you don't want to use this action, the manual workflow we recommend for running the `version` and `publish` commands is:
 

--- a/docs/automating-changesets.md
+++ b/docs/automating-changesets.md
@@ -47,7 +47,12 @@ We have a [github action](https://github.com/changesets/action) that
 
 #### GitHub permissions issues
 
-You may encounter issues of changesets/action jobs failing for no reason and if that's the case, you can try the following steps :
+You may encounter issues of changesets/action jobs failing with some of these errors :
+
+- `remote: Permission to xxx.git denied to github-actions[bot]`
+- `GitHub Actions is not permitted to create or approve pull requests`
+
+If that's the case, you can try the following steps :
 
 1. Add writing permissions for the GitHub access token used by the job that triggers changesets/action :
 
@@ -58,8 +63,8 @@ jobs:
   release:
     # ...
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # For changesets to create/update PRs
+      pull-requests: write # For changesets to push tags
     steps:
       # ...
       - name: Create Release PR

--- a/docs/automating-changesets.md
+++ b/docs/automating-changesets.md
@@ -68,7 +68,7 @@ jobs:
     steps:
       # ...
       - name: Create Release PR
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
 ```
 
 2. In your GitHub repository's settings, go to `Code and automation > Actions > General` and enable the option `Allow GitHub Actions to create and approve pull requests` at the end.

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -52,10 +52,44 @@ If you want to merge a change without doing any releases (such as when you only 
 
 ## How do I run the version and publish commands?
 
+### Automatic setup
+
 You can set up the [Changesets GitHub Action](https://github.com/changesets/action) to automate this process:
 
 - It creates a `version` PR, then keeps it up to date, recreating it when merged.
 - Optionally, if publishing is set up, it automatically publishes the release whenever the PR is merged.
+
+#### GitHub permissions issues
+
+One important step to not miss is to enable appropriate permissions for the action to work :
+
+1. Add writing permissions for the GitHub access token used by the job that triggers `changesets/action` :
+
+```yml
+# In .github/workflows/release.yml or similar
+
+jobs:
+  release:
+    # ...
+    permissions:
+      contents: write # For changesets to create/update PRs
+      pull-requests: write # For changesets to push tags
+    steps:
+      # ...
+      - name: Create Release PR
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+```
+
+2. In your GitHub repository's settings, go to `Code and automation > Actions > General` and enable the option `Allow GitHub Actions to create and approve pull requests` at the end.
+
+::: details Errors you may encounter if you skip these steps
+
+- `remote: Permission to xxx.git denied to github-actions[bot]`
+- `GitHub Actions is not permitted to create or approve pull requests`
+
+:::
+
+### Manual setup
 
 If you do not want to use this action, the manual workflow we recommend is:
 


### PR DESCRIPTION
Added intructions to mitigate GitHub Actions permissions issues in the Automating Changesets page.

This is related to https://github.com/changesets/action/issues/106 and is basically what [this comment](https://github.com/changesets/action/issues/199#issuecomment-2012315190) suggests to do