### PR TITLE
Preserve package.json formatting when update

### DIFF
--- a/.changeset/eager-peas-hide.md
+++ b/.changeset/eager-peas-hide.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": minor
+---
+
+Preserve the existing formatting of `package.json` when updating version and dependency ranges

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -20,7 +20,7 @@
     "@changesets/should-skip-package": "workspace:^",
     "@changesets/types": "workspace:^",
     "import-meta-resolve": "^4.2.0",
-    "json-cst": "^1.2.0",
+    "jsonc-parser": "^3.3.1",
     "semver": "^7.8.0"
   },
   "devDependencies": {

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -19,8 +19,8 @@
     "@changesets/git": "workspace:^",
     "@changesets/should-skip-package": "workspace:^",
     "@changesets/types": "workspace:^",
-    "detect-indent": "^7.0.2",
     "import-meta-resolve": "^4.2.0",
+    "json-cst": "^1.2.0",
     "semver": "^7.8.0"
   },
   "devDependencies": {

--- a/packages/apply-release-plan/src/edit-json.test.ts
+++ b/packages/apply-release-plan/src/edit-json.test.ts
@@ -88,3 +88,20 @@ it("throws when a key path does not exist", () => {
     ]);
   }).toThrow('Key path "version" not found in JSON');
 });
+
+it("throws on malformed JSON", () => {
+  const jsons = [`{{{`, ``, `{//comment\n"version":"1.0.0"}`];
+
+  expect.assertions(jsons.length);
+
+  for (const json of jsons) {
+    expect(() => {
+      editJson(json, [
+        {
+          keys: ["version"],
+          value: "2.0.0",
+        },
+      ]);
+    }).toThrow(/Failed to parse JSON/);
+  }
+});

--- a/packages/apply-release-plan/src/edit-json.test.ts
+++ b/packages/apply-release-plan/src/edit-json.test.ts
@@ -63,6 +63,19 @@ it("preserves formatting", () => {
   );
 });
 
+it("preserves bizarre formatting", () => {
+  const json = `{\n\t\n\n\n"a"\n:\t\t\n{"b":{"c":"^1.0.0"}}\n\n\n,  \t  \n\t"name":"pkg-a"\n\n\n\n\n}\t\t\t\t`;
+
+  const result = editJson(json, [
+    {
+      keys: ["a", "b", "c"],
+      value: "^2.0.0",
+    },
+  ]);
+
+  expect(result).toEqual(json.replace(`"^1.0.0"`, `"^2.0.0"`));
+});
+
 it("throws when a key path does not exist", () => {
   const json = `{"name":"pkg-a"}`;
 

--- a/packages/apply-release-plan/src/edit-json.test.ts
+++ b/packages/apply-release-plan/src/edit-json.test.ts
@@ -1,0 +1,58 @@
+import { expect, it } from "vitest";
+import { editJson } from "./edit-json.ts";
+
+it("updates a direct value", () => {
+  const json = `{"name":"pkg-a","version":"1.0.0"}`;
+
+  const result = editJson(json, [
+    {
+      keys: ["version"],
+      value: "^2.0.0",
+    },
+  ]);
+
+  expect(result).toMatchInlineSnapshot(`"{"name":"pkg-a","version":"^2.0.0"}"`);
+});
+
+it("updates a nested value", () => {
+  const json = `{"name":"pkg-a","version":"1.0.0","dependencies":{"pkg-b":"^1.0.0"}}`;
+
+  const result = editJson(json, [
+    {
+      keys: ["dependencies", "pkg-b"],
+      value: "^2.0.0",
+    },
+  ]);
+
+  expect(result).toMatchInlineSnapshot(
+    `"{"name":"pkg-a","version":"1.0.0","dependencies":{"pkg-b":"^2.0.0"}}"`,
+  );
+});
+
+it("preserves formatting", () => {
+  const json = ` {"name" :"pkg-a" ,"version":"1.0.0"} `;
+
+  const result = editJson(json, [
+    {
+      keys: ["version"],
+      value: "^2.0.0",
+    },
+  ]);
+
+  expect(result).toMatchInlineSnapshot(
+    `" {"name" :"pkg-a" ,"version":"^2.0.0"} "`,
+  );
+});
+
+it("throws when a key path does not exist", () => {
+  const json = `{"name":"pkg-a"}`;
+
+  expect(() => {
+    editJson(json, [
+      {
+        keys: ["version"],
+        value: "1.1.0",
+      },
+    ]);
+  }).toThrow('Key path "version" not found in JSON');
+});

--- a/packages/apply-release-plan/src/edit-json.test.ts
+++ b/packages/apply-release-plan/src/edit-json.test.ts
@@ -29,6 +29,25 @@ it("updates a nested value", () => {
   );
 });
 
+it("updates a multiple values", () => {
+  const json = `{"name":"pkg-a","version":"1.0.0","dependencies":{"pkg-b":"^1.0.0"}}`;
+
+  const result = editJson(json, [
+    {
+      keys: ["version"],
+      value: "2.0.0-longer-than-before.0",
+    },
+    {
+      keys: ["dependencies", "pkg-b"],
+      value: "^2.0.0",
+    },
+  ]);
+
+  expect(result).toMatchInlineSnapshot(
+    `"{"name":"pkg-a","version":"2.0.0-longer-than-before.0","dependencies":{"pkg-b":"^2.0.0"}}"`,
+  );
+});
+
 it("preserves formatting", () => {
   const json = ` {"name" :"pkg-a" ,"version":"1.0.0"} `;
 

--- a/packages/apply-release-plan/src/edit-json.ts
+++ b/packages/apply-release-plan/src/edit-json.ts
@@ -15,13 +15,21 @@ export function editJson(
 ): string {
   const parsed = parse(json);
 
+  const nodesToUpdate: { node: CstValueNode; value: unknown }[] = [];
   for (const op of operations) {
     const valueNode = getValueNode(parsed.root, op.keys);
     if (!valueNode) {
       throw new Error(`Key path "${op.keys.join(".")}" not found in JSON`);
     }
-    const { start, end } = valueNode.range;
-    json = json.slice(0, start) + JSON.stringify(op.value) + json.slice(end);
+    nodesToUpdate.push({ node: valueNode, value: op.value });
+  }
+
+  // Update nodes in reverse order to avoid altering offsets of subsequent runs
+  nodesToUpdate.sort((a, b) => b.node.range.start - a.node.range.start);
+  for (const update of nodesToUpdate) {
+    const { start, end } = update.node.range;
+    json =
+      json.slice(0, start) + JSON.stringify(update.value) + json.slice(end);
   }
 
   return json;

--- a/packages/apply-release-plan/src/edit-json.ts
+++ b/packages/apply-release-plan/src/edit-json.ts
@@ -1,4 +1,11 @@
-import { parse, type CstValueNode } from "json-cst";
+import {
+  applyEdits,
+  parseTree,
+  printParseErrorCode,
+  type EditResult,
+  type Node,
+  type ParseError,
+} from "jsonc-parser";
 
 export interface EditJsonOperation {
   keys: string[];
@@ -13,35 +20,49 @@ export function editJson(
   json: string,
   operations: EditJsonOperation[],
 ): string {
-  const parsed = parse(json);
+  const errors: ParseError[] = [];
+  const parsed = parseTree(json, errors, {
+    allowEmptyContent: false,
+    allowTrailingComma: false,
+    disallowComments: true,
+  });
 
-  const nodesToUpdate = operations.map((op) => {
-    const valueNode = getValueNode(parsed.root, op.keys);
+  if (errors.length > 0 || !parsed) {
+    // Since the first error could cause subsequent errors, we only report the first one
+    const error = errors[0];
+    throw new Error(
+      `Failed to parse JSON at offset ${error.offset}: ${printParseErrorCode(error.error)}`,
+    );
+  }
+
+  const edits: EditResult = operations.map((op) => {
+    const valueNode = getValueNode(parsed, op.keys);
     if (!valueNode) {
       throw new Error(`Key path "${op.keys.join(".")}" not found in JSON`);
     }
-    return { node: valueNode, value: op.value };
+    return {
+      content: JSON.stringify(op.value),
+      offset: valueNode.offset,
+      length: valueNode.length,
+    };
   });
 
-  // Update nodes in reverse order to avoid altering offsets of subsequent runs
-  nodesToUpdate.sort((a, b) => b.node.range.start - a.node.range.start);
-
-  for (const update of nodesToUpdate) {
-    const { start, end } = update.node.range;
-    json =
-      json.slice(0, start) + JSON.stringify(update.value) + json.slice(end);
-  }
-
-  return json;
+  return applyEdits(json, edits);
 }
 
-function getValueNode(root: CstValueNode, keys: string[]): CstValueNode | null {
+function getValueNode(root: Node, keys: string[]): Node | null {
   let node = root;
   for (const key of keys) {
-    if (node.kind !== "object") return null;
-    const property = node.children.find((child) => child.key === key);
+    if (node.type !== "object") return null;
+    const property = node.children?.find(
+      (child) =>
+        child.type === "property" &&
+        child.children?.length === 2 &&
+        child.children[0].value === key,
+    );
     if (!property) return null;
-    node = property.valueNode;
+    // We've checked above that `children[1]` exists
+    node = property.children![1];
   }
   return node;
 }

--- a/packages/apply-release-plan/src/edit-json.ts
+++ b/packages/apply-release-plan/src/edit-json.ts
@@ -15,17 +15,17 @@ export function editJson(
 ): string {
   const parsed = parse(json);
 
-  const nodesToUpdate: { node: CstValueNode; value: unknown }[] = [];
-  for (const op of operations) {
+  const nodesToUpdate = operations.map((op) => {
     const valueNode = getValueNode(parsed.root, op.keys);
     if (!valueNode) {
       throw new Error(`Key path "${op.keys.join(".")}" not found in JSON`);
     }
-    nodesToUpdate.push({ node: valueNode, value: op.value });
-  }
+    return { node: valueNode, value: op.value };
+  });
 
   // Update nodes in reverse order to avoid altering offsets of subsequent runs
   nodesToUpdate.sort((a, b) => b.node.range.start - a.node.range.start);
+
   for (const update of nodesToUpdate) {
     const { start, end } = update.node.range;
     json =

--- a/packages/apply-release-plan/src/edit-json.ts
+++ b/packages/apply-release-plan/src/edit-json.ts
@@ -27,7 +27,10 @@ export function editJson(
     disallowComments: true,
   });
 
-  if (errors.length > 0 || !parsed) {
+  if (!parsed) {
+    throw new Error("Failed to parse JSON");
+  }
+  if (errors.length > 0) {
     // Since the first error could cause subsequent errors, we only report the first one
     const error = errors[0];
     throw new Error(

--- a/packages/apply-release-plan/src/edit-json.ts
+++ b/packages/apply-release-plan/src/edit-json.ts
@@ -1,0 +1,39 @@
+import { parse, type CstValueNode } from "json-cst";
+
+export interface EditJsonOperation {
+  keys: string[];
+  value: unknown;
+}
+
+/**
+ * A simple JSON editing utility that preserves formatting. They specified operation keys
+ * must exist in the JSON for this implementation.
+ */
+export function editJson(
+  json: string,
+  operations: EditJsonOperation[],
+): string {
+  const parsed = parse(json);
+
+  for (const op of operations) {
+    const valueNode = getValueNode(parsed.root, op.keys);
+    if (!valueNode) {
+      throw new Error(`Key path "${op.keys.join(".")}" not found in JSON`);
+    }
+    const { start, end } = valueNode.range;
+    json = json.slice(0, start) + JSON.stringify(op.value) + json.slice(end);
+  }
+
+  return json;
+}
+
+function getValueNode(root: CstValueNode, keys: string[]): CstValueNode | null {
+  let node = root;
+  for (const key of keys) {
+    if (node.kind !== "object") return null;
+    const property = node.children.find((child) => child.key === key);
+    if (!property) return null;
+    node = property.valueNode;
+  }
+  return node;
+}

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -212,7 +212,7 @@ describe("apply release plan", () => {
             "package.json": JSON.stringify({
               name: "pkg-a",
               version: "1.0.0",
-            }),
+            }, null, 2),
           },
           releasePlan.getReleasePlan(),
           releasePlan.config,
@@ -235,7 +235,7 @@ describe("apply release plan", () => {
               JSON.stringify({
                 name: "pkg-a",
                 version: "1.0.0",
-              }) + "\n",
+              }, null, 2) + "\n",
           },
           releasePlan.getReleasePlan(),
           releasePlan.config,

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -209,10 +209,14 @@ describe("apply release plan", () => {
         const releasePlan = new FakeReleasePlan();
         const { changedFiles } = await testSetup(
           {
-            "package.json": JSON.stringify({
-              name: "pkg-a",
-              version: "1.0.0",
-            }, null, 2),
+            "package.json": JSON.stringify(
+              {
+                name: "pkg-a",
+                version: "1.0.0",
+              },
+              null,
+              2,
+            ),
           },
           releasePlan.getReleasePlan(),
           releasePlan.config,
@@ -232,10 +236,14 @@ describe("apply release plan", () => {
         const { changedFiles } = await testSetup(
           {
             "package.json":
-              JSON.stringify({
-                name: "pkg-a",
-                version: "1.0.0",
-              }, null, 2) + "\n",
+              JSON.stringify(
+                {
+                  name: "pkg-a",
+                  version: "1.0.0",
+                },
+                null,
+                2,
+              ) + "\n",
           },
           releasePlan.getReleasePlan(),
           releasePlan.config,

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -20,8 +20,10 @@ import type {
 import { resolve } from "import-meta-resolve";
 import { editJson } from "./edit-json.ts";
 import { getChangelogEntry } from "./get-changelog-entry.ts";
-import type { ModCompWithPackageAndChangelog } from "./types.ts";
-import { versionPackage } from "./version-package.ts";
+import {
+  versionPackage,
+  type ModCompWithPackageAndChangelog,
+} from "./version-package.ts";
 
 function importResolveFromDir(specifier: string, dir: string) {
   return resolve(specifier, pathToFileURL(path.join(dir, "x.mjs")).toString());

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -17,9 +17,10 @@ import type {
   NewChangeset,
   ReleasePlan,
 } from "@changesets/types";
-import detectIndent from "detect-indent";
 import { resolve } from "import-meta-resolve";
+import { editJson } from "./edit-json.ts";
 import { getChangelogEntry } from "./get-changelog-entry.ts";
+import type { ModCompWithPackageAndChangelog } from "./types.ts";
 import { versionPackage } from "./version-package.ts";
 
 function importResolveFromDir(specifier: string, dir: string) {
@@ -136,11 +137,13 @@ export async function applyReleasePlan(
 
   const filesToFormat: string[] = [];
   for (const release of finalisedRelease) {
-    const { changelog, packageJson, dir, name } = release;
+    const { changelog, pkgJsonEdits, dir, name } = release;
 
-    const pkgJSONPath = path.resolve(dir, "package.json");
-    await updatePackageJson(pkgJSONPath, packageJson);
-    touchedFiles.push(pkgJSONPath);
+    const pkgJsonPath = path.resolve(dir, "package.json");
+    const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
+    const pkgUpdated = editJson(pkgRaw, pkgJsonEdits);
+    await fs.writeFile(pkgJsonPath, pkgUpdated);
+    touchedFiles.push(pkgJsonPath);
 
     if (changelog && changelog.length > 0) {
       const changelogPath = path.resolve(dir, "CHANGELOG.md");
@@ -200,7 +203,7 @@ async function getNewChangelogEntry(
   config: Config,
   cwd: string,
   contextDir: string,
-) {
+): Promise<ModCompWithPackageAndChangelog[]> {
   if (!config.changelog) {
     return Promise.resolve(
       releasesWithPackage.map((release) => ({
@@ -327,18 +330,6 @@ async function updateChangelog(
   }
 
   await fs.writeFile(changelogPath, newChangelog);
-}
-
-async function updatePackageJson(
-  pkgJsonPath: string,
-  pkgJson: any,
-): Promise<void> {
-  const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
-  const indent = detectIndent(pkgRaw).indent || "  ";
-  const stringified =
-    JSON.stringify(pkgJson, null, indent) + (pkgRaw.endsWith("\n") ? "\n" : "");
-
-  return fs.writeFile(pkgJsonPath, stringified);
 }
 
 /** @deprecated Use named export `applyReleasePlan` instead */

--- a/packages/apply-release-plan/src/types.ts
+++ b/packages/apply-release-plan/src/types.ts
@@ -1,5 +1,0 @@
-import type { ModCompWithPackage } from "@changesets/types";
-
-export type ModCompWithPackageAndChangelog = ModCompWithPackage & {
-  changelog: string | null;
-};

--- a/packages/apply-release-plan/src/types.ts
+++ b/packages/apply-release-plan/src/types.ts
@@ -1,0 +1,5 @@
+import type { ModCompWithPackage } from "@changesets/types";
+
+export type ModCompWithPackageAndChangelog = ModCompWithPackage & {
+  changelog: string | null;
+};

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -1,9 +1,8 @@
-import type { VersionType } from "@changesets/types";
+import type { ModCompWithPackage, VersionType } from "@changesets/types";
 import Range from "semver/classes/range.js";
 import semverPrerelease from "semver/functions/prerelease.js";
 import validRange from "semver/ranges/valid.js";
 import type { EditJsonOperation } from "./edit-json.ts";
-import type { ModCompWithPackageAndChangelog } from "./types.ts";
 import { shouldUpdateDependencyBasedOnConfig } from "./utils.ts";
 
 const DEPENDENCY_TYPES = [
@@ -12,6 +11,10 @@ const DEPENDENCY_TYPES = [
   "peerDependencies",
   "optionalDependencies",
 ] as const;
+
+export type ModCompWithPackageAndChangelog = ModCompWithPackage & {
+  changelog: string | null;
+};
 
 type ModCompWithPackageAndChangelogAndEdits = ModCompWithPackageAndChangelog & {
   pkgJsonEdits: EditJsonOperation[];

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -1,11 +1,9 @@
-import type {
-  ComprehensiveRelease,
-  PackageJSON,
-  VersionType,
-} from "@changesets/types";
+import type { VersionType } from "@changesets/types";
 import Range from "semver/classes/range.js";
 import semverPrerelease from "semver/functions/prerelease.js";
 import validRange from "semver/ranges/valid.js";
+import type { EditJsonOperation } from "./edit-json.ts";
+import type { ModCompWithPackageAndChangelog } from "./types.ts";
 import { shouldUpdateDependencyBasedOnConfig } from "./utils.ts";
 
 const DEPENDENCY_TYPES = [
@@ -15,12 +13,12 @@ const DEPENDENCY_TYPES = [
   "optionalDependencies",
 ] as const;
 
+type ModCompWithPackageAndChangelogAndEdits = ModCompWithPackageAndChangelog & {
+  pkgJsonEdits: EditJsonOperation[];
+};
+
 export function versionPackage(
-  release: ComprehensiveRelease & {
-    changelog: string | null;
-    packageJson: PackageJSON;
-    dir: string;
-  },
+  release: ModCompWithPackageAndChangelog,
   versionsToUpdate: Array<{
     name: string;
     version: string;
@@ -41,10 +39,11 @@ export function versionPackage(
     bumpVersionsWithWorkspaceProtocolOnly?: boolean;
     snapshot?: string | boolean | undefined;
   },
-) {
+): ModCompWithPackageAndChangelogAndEdits {
+  const pkgJsonEdits: EditJsonOperation[] = [];
   const { newVersion, packageJson } = release;
 
-  packageJson.version = newVersion;
+  pkgJsonEdits.push({ keys: ["version"], value: newVersion });
 
   for (const depType of DEPENDENCY_TYPES) {
     const deps = packageJson[depType];
@@ -109,13 +108,13 @@ export function versionPackage(
             ? version
             : `${getVersionRangeType(depCurrentVersion)}${version}`;
           if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
-          deps[name] = newNewRange;
+          pkgJsonEdits.push({ keys: [depType, name], value: newNewRange });
         }
       }
     }
   }
 
-  return { ...release, packageJson };
+  return { ...release, pkgJsonEdits };
 }
 
 function getVersionRangeType(

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -108,7 +108,9 @@ describe("version", () => {
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8",
       ),
-    ).toMatchInlineSnapshot(`"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.1.0"}}"`);
+    ).toMatchInlineSnapshot(
+      `"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.1.0"}}"`,
+    );
 
     expect(
       await fs.readFile(
@@ -218,7 +220,9 @@ describe("version", () => {
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8",
       ),
-    ).toMatchInlineSnapshot(`"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.0.0"}}"`);
+    ).toMatchInlineSnapshot(
+      `"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.0.0"}}"`,
+    );
 
     expect(
       await fs.readFile(

--- a/packages/release-utils/src/run.test.ts
+++ b/packages/release-utils/src/run.test.ts
@@ -108,27 +108,14 @@ describe("version", () => {
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8",
       ),
-    ).toMatchInlineSnapshot(`
-      "{
-        "name": "pkg-a",
-        "version": "1.1.0",
-        "dependencies": {
-          "pkg-b": "1.1.0"
-        }
-      }"
-    `);
+    ).toMatchInlineSnapshot(`"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.1.0"}}"`);
 
     expect(
       await fs.readFile(
         path.join(cwd, "packages", "pkg-b", "package.json"),
         "utf8",
       ),
-    ).toMatchInlineSnapshot(`
-      "{
-        "name": "pkg-b",
-        "version": "1.1.0"
-      }"
-    `);
+    ).toMatchInlineSnapshot(`"{"name":"pkg-b","version":"1.1.0"}"`);
     expect(
       await fs.readFile(
         path.join(cwd, "packages", "pkg-a", "CHANGELOG.md"),
@@ -231,15 +218,7 @@ describe("version", () => {
         path.join(cwd, "packages", "pkg-a", "package.json"),
         "utf8",
       ),
-    ).toMatchInlineSnapshot(`
-      "{
-        "name": "pkg-a",
-        "version": "1.1.0",
-        "dependencies": {
-          "pkg-b": "1.0.0"
-        }
-      }"
-    `);
+    ).toMatchInlineSnapshot(`"{"name":"pkg-a","version":"1.1.0","dependencies":{"pkg-b":"1.0.0"}}"`);
 
     expect(
       await fs.readFile(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,9 @@ importers:
       import-meta-resolve:
         specifier: ^4.2.0
         version: 4.2.0
-      json-cst:
-        specifier: ^1.2.0
-        version: 1.2.0
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -1439,13 +1439,6 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
-  json-cst@1.2.0:
-    resolution: {integrity: sha512-liC8jqILo2mZjKs/c/zDknohoLo2FocQH5ZGyPZzPNNHSC/LarVq42R4WA58lqPdH9ssP/JKArp6SZ6aP7vyhA==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-
-  json-lexer@1.2.0:
-    resolution: {integrity: sha512-7otpx5UPFeSELoF8nkZPHCfywg86wOsJV0WNOaysuO7mfWj1QFp2vlqESRRCeJKBXr+tqDgHh4HgqUFKTLcifQ==}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -1454,6 +1447,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2819,17 +2815,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
-  json-cst@1.2.0:
-    dependencies:
-      json-lexer: 1.2.0
-
-  json-lexer@1.2.0: {}
-
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
+
+  jsonc-parser@3.3.1: {}
 
   keyv@4.5.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,12 +90,12 @@ importers:
       '@changesets/types':
         specifier: workspace:^
         version: link:../types
-      detect-indent:
-        specifier: ^7.0.2
-        version: 7.0.2
       import-meta-resolve:
         specifier: ^4.2.0
         version: 4.2.0
+      json-cst:
+        specifier: ^1.2.0
+        version: 1.2.0
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -1438,6 +1438,13 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-cst@1.2.0:
+    resolution: {integrity: sha512-liC8jqILo2mZjKs/c/zDknohoLo2FocQH5ZGyPZzPNNHSC/LarVq42R4WA58lqPdH9ssP/JKArp6SZ6aP7vyhA==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  json-lexer@1.2.0:
+    resolution: {integrity: sha512-7otpx5UPFeSELoF8nkZPHCfywg86wOsJV0WNOaysuO7mfWj1QFp2vlqESRRCeJKBXr+tqDgHh4HgqUFKTLcifQ==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2811,6 +2818,12 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-cst@1.2.0:
+    dependencies:
+      json-lexer: 1.2.0
+
+  json-lexer@1.2.0: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
fix #1434

Parse the package.json and edit it by the AST range to preserve formatting. It uses `jsonc-parser` to parse and apply edits.