### PR TITLE
Support `{commit-short}` in `snapshot.prereleaseTemplate`

### DIFF
--- a/.changeset/eight-ears-study.md
+++ b/.changeset/eight-ears-study.md
@@ -1,0 +1,6 @@
+---
+"@changesets/assemble-release-plan": minor
+"@changesets/cli": minor
+---
+
+Support `{commit-short}` placeholder for the `snapshot.prereleaseTemplate` config, which is a 7 character variant of `{commit}`

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -42,6 +42,7 @@ function getSnapshotSuffix(
 
   const placeholderValues = {
     commit: snapshotParameters.commit,
+    "commit-short": snapshotParameters.commit?.slice(0, 7),
     tag: snapshotParameters.tag,
     timestamp: snapshotRefDate.getTime().toString(),
     datetime: snapshotRefDate

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -105,8 +105,8 @@ You can then run ${c.cyan("changeset version")} again to do a normal release.
     options.snapshot
       ? {
           tag: options.snapshot === true ? undefined : options.snapshot,
-          commit: releaseConfig.snapshot.prereleaseTemplate?.includes(
-            "{commit}",
+          commit: ["{commit}", "{commit-short}"].some((placeholder) =>
+            releaseConfig.snapshot.prereleaseTemplate?.includes(placeholder),
           )
             ? await git.getCurrentCommitId({ cwd })
             : undefined,

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -35,7 +35,9 @@ mockedGit.commit.mockImplementation(async () => true);
 mockedGit.getCommitsThatAddFiles.mockImplementation(async (changesetIds) =>
   changesetIds.map(() => "g1th4sh"),
 );
-mockedGit.getCurrentCommitId.mockImplementation(async () => "abcdef");
+mockedGit.getCurrentCommitId.mockImplementation(
+  async () => "abcdefghijklmnopqrstuvwxyz",
+);
 mockedGit.tag.mockImplementation(async () => true);
 
 const writeChangesets = (changesets: Changeset[], cwd: string) => {
@@ -1790,15 +1792,17 @@ describe("snapshot release", () => {
       // Template-based
       ["{tag}", "test", "0.0.0-test"],
       ["{tag}-{tag}", "test", "0.0.0-test-test"],
-      ["{commit}", true, "0.0.0-abcdef"],
+      ["{commit}", true, "0.0.0-abcdefghijklmnopqrstuvwxyz"],
+      ["{commit-short}", true, "0.0.0-abcdefg"],
       ["{timestamp}", true, "0.0.0-1639354050879"],
       ["{datetime}", true, "0.0.0-20211213000730"],
       // Mixing template and static string
       [
         "{tag}.{timestamp}.{commit}",
         "alpha",
-        "0.0.0-alpha.1639354050879.abcdef",
+        "0.0.0-alpha.1639354050879.abcdefghijklmnopqrstuvwxyz",
       ],
+      ["{tag}.{commit-short}", "alpha", "0.0.0-alpha.abcdefg"],
       ["{datetime}-{tag}", "alpha", "0.0.0-20211213000730-alpha"],
     ])(
       "should customize release correctly based on snapshotPrereleaseTemplate template: %s (tag: '%s')",


### PR DESCRIPTION
close #1635

we could support like `{commit:7}` similar to [rollup](https://rollupjs.org/configuration-options/#output-chunkfilenames), but since we're also thinking about a templating format for changelogs, i opt with `commit-short` for now.