### PR TITLE
Ignore agent files as changesets

### DIFF
--- a/.changeset/shiny-monkeys-notice.md
+++ b/.changeset/shiny-monkeys-notice.md
@@ -1,0 +1,5 @@
+---
+"@changesets/read": minor
+---
+
+Ignore more markdown files in the `.changeset` directory when reading changesets, including AGENTS.md, CLAUDE.md, and GEMINI.md

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -6,7 +6,7 @@ import type { NewChangeset } from "@changesets/types";
 
 // Files in `.changeset` that should not be considered as changesets. We may
 // revisit this if it becomes difficult to maintain the common list of files.
-const ignoredMdFiles = ["README.md", "AGENTS.md", "CLAUDE.md", "GEMINI.md"];
+const ignoredMdFiles = [/^README\.md$/i, "AGENTS.md", "CLAUDE.md", "GEMINI.md"];
 
 async function filterChangesetsSinceRef(
   changesets: Array<string>,
@@ -51,7 +51,9 @@ export async function readChangesets(
     (file) =>
       !file.startsWith(".") &&
       file.endsWith(".md") &&
-      !ignoredMdFiles.includes(file),
+      !ignoredMdFiles.some((pattern) =>
+        typeof pattern === "string" ? pattern === file : pattern.test(file),
+      ),
   );
 
   const changesetContents = changesets.map(async (file) => {

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -4,6 +4,10 @@ import * as git from "@changesets/git";
 import { parseChangesetFile } from "@changesets/parse";
 import type { NewChangeset } from "@changesets/types";
 
+// Files in `.changeset` that should not be considered as changesets. We may
+// revisit this if it becomes difficult to maintain the common list of files.
+const ignoredMdFiles = ["README.md", "AGENTS.md", "CLAUDE.md", "GEMINI.md"];
+
 async function filterChangesetsSinceRef(
   changesets: Array<string>,
   changesetBase: string,
@@ -47,7 +51,7 @@ export async function readChangesets(
     (file) =>
       !file.startsWith(".") &&
       file.endsWith(".md") &&
-      !/^README\.md$/i.test(file),
+      !ignoredMdFiles.includes(file),
   );
 
   const changesetContents = changesets.map(async (file) => {


### PR DESCRIPTION
closes #1906
supersedes and closes #1912

As mentioned in #1906, we hardcode the common list of files to ignore for now. We can likely expand on this non-breakingly later.