### PR TITLE
Show private in changeset add

### DIFF
--- a/.changeset/wild-drinks-hang.md
+++ b/.changeset/wild-drinks-hang.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Show if a package is private when selecting packages in `changeset add`

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -447,8 +447,8 @@ describe("Add command", () => {
     expect(mockedUtils.askMultiselect).toHaveBeenCalledWith(
       expect.stringContaining("Which packages"),
       {
-        "changed packages": [{ value: "pkg-b" }],
-        "unchanged packages": [{ value: "pkg-a" }],
+        "changed packages": [{ label: "pkg-b", value: "pkg-b" }],
+        "unchanged packages": [{ label: "pkg-a", value: "pkg-a" }],
       },
       { required: true },
     );
@@ -493,7 +493,10 @@ describe("Add command", () => {
     await addChangeset({ cwd });
     const choices =
       mockedUtils.askMultiselect.mock.calls[0][1]["unchanged packages"];
-    expect(choices).toMatchObject([{ value: "pkg-a" }, { value: "pkg-c" }]);
+    expect(choices).toMatchObject([
+      { label: "pkg-a", value: "pkg-a" },
+      { label: "pkg-c", value: "pkg-c" },
+    ]);
   });
 
   it("should not include private packages without a version in the prompt", async () => {
@@ -523,7 +526,10 @@ describe("Add command", () => {
     await addChangeset({ cwd });
     const choices =
       mockedUtils.askMultiselect.mock.calls[0][1]["unchanged packages"];
-    expect(choices).toStrictEqual([{ value: "pkg-a" }, { value: "pkg-c" }]);
+    expect(choices).toStrictEqual([
+      { label: "pkg-a", value: "pkg-a" },
+      { label: "pkg-c", value: "pkg-c" },
+    ]);
   });
 
   it("should not include private packages with a version in the prompt if private packages are configured to be not versionable", async () => {
@@ -560,7 +566,10 @@ describe("Add command", () => {
     await addChangeset({ cwd });
     const choices =
       mockedUtils.askMultiselect.mock.calls[0][1]["unchanged packages"];
-    expect(choices).toStrictEqual([{ value: "pkg-a" }, { value: "pkg-c" }]);
+    expect(choices).toStrictEqual([
+      { label: "pkg-a", value: "pkg-a" },
+      { label: "pkg-c", value: "pkg-c" },
+    ]);
   });
 
   it("should exit with an error when there are no versionable packages in a single-package repo", async () => {

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -1,7 +1,7 @@
 import c from "@changesets/color";
-import { ExitError } from "@changesets/errors";
+import { ExitError, InternalError } from "@changesets/errors";
 import type { Package, PackageJSON, Release } from "@changesets/types";
-import { log } from "@clack/prompts";
+import { log, type Option } from "@clack/prompts";
 import semverLt from "semver/functions/lt.js";
 import { askWithEditor } from "../../utils/askWithEditor.ts";
 import * as cli from "../../utils/cli-utilities.ts";
@@ -27,43 +27,43 @@ async function getPackagesToRelease(
   changedPackages: Array<string>,
   allPackages: Array<Package>,
 ): Promise<string[]> {
-  if (allPackages.length > 1) {
-    const unchangedPackagesNames = allPackages
-      .map(({ packageJson }) => packageJson.name)
-      .filter((name) => !changedPackages.includes(name));
-
-    const defaultChoiceList = Object.fromEntries(
-      (
-        [
-          [
-            "changed packages",
-            changedPackages
-              .toSorted((a, b) => a.localeCompare(b))
-              .map((value) => ({ value })),
-          ],
-          [
-            "unchanged packages",
-            unchangedPackagesNames
-              .toSorted((a, b) => a.localeCompare(b))
-              .map((value) => ({ value })),
-          ],
-        ] as const
-      ).filter(([, choices]) => choices.length !== 0),
-    );
-
-    const packagesToRelease = await cli.askMultiselect(
-      // TODO: Make this wording better
-      "Which packages were affected by the changes you made?",
-      defaultChoiceList,
-      { required: true },
-    );
-
-    return packagesToRelease.filter(
-      (pkgName) =>
-        pkgName !== "changed packages" && pkgName !== "unchanged packages",
+  if (allPackages.length <= 1) {
+    throw new InternalError(
+      "getPackagesToRelease should not be called if there is only one package",
     );
   }
-  return [allPackages[0].packageJson.name];
+
+  const allSortedPackages = allPackages.toSorted((a, b) =>
+    a.packageJson.name.localeCompare(b.packageJson.name),
+  );
+  const changedPackagesList: Option<string>[] = [];
+  const unchangedPackagesList: Option<string>[] = [];
+
+  for (const { packageJson } of allSortedPackages) {
+    const pkgName = packageJson.name;
+    const list = changedPackages.includes(pkgName)
+      ? changedPackagesList
+      : unchangedPackagesList;
+    list.push({
+      label: pkgName + (packageJson.private ? " (private)" : ""),
+      value: pkgName,
+    });
+  }
+
+  const multiselectValues: cli.MultiselectOptions<string> = {};
+  if (changedPackagesList.length > 0) {
+    multiselectValues["changed packages"] = changedPackagesList;
+  }
+  if (unchangedPackagesList.length > 0) {
+    multiselectValues["unchanged packages"] = unchangedPackagesList;
+  }
+
+  return await cli.askMultiselect(
+    // TODO: Make this wording better
+    "Which packages were affected by the changes you made?",
+    multiselectValues,
+    { required: true },
+  );
 }
 
 function getPkgJsonsByName(packages: Array<Package>) {

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -24,7 +24,7 @@ function importantWarning(message: string): void {
   note(message.trim(), c.yellow("IMPORTANT"), { format: c.white });
 }
 
-type MultiselectOptions<Value> = Record<string, Option<Value>[]>;
+export type MultiselectOptions<Value> = Record<string, Option<Value>[]>;
 
 async function askMultiselect<Value>(
   message: string,


### PR DESCRIPTION
close #1706

I kinda like the idea that when selecting packages, it'd show if it's private so they know if the changeset wouldn't trigger a publish of it. I'm also open to discuss if we really need this.

I also went ahead and refactored the packages question function a bit.

<img width="418" height="208" alt="image" src="https://github.com/user-attachments/assets/fafca39b-6dbf-4127-869e-c9b8c36b05e4" />
