### PR TITLE
Update dependabot group to exclude major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,14 @@ updates:
     groups:
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - minor
+          - patch
       development-dependencies:
         dependency-type: "development"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Grouped updates no longer include major bumps, so majors come in individual PRs that we can address respectively. Dependabot doesn't support a proper way to handle v0 bumps, so it'll still include v0 minors together, but I think it's ok for now.

If we merge this now, we may get a barrage of dependabot PRs because we have some deps majors behind. This shouldn't be a problem once we merge next to main though as deps there are up to date.

I think this might be the final dependabot config and we can copy to other repos.