### PR TITLE
Replace `npm info` with package manager aware registry query

### DIFF
--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -260,4 +260,67 @@ describe("getPackageInfo", () => {
 
     expect(result).toEqual(packageData);
   });
+
+  it("uses yarn npm info when packageManager field specifies yarn berry", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        packageManager: "yarn@4.0.0",
+      }),
+    });
+
+    mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
+      Promise.resolve(
+        cmd === "yarn" && args?.[0] === "npm" && args?.[1] === "info"
+          ? spawnResult(
+              JSON.stringify({
+                name: "pkg-a",
+                version: "1.0.0",
+                versions: ["1.0.0"],
+              })
+            )
+          : spawnResult("", 1)
+      )) as any);
+
+    const result = await getPackageInfo(
+      { name: "pkg-a", version: "1.0.0" },
+      cwd
+    );
+
+    expect(result).toMatchObject({ name: "pkg-a" });
+    expect(
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) =>
+          cmd === "yarn" && args?.[0] === "npm" && args?.[1] === "info"
+      )
+    ).toBe(true);
+    expect(
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "npm" && args?.[0] === "info"
+      )
+    ).toBe(false);
+  });
+
+  it("throws when yarn classic returns unparseable non-JSON output", async () => {
+    // isYarnClassicError's JSON.parse throws on non-JSON output, returning false
+    // from the catch block. The output is treated as non-empty, so jsonParse
+    // is called next and propagates the SyntaxError.
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        packageManager: "yarn@1.22.0",
+      }),
+    });
+
+    mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
+      Promise.resolve(
+        cmd === "yarn" && args?.[0] === "info"
+          ? spawnResult("error: network timeout")
+          : spawnResult("", 1)
+      )) as any);
+
+    await expect(
+      getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd)
+    ).rejects.toThrow(SyntaxError);
+  });
 });

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,4 +1,18 @@
-import { getCorrectRegistry, isCustomRegistry } from "../npm-utils";
+import { getCorrectRegistry, isCustomRegistry, getPackageInfo } from "../npm-utils";
+import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
+import spawn from "spawndamnit";
+
+jest.mock("spawndamnit");
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+function spawnResult(stdout: string, code = 0) {
+  return {
+    code,
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.from(""),
+  };
+}
 
 const originalEnv = process.env;
 
@@ -124,5 +138,97 @@ describe("isCustomRegistry", () => {
 
   it("returns true for a path-based custom registry", () => {
     expect(isCustomRegistry("https://registry.example.com/npm")).toBe(true);
+  });
+});
+
+describe("getPackageInfo", () => {
+  silenceLogsInBlock();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses pnpm info when packageManager field specifies pnpm", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        packageManager: "pnpm@9.0.0",
+      }),
+    });
+
+    mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
+      Promise.resolve(
+        cmd === "pnpm" && args?.[0] === "info"
+          ? spawnResult(
+              JSON.stringify({ name: "pkg-a", version: "1.0.0", versions: ["1.0.0"] })
+            )
+          : spawnResult("", 1)
+      )) as any);
+
+    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+
+    expect(result).toMatchObject({ name: "pkg-a" });
+    expect(
+      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
+    ).toBe(false);
+    expect(
+      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "pnpm" && args?.[0] === "info")
+    ).toBe(true);
+  });
+
+  it("treats yarn classic error JSON as not found and returns E404 when both queries fail", async () => {
+    // yarn v1 returns {"type":"error","data":"..."} (non-empty) instead of empty stdout
+    // when a package or version isn't found. Without the fix, the empty-stdout guard never
+    // fires, the error object bypasses E404 normalization, and the package appears published.
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        packageManager: "yarn@1.22.0",
+      }),
+    });
+
+    mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
+      Promise.resolve(
+        cmd === "yarn" && args?.[0] === "info"
+          ? spawnResult(
+              JSON.stringify({
+                type: "error",
+                data: 'error Couldn\'t find package "pkg-a" on the "npm" registry.',
+              })
+            )
+          : spawnResult("", 1)
+      )) as any);
+
+    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+
+    expect(result).toEqual({ error: { code: "E404" } });
+    expect(
+      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
+    ).toBe(false);
+    expect(
+      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "yarn" && args?.[0] === "info")
+    ).toBe(true);
+  });
+
+  it("strips the yarn classic inspect wrapper from a successful response", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        packageManager: "yarn@1.22.0",
+      }),
+    });
+
+    const packageData = { name: "pkg-a", version: "1.0.0", versions: ["1.0.0"] };
+
+    mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
+      Promise.resolve(
+        cmd === "yarn" && args?.[0] === "info"
+          ? spawnResult(JSON.stringify({ type: "inspect", data: packageData }))
+          : spawnResult("", 1)
+      )) as any);
+
+    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+
+    expect(result).toEqual(packageData);
   });
 });

--- a/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/npm-utils.test.ts
@@ -1,4 +1,8 @@
-import { getCorrectRegistry, isCustomRegistry, getPackageInfo } from "../npm-utils";
+import {
+  getCorrectRegistry,
+  isCustomRegistry,
+  getPackageInfo,
+} from "../npm-utils";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import spawn from "spawndamnit";
 
@@ -160,19 +164,30 @@ describe("getPackageInfo", () => {
       Promise.resolve(
         cmd === "pnpm" && args?.[0] === "info"
           ? spawnResult(
-              JSON.stringify({ name: "pkg-a", version: "1.0.0", versions: ["1.0.0"] })
+              JSON.stringify({
+                name: "pkg-a",
+                version: "1.0.0",
+                versions: ["1.0.0"],
+              })
             )
           : spawnResult("", 1)
       )) as any);
 
-    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+    const result = await getPackageInfo(
+      { name: "pkg-a", version: "1.0.0" },
+      cwd
+    );
 
     expect(result).toMatchObject({ name: "pkg-a" });
     expect(
-      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "npm" && args?.[0] === "info"
+      )
     ).toBe(false);
     expect(
-      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "pnpm" && args?.[0] === "info")
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "pnpm" && args?.[0] === "info"
+      )
     ).toBe(true);
   });
 
@@ -199,14 +214,21 @@ describe("getPackageInfo", () => {
           : spawnResult("", 1)
       )) as any);
 
-    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+    const result = await getPackageInfo(
+      { name: "pkg-a", version: "1.0.0" },
+      cwd
+    );
 
     expect(result).toEqual({ error: { code: "E404" } });
     expect(
-      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "npm" && args?.[0] === "info"
+      )
     ).toBe(false);
     expect(
-      mockSpawn.mock.calls.some(([cmd, args]) => cmd === "yarn" && args?.[0] === "info")
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "yarn" && args?.[0] === "info"
+      )
     ).toBe(true);
   });
 
@@ -218,7 +240,11 @@ describe("getPackageInfo", () => {
       }),
     });
 
-    const packageData = { name: "pkg-a", version: "1.0.0", versions: ["1.0.0"] };
+    const packageData = {
+      name: "pkg-a",
+      version: "1.0.0",
+      versions: ["1.0.0"],
+    };
 
     mockSpawn.mockImplementation(((cmd: string, args: string[]) =>
       Promise.resolve(
@@ -227,7 +253,10 @@ describe("getPackageInfo", () => {
           : spawnResult("", 1)
       )) as any);
 
-    const result = await getPackageInfo({ name: "pkg-a", version: "1.0.0" }, cwd);
+    const result = await getPackageInfo(
+      { name: "pkg-a", version: "1.0.0" },
+      cwd
+    );
 
     expect(result).toEqual(packageData);
   });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -200,6 +200,48 @@ describe("publishPackages", () => {
     );
   });
 
+  it("passes the otp token to npm publish when provided", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+    });
+
+    mockSpawnImplementation((cmd, args) => {
+      if (cmd === "npm" && args?.[0] === "info") {
+        return spawnResult("");
+      }
+      if (cmd === "npm" && args?.[0] === "publish") {
+        return spawnResult(JSON.stringify({ id: "pkg-a@1.0.0" }));
+      }
+      return spawnResult("", 1);
+    });
+
+    const result = await publishPackages({
+      packages: (await getPackages(cwd)).packages,
+      access: "public",
+      preState: undefined,
+      otp: "123456",
+      cwd,
+    });
+
+    expect(result).toEqual([
+      { name: "pkg-a", newVersion: "1.0.0", result: "published" },
+    ]);
+
+    const publishCall = mockSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === "npm" && args?.[0] === "publish"
+    );
+    expect(publishCall?.[1]).toEqual(
+      expect.arrayContaining(["--otp", "123456"])
+    );
+  });
+
   it("publishes with specified tag on GitHub Packages when new version not yet published", async () => {
     // GitHub Packages does not auto-assign latest on first publish. When both
     // the bare query and the exact-version fallback return empty, there is no

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -55,6 +55,7 @@ describe("publishPackages", () => {
       packages: (await getPackages(cwd)).packages,
       access: "public",
       preState: undefined,
+      cwd,
     });
 
     const spawnCalls = mockSpawn.mock.calls;
@@ -99,6 +100,7 @@ describe("publishPackages", () => {
       packages: (await getPackages(cwd)).packages,
       access: "public",
       preState: undefined,
+      cwd,
     });
 
     expect(result).toEqual([]);
@@ -135,6 +137,7 @@ describe("publishPackages", () => {
       packages: (await getPackages(cwd)).packages,
       access: "public",
       preState: undefined,
+      cwd,
     });
 
     expect(result).toEqual([
@@ -182,6 +185,7 @@ describe("publishPackages", () => {
         initialVersions: {},
         changesets: [],
       },
+      cwd,
     });
 
     expect(result).toEqual([
@@ -231,6 +235,7 @@ describe("publishPackages", () => {
         initialVersions: {},
         changesets: [],
       },
+      cwd,
     });
 
     expect(result).toEqual([
@@ -243,4 +248,5 @@ describe("publishPackages", () => {
     expect(publishCall?.[1]).toEqual(expect.arrayContaining(["--tag", "beta"]));
     expect(publishCall?.[1]).not.toContain("latest");
   });
+
 });

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -248,5 +248,4 @@ describe("publishPackages", () => {
     expect(publishCall?.[1]).toEqual(expect.arrayContaining(["--tag", "beta"]));
     expect(publishCall?.[1]).not.toContain("latest");
   });
-
 });

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -67,6 +67,7 @@ export default async function publish(
     otp,
     preState,
     tag: releaseTag,
+    cwd,
   });
   const privatePackages = packages.filter(
     (pkg) => pkg.packageJson.private && pkg.packageJson.version

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -195,10 +195,7 @@ function isYarnClassicError(output: string): boolean {
 //   no versions list → only-pre detection is not possible. Such packages
 //   (e.g. GitHub Packages with no auto-latest) are published with
 //   preState.tag rather than "latest".
-export function getPackageInfo(
-  packageJson: PackageJSON,
-  cwd = process.cwd()
-) {
+export function getPackageInfo(packageJson: PackageJSON, cwd = process.cwd()) {
   return npmRequestQueue.add(async () => {
     info(`npm info ${packageJson.name}`);
 
@@ -218,7 +215,9 @@ export function getPackageInfo(
         return spawn("yarn", ["npm", "info", pkgSpecifier, "--json"], { cwd });
       }
       const cmd = infoTool.name === "yarn-classic" ? "yarn" : infoTool.name;
-      return spawn(cmd, ["info", pkgSpecifier, registryFlag, "--json"], { cwd });
+      return spawn(cmd, ["info", pkgSpecifier, registryFlag, "--json"], {
+        cwd,
+      });
     };
 
     // "no useful result" means empty stdout for npm/pnpm/yarn-berry, or a

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -127,8 +127,37 @@ export async function getTokenIsRequired() {
   return json.tfa.mode === "auth-and-writes";
 }
 
-// `npm info <pkg> --json` (aka `npm view`) behavior:
+type InfoTool =
+  | { name: "npm" }
+  | { name: "pnpm" }
+  | { name: "yarn-classic" }
+  | { name: "yarn-berry" };
+
+async function getInfoTool(cwd: string): Promise<InfoTool> {
+  const pm = await detect({ cwd });
+  if (pm?.name === "pnpm") return { name: "pnpm" };
+  if (pm?.name === "yarn") {
+    return pm.agent === "yarn@berry"
+      ? { name: "yarn-berry" }
+      : { name: "yarn-classic" };
+  }
+  return { name: "npm" };
+}
+
+// yarn v1 returns {"type":"error","data":"..."} (non-empty stdout) when a package or
+// version isn't found, unlike npm/pnpm which return empty stdout.
+function isYarnClassicError(output: string): boolean {
+  try {
+    return JSON.parse(output)?.type === "error";
+  } catch {
+    return false;
+  }
+}
+
+// Queries the registry for package info using the detected package manager.
+// Tool-specific behaviour:
 //
+// npm / pnpm:
 // - Bare package name starts with version string `'latest'`. If
 //   `dist-tags['latest']` exists, it's replaced with that value (e.g.
 //   `'1.0.0'`). Then ALL versions are filtered through
@@ -141,60 +170,99 @@ export async function getTokenIsRequired() {
 // - When at least one version matches, the JSON output includes a `versions`
 //   array with ALL published versions including prereleases (bleeds through
 //   from the packument, unfiltered).
-// - npmjs.org auto-assigns `latest` on first publish in addition to the
-//   provided --tag, so bare queries always work there. GitHub Packages does
-//   NOT auto-assign `latest`, so the empty-stdout case above applies.
-// - `npm info <pkg>@<exact-prerelease> --json` works as long as that
-//   version exists on the registry: exact strings pass `semver.satisfies`,
-//   and the output still includes the full `versions` history (same
-//   packument merge). Returns empty when the version doesn't exist yet.
-// - Consequence: the exact-version fallback only provides data when
-//   localVersion is already published. For a new unpublished version both
-//   queries return empty → no versions list → only-pre detection is not
-//   possible. Such packages (e.g. GitHub Packages with no auto-latest) are
-//   published with preState.tag rather than "latest".
-export function getPackageInfo(packageJson: PackageJSON) {
+// - Registry is passed via `--registry` (or `--<scope>:registry`) CLI flag.
+//
+// yarn berry:
+// - Uses `yarn npm info`, which reads the registry from `.yarnrc.yml` rather
+//   than accepting a CLI `--registry` flag.
+// - Returns npm-compatible JSON directly (no envelope wrapping).
+//
+// yarn classic (v1):
+// - Uses `yarn info`, which wraps the result in `{ type: "inspect", data: {...} }`.
+//   The wrapper is stripped before returning so callers get the raw packument shape.
+// - Registry is passed via `--registry` (not the scoped `--@scope:registry` form,
+//   which yarn v1 silently ignores).
+// - Returns `{ type: "error", data: "..." }` (non-empty) instead of empty stdout
+//   when a package or version isn't found.
+//
+// Two-query strategy (applies to all tools):
+// - npmjs.org auto-assigns `latest` on first publish, so bare queries always
+//   work there. GitHub Packages does NOT auto-assign `latest`, so the bare
+//   query returns empty stdout (or a yarn-classic error) and we fall back to
+//   an exact-version query.
+// - The exact-version fallback only provides data when localVersion is already
+//   published. For a new unpublished version both queries return empty →
+//   no versions list → only-pre detection is not possible. Such packages
+//   (e.g. GitHub Packages with no auto-latest) are published with
+//   preState.tag rather than "latest".
+export function getPackageInfo(
+  packageJson: PackageJSON,
+  cwd = process.cwd()
+) {
   return npmRequestQueue.add(async () => {
     info(`npm info ${packageJson.name}`);
 
     const { scope, registry } = getCorrectRegistry(packageJson);
+    const infoTool = await getInfoTool(cwd);
+
+    // yarn classic only understands --registry=<url>, not --@scope:registry=<url>
+    const registryFlag =
+      infoTool.name === "yarn-classic"
+        ? `--registry=${registry}`
+        : `--${scope ? `${scope}:` : ""}registry=${registry}`;
+
+    const runInfoCommand = (pkgSpecifier: string) => {
+      if (infoTool.name === "yarn-berry") {
+        // yarn berry's `npm` subcommand returns npm-compatible JSON;
+        // registry is read from .yarnrc.yml rather than a CLI flag
+        return spawn("yarn", ["npm", "info", pkgSpecifier, "--json"], { cwd });
+      }
+      const cmd = infoTool.name === "yarn-classic" ? "yarn" : infoTool.name;
+      return spawn(cmd, ["info", pkgSpecifier, registryFlag, "--json"], { cwd });
+    };
+
+    // "no useful result" means empty stdout for npm/pnpm/yarn-berry, or a
+    // {"type":"error"} response for yarn classic (which never returns empty stdout).
+    const isEmptyResult = (output: string) =>
+      output === "" ||
+      (infoTool.name === "yarn-classic" && isYarnClassicError(output));
 
     // Bare query: when dist-tags.latest is set, returns the full `versions` array via packument
     // bleed-through, enabling only-pre detection downstream. Returns empty when no `latest` exists.
-    let result = await spawn("npm", [
-      "info",
-      packageJson.name,
-      `--${scope ? `${scope}:` : ""}registry=${registry}`,
-      "--json",
-    ]);
+    let result = await runInfoCommand(packageJson.name);
 
     // Bare query returned nothing — retry with exact version specifier
     // to handle prerelease-only packages on registries without auto-`latest`.
-    if (result.stdout.toString() === "") {
-      result = await spawn("npm", [
-        "info",
-        `${packageJson.name}@${packageJson.version}`,
-        `--${scope ? `${scope}:` : ""}registry=${registry}`,
-        "--json",
-      ]);
+    if (isEmptyResult(result.stdout.toString())) {
+      result = await runInfoCommand(
+        `${packageJson.name}@${packageJson.version}`
+      );
     }
 
     // Normalize, just in case. The above prerelease-only package query should already have returned:
     // - either a result (when the package+version exists)
     // - or an error with: "code": "E404", "summary": "No match found for version $VERSION",
-    if (result.stdout.toString() === "") {
+    if (isEmptyResult(result.stdout.toString())) {
       return {
         error: {
           code: "E404",
         },
       };
     }
-    return jsonParse(result.stdout.toString());
+
+    const parsed = jsonParse(result.stdout.toString());
+
+    // yarn classic wraps packument data in { type: "inspect", data: {...} }
+    if (infoTool.name === "yarn-classic" && parsed?.type === "inspect") {
+      return parsed.data;
+    }
+
+    return parsed;
   });
 }
 
-export async function infoAllow404(packageJson: PackageJSON) {
-  let pkgInfo = await getPackageInfo(packageJson);
+export async function infoAllow404(packageJson: PackageJSON, cwd?: string) {
+  let pkgInfo = await getPackageInfo(packageJson, cwd);
   if (pkgInfo.error?.code === "E404") {
     warn(`Received 404 for npm info ${pc.cyan(`"${packageJson.name}"`)}`);
     return { published: false, pkgInfo: {} };

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -88,18 +88,21 @@ export default async function publishPackages({
   otp,
   preState,
   tag,
+  cwd = process.cwd(),
 }: {
   packages: Package[];
   access: AccessType;
   otp?: string;
   preState: PreState | undefined;
   tag?: string;
+  cwd?: string;
 }) {
   const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
   const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
   const unpublishedPackagesInfo = await getUnpublishedPackages(
     publicPackages,
-    preState
+    preState,
+    cwd
   );
 
   if (unpublishedPackagesInfo.length === 0) {
@@ -159,11 +162,12 @@ async function publishAPackage(
 
 async function getUnpublishedPackages(
   packages: Array<Package>,
-  preState: PreState | undefined
+  preState: PreState | undefined,
+  cwd: string
 ) {
   const results: Array<PkgInfo> = await Promise.all(
     packages.map(async ({ packageJson }) => {
-      const response = await infoAllow404(packageJson);
+      const response = await infoAllow404(packageJson, cwd);
       let publishedState: PublishedState = "never";
       if (response.published) {
         publishedState = "published";


### PR DESCRIPTION
# Issue
Resolves #965

# Problem

The `getPackageInfo` function in the publish command always uses `npm info` to query package metadata, regardless of which package manager the project is configured to use.

Projects can declare their package manager using either the `packageManager` field or the `devEngines.packageManager` field in package.json:

```json
{
  "packageManager": "pnpm@10.12.1"
}
OR
{
  "devEngines": {
    "packageManager": {
      "name": "pnpm",
      "version": ">=10",
      "onFail": "error"
    }
  }
}
```

The devEngines field is an [OpenJS Foundation standard](https://github.com/openjs-foundation/package-metadata-interoperability-working-group/blob/main/devengines-field-proposal.md) for declaring package manager and runtime requirements during development.

Because `npm info` is always used, projects that rely on pnpm or Yarn-specific registry configuration and authentication may fail or behave incorrectly. Both pnpm and Yarn provide their own info commands that respect their configured registries and credentials.

The publish workflow should use the project's configured package manager when querying package metadata.

# What changed

* Added `getInfoTool(cwd)` to detect the project's package manager using `detect({ cwd })` and map it to:

  * `npm`
  * `pnpm`
  * `yarn-classic`
  * `yarn-berry`

* Updated `getPackageInfo` to use the appropriate package manager command:

  * **npm / pnpm**

    ```sh
    <pm> info <pkg> --registry=<url> --json
    ```
  * **Yarn Berry**

    ```sh
    yarn npm info <pkg> --json
    ```

    Registry configuration is read from `.yarnrc.yml`.
  * **Yarn Classic**

    ```sh
    yarn info <pkg> --registry=<url> --json
    ```

    Handles Yarn v1's `{ type: "inspect", data }` response format and treats `{ type: "error" }` as a package-not-found result.

* Extended `isEmptyResult` to recognize Yarn Classic error responses, ensuring the existing two-query fallback and E404 normalization logic continue to work correctly.

* Threaded `cwd` through:

  ```
  publishPackages
    → getUnpublishedPackages
      → infoAllow404
        → getPackageInfo
  ```

  so package manager detection always runs relative to the project root.


# Testing

  New unit tests cover:
  - pnpm: verify pnpm info is called instead of npm info
  - yarn classic error response: verify it is treated as "not found" and falls through to E404
  - yarn classic success response: verify the { type: "inspect", data } wrapper is stripped before returning