### PR TITLE
Change allowed publish pattern to `maintenance/v*` given rulesets behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
     branches:
       - main
       - next
-      - "maintenance/v[0-9]+"
+      # merge group rulesets don't allow wildcards so in settings each maintenance branch needs to be added separately
+      - "maintenance/v*" # branch rulesets don't support v[0-9]+
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - next
-      - "maintenance/v[0-9]+"
+      - "maintenance/v*" # branch rulesets don't support v[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I tested this with both patterns and a force push was only rejected with `maintenance/v*`