### PR TITLE
fix: should-skip-package doesn't respect glob patterns in config

### DIFF
--- a/.changeset/wise-timers-count.md
+++ b/.changeset/wise-timers-count.md
@@ -1,0 +1,5 @@
+---
+"@changesets/should-skip-package": patch
+---
+
+Use micromatch when checking ignored packages so ignore globs are respected.

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -752,6 +752,34 @@ describe("parser errors", () => {
     `);
   });
 
+  test("ignore globs require dependent packages to also be ignored", async () => {
+    expect(() =>
+      unsafeParse(
+        { ignore: ["pkg-*", "!pkg-a"] },
+        {
+          ...defaultPackages,
+          packages: [
+            {
+              packageJson: {
+                name: "pkg-a",
+                version: "1.0.0",
+                dependencies: { "pkg-b": "1.0.0" },
+              },
+              dir: "dir",
+            },
+            {
+              packageJson: { name: "pkg-b", version: "1.0.0" },
+              dir: "dir",
+            },
+          ],
+        }
+      )
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Some errors occurred when validating the changesets config:
+      The package "pkg-a" depends on the skipped package "pkg-b", but "pkg-a" is not being skipped. Please add "pkg-a" to the \`ignore\` option."
+    `);
+  });
+
   test("ignore should not require private versioned dependents to also be ignored", () => {
     expect(() =>
       unsafeParse(

--- a/packages/should-skip-package/package.json
+++ b/packages/should-skip-package/package.json
@@ -20,9 +20,11 @@
   "repository": "https://github.com/changesets/changesets/tree/main/packages/should-skip-package",
   "dependencies": {
     "@changesets/types": "^6.1.0",
-    "@manypkg/get-packages": "^1.1.3"
+    "@manypkg/get-packages": "^1.1.3",
+    "micromatch": "^4.0.8"
   },
   "devDependencies": {
-    "@changesets/test-utils": "*"
+    "@changesets/test-utils": "*",
+    "@types/micromatch": "^4.0.1"
   }
 }

--- a/packages/should-skip-package/src/index.ts
+++ b/packages/should-skip-package/src/index.ts
@@ -1,5 +1,6 @@
 import { Package } from "@manypkg/get-packages";
 import { PackageGroup } from "@changesets/types";
+import micromatch from "micromatch";
 
 export function shouldSkipPackage(
   { packageJson }: Package,
@@ -11,7 +12,7 @@ export function shouldSkipPackage(
     allowPrivatePackages: boolean;
   }
 ) {
-  if (ignore.includes(packageJson.name)) {
+  if (micromatch([packageJson.name], ignore).length > 0) {
     return true;
   }
 


### PR DESCRIPTION
With the config `["*", "@icewolf/*", "!@icewolf/other-package"]`, I got the error below:

```
🦋  error ValidationError: Some errors occurred when validating the changesets config:
🦋  error The package "@icewolf/public-package" depends on the skipped package "@icewolf/private-package", but "@icewolf/public-package" is not being skipped. Please add "@icewolf/public-package" to the `ignore` option.
```

I traced this to a bug in `@changesets/should-skip-packages`. Unlike `@changesets/config`'s parser, which supports globs via micromatch, `@changesets/should-skip-packages` treated the ignore list as literal strings (`ignore.includes(...)`). With this pr, that check now also uses micromatch as expected.