### PR TITLE
feat(changelog-github)!: add composeReleaseLine, remove disableThanks

### DIFF
--- a/.changeset/changelog-github-compose.md
+++ b/.changeset/changelog-github-compose.md
@@ -1,0 +1,9 @@
+---
+"@changesets/changelog-github": major
+---
+
+Add `composeReleaseLine` and remove the `disableThanks` option.
+
+Point `changelog` at a small local module and compose each changelog line in JS from `summary`, `pr`, `commit`, `authors[]`, and the `linkRefs`/`linkHints` helpers, with an optional `separator` override (e.g. for compact output). Default output is unchanged.
+
+Migration: replace `disableThanks: true` with a `composeReleaseLine` callback that omits the `Thanks ...!` segment. See `docs/config-file-options.md`.

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -162,7 +162,75 @@ You would specify our github changelog generator with:
 }
 ```
 
-If you want to disable thank you messages, add `"disableThanks": true` to the options.
+#### Custom line format with `composeReleaseLine`
+
+For full control over each changelog line, point `changelog` at a small local module and compose the line in JavaScript with `composeReleaseLine`:
+
+```js
+// .changeset/changelog.js
+import { composeReleaseLine } from "@changesets/changelog-github";
+
+export const getReleaseLine = composeReleaseLine(
+  ({ summary, pr, commit, authors, linkRefs, linkHints }) => {
+    // return a string, or { separator, line } to override the entry separator
+  },
+);
+
+export { getDependencyReleaseLine } from "@changesets/changelog-github";
+```
+
+```json
+{
+  "changelog": ["./changelog.js", { "repo": "<org>/<repo>" }]
+}
+```
+
+The callback receives:
+
+| Field       | Value                                                             |
+| ----------- | ----------------------------------------------------------------- |
+| `summary`   | the changeset summary's first line, raw (not linkified)           |
+| `pr`        | `[#123](url)`, or `""` when there is none                         |
+| `commit`    | ``[`abc1234`](url)``, or `""` when there is none                  |
+| `authors`   | array of `[@user](url)` links; empty when there is no attribution |
+| `linkRefs`  | links every bare `#123` (the default issue autolinking)           |
+| `linkHints` | links only refs inside `(fix #123)`, `(fixes #123)`, `(see #123)` |
+
+Return a string to use the default `\n\n` entry separator, or `{ separator, line }` to override it. Continuation lines of a multi-line summary are always appended below, indented by two spaces and linkified with `linkRefs`.
+
+**Default output** (what you get with no custom module):
+
+```js
+({ summary, pr, commit, authors, linkRefs }) => {
+  const prefix = [
+    pr ? ` ${pr}` : "",
+    commit ? ` ${commit}` : "",
+    authors.length ? ` Thanks ${authors.join(", ")}!` : "",
+  ].join("");
+  return `-${prefix ? `${prefix} -` : ""} ${linkRefs(summary)}`;
+};
+```
+
+**Compact** (reproduces `@svitejs/changesets-changelog-github-compact`, which is unmaintained):
+
+```js
+({ summary, pr, commit, linkHints }) => {
+  const ref = pr || commit;
+  return {
+    separator: "\n",
+    line: `- ${linkHints(summary)}${ref ? ` (${ref})` : ""}`,
+  };
+};
+```
+
+**Without thank-you messages** (replaces the old `disableThanks: true`):
+
+```js
+({ summary, pr, commit, linkRefs }) => {
+  const refs = [pr, commit].filter(Boolean).join(" ");
+  return `-${refs ? ` ${refs} -` : ""} ${linkRefs(summary)}`;
+};
+```
 
 For more details on these functions and information on how to write your own see [changelog-functions](./modifying-changelog-format.md)
 

--- a/packages/changelog-github/src/index.test.ts
+++ b/packages/changelog-github/src/index.test.ts
@@ -1,6 +1,6 @@
 import { parseChangesetFile as parse } from "@changesets/parse";
 import { describe, expect, it, test, vi } from "vitest";
-import changelogFunctions from "./index.ts";
+import changelogFunctions, { composeReleaseLine } from "./index.ts";
 
 const getReleaseLine = changelogFunctions.getReleaseLine;
 
@@ -242,20 +242,163 @@ it("with multiple authors", async () => {
   `);
 });
 
-it("disables thanks if disableThanks is enabled", async () => {
-  const [changeset, releaseType, options] = getChangeset(
-    "author: @Andarist",
-    data.commit,
-  );
-  expect(
-    await getReleaseLine(changeset, releaseType, {
-      ...options,
-      disableThanks: true,
-    }),
-  ).toMatchInlineSnapshot(`
-    "
+describe("composeReleaseLine", () => {
+  const baseChangeset = {
+    id: "x",
+    summary: "fix the thing",
+    releases: [{ name: "pkg", type: "minor" as const }],
+    commit: data.commit,
+  };
 
-    - [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) - something
-    "
-  `);
+  it("passes resolved pieces to the callback", async () => {
+    const seen: any = {};
+    const fn = composeReleaseLine(
+      ({ summary, pr, commit, authors, linkRefs, linkHints }) => {
+        Object.assign(seen, { summary, pr, commit, authors });
+        expect(typeof linkRefs).toBe("function");
+        expect(typeof linkHints).toBe("function");
+        return `- ${summary}`;
+      },
+    );
+    await fn(baseChangeset, "minor", { repo: data.repo });
+    expect(seen.summary).toBe("fix the thing");
+    expect(seen.pr).toBe(
+      "[#1613](https://github.com/emotion-js/emotion/pull/1613)",
+    );
+    expect(seen.commit).toBe(
+      "[`a085003`](https://github.com/emotion-js/emotion/commit/a085003)",
+    );
+    expect(seen.authors).toEqual(["[@Andarist](https://github.com/Andarist)"]);
+  });
+
+  it("uses \\n\\n separator and appends continuation when a string is returned", async () => {
+    const fn = composeReleaseLine(({ summary }) => `- ${summary}`);
+    expect(
+      await fn({ ...baseChangeset, summary: "first\nsecond" }, "minor", {
+        repo: data.repo,
+      }),
+    ).toBe("\n\n- first\n  second");
+  });
+
+  it("lets the callback override the separator (compact)", async () => {
+    const fn = composeReleaseLine(({ summary, pr, linkHints }) => ({
+      separator: "\n",
+      line: `- ${linkHints(summary)} (${pr})`,
+    }));
+    expect(await fn(baseChangeset, "minor", { repo: data.repo })).toBe(
+      "\n- fix the thing ([#1613](https://github.com/emotion-js/emotion/pull/1613))\n",
+    );
+  });
+
+  it("linkHints only links refs inside (fix|fixes|see #n)", async () => {
+    const fn = composeReleaseLine(
+      ({ summary, linkHints }) => `- ${linkHints(summary)}`,
+    );
+    const line = await fn(
+      { ...baseChangeset, summary: "did (fixes #99) and also #1234" },
+      "minor",
+      { repo: data.repo },
+    );
+    expect(line).toContain(
+      "(fixes [#99](https://github.com/emotion-js/emotion/issues/99))",
+    );
+    expect(line).toContain("and also #1234");
+    expect(line).not.toContain("issues/1234");
+  });
+
+  it("authors is empty array when there is no author", async () => {
+    let captured: string[] | undefined;
+    const fn = composeReleaseLine(({ summary, authors }) => {
+      captured = authors;
+      return `- ${summary}`;
+    });
+    await fn(
+      {
+        id: "x",
+        summary: "no author",
+        releases: baseChangeset.releases,
+        commit: undefined,
+      },
+      "minor",
+      { repo: data.repo },
+    );
+    expect(captured).toEqual([]);
+  });
+
+  it("throws when repo is missing", async () => {
+    const fn = composeReleaseLine(({ summary }) => `- ${summary}`);
+    await expect(fn(baseChangeset, "minor", {} as any)).rejects.toThrow(
+      /provide a repo/,
+    );
+  });
+
+  it("overrides the commit link from a `commit:` hint when a PR is also given", async () => {
+    let captured: any;
+    const fn = composeReleaseLine((parts) => {
+      captured = parts;
+      return `- ${parts.summary}`;
+    });
+    await fn(
+      {
+        id: "x",
+        summary: "pr: #1613\ncommit: deadbeef1234\nfix the thing",
+        releases: baseChangeset.releases,
+        commit: undefined,
+      },
+      "minor",
+      { repo: data.repo },
+    );
+    expect(captured.pr).toBe(
+      "[#1613](https://github.com/emotion-js/emotion/pull/1613)",
+    );
+    expect(captured.commit).toBe(
+      "[`deadbee`](https://github.com/emotion-js/emotion/commit/deadbeef1234)",
+    );
+    expect(captured.summary).toBe("fix the thing");
+  });
+});
+
+describe("getDependencyReleaseLine", () => {
+  const fn = changelogFunctions.getDependencyReleaseLine;
+
+  it("throws when repo is missing", async () => {
+    await expect(
+      fn(
+        [{ commit: data.commit } as any],
+        [{ name: "pkg-a", type: "patch", newVersion: "1.0.1" } as any],
+        {} as any,
+      ),
+    ).rejects.toThrow(/provide a repo/);
+  });
+
+  it("returns an empty string when no dependencies were updated", async () => {
+    expect(
+      await fn([{ commit: data.commit } as any], [], { repo: data.repo }),
+    ).toBe("");
+  });
+
+  it("lists updated dependencies under a commit link", async () => {
+    expect(
+      await fn(
+        [{ commit: data.commit } as any],
+        [
+          { name: "pkg-a", type: "patch", newVersion: "1.0.1" } as any,
+          { name: "pkg-b", type: "minor", newVersion: "2.1.0" } as any,
+        ],
+        { repo: data.repo },
+      ),
+    ).toBe(
+      "- Updated dependencies [[`a085003`](https://github.com/emotion-js/emotion/commit/a085003)]:\n  - pkg-a@1.0.1\n  - pkg-b@2.1.0",
+    );
+  });
+
+  it("skips changesets without a commit", async () => {
+    expect(
+      await fn(
+        [{ commit: undefined } as any],
+        [{ name: "pkg-a", type: "patch", newVersion: "1.0.1" } as any],
+        { repo: data.repo },
+      ),
+    ).toBe("- Updated dependencies []:\n  - pkg-a@1.0.1");
+  });
 });

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -17,6 +17,18 @@ function linkifyIssueRefs(
   );
 }
 
+// narrow autolinking (exposed to composers as `linkHints`): only links a ref
+// that sits inside `(fix #123)`, `(fixes #123)`, or `(see #123)`
+function linkifyIssueHints(
+  line: string,
+  { serverUrl, repo }: { serverUrl: string; repo: string },
+): string {
+  return line.replace(
+    /(?<=\( ?(?:fix|fixes|see) )#(\d+)(?= ?\))/g,
+    (_match, issue) => `[#${issue}](${serverUrl}/${repo}/issues/${issue})`,
+  );
+}
+
 async function readEnvFile() {
   const envFile = path.resolve(process.cwd(), ".env");
   let content: string | undefined;
@@ -42,43 +54,48 @@ async function readEnv() {
   return { GITHUB_SERVER_URL };
 }
 
-const changelogFunctions: ChangelogFunctions = {
-  getDependencyReleaseLine: async (
-    changesets,
-    dependenciesUpdated,
-    options,
-  ) => {
-    const repo = options?.repo;
-    if (!repo || typeof repo !== "string") {
-      throw new Error(
-        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
-      );
-    }
-    if (dependenciesUpdated.length === 0) return "";
+export interface ReleaseLineParts {
+  /** First line of the changeset summary, raw (not linkified). */
+  summary: string;
+  /** Markdown PR link, or "" when there is none. */
+  pr: string;
+  /** Markdown commit link, or "" when there is none. */
+  commit: string;
+  /** Markdown author links; empty when there is no attribution. */
+  authors: string[];
+  /** Links every bare `#123` in the given string (the default behavior). */
+  linkRefs: (line: string) => string;
+  /** Links only refs inside `(fix|fixes|see #123)`. */
+  linkHints: (line: string) => string;
+}
 
-    const changesetLink = `- Updated dependencies [${(
-      await Promise.all(
-        changesets.map(async (cs) => {
-          if (cs.commit) {
-            const { links } = await getInfo({
-              repo,
-              commit: cs.commit,
-            });
-            return links.commit;
-          }
-        }),
-      )
-    )
-      .filter((_) => _)
-      .join(", ")}]:`;
+export type ReleaseLineResult = string | { separator?: string; line: string };
 
-    const updatedDepenenciesList = dependenciesUpdated.map(
-      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
-    );
+export type ReleaseLineComposer = (
+  parts: ReleaseLineParts,
+) => ReleaseLineResult;
 
-    return [changesetLink, ...updatedDepenenciesList].join("\n");
-  },
-  getReleaseLine: async (changeset, type, options) => {
+// Reproduces the historical default line, byte-for-byte:
+//   - {pr} {commit} Thanks {authors}! - {summary}
+const defaultReleaseLine: ReleaseLineComposer = ({
+  summary,
+  pr,
+  commit,
+  authors,
+  linkRefs,
+}) => {
+  const prefix = [
+    pr ? ` ${pr}` : "",
+    commit ? ` ${commit}` : "",
+    authors.length ? ` Thanks ${authors.join(", ")}!` : "",
+  ].join("");
+  return `-${prefix ? `${prefix} -` : ""} ${linkRefs(summary)}`;
+};
+
+export function composeReleaseLine(
+  compose: ReleaseLineComposer,
+): ChangelogFunctions["getReleaseLine"] {
+  return async (changeset, _type, options) => {
     const repo = options?.repo;
     if (!repo || typeof repo !== "string") {
       throw new Error(
@@ -129,49 +146,82 @@ const changelogFunctions: ChangelogFunctions = {
       }
       const commitToFetchFrom = commitFromSummary || changeset.commit;
       if (commitToFetchFrom) {
-        const { links } = await getInfo({
-          repo,
-          commit: commitToFetchFrom,
-        });
+        const { links } = await getInfo({ repo, commit: commitToFetchFrom });
         return links;
       }
-      return {
-        commit: null,
-        pull: null,
-        user: null,
-      };
+      return { commit: null, pull: null, user: null };
     })();
 
-    const users = options.disableThanks
-      ? null
-      : usersFromSummary.length
-        ? usersFromSummary
-            .map(
-              (userFromSummary) =>
-                `[@${userFromSummary}](${GITHUB_SERVER_URL}/${userFromSummary})`,
-            )
-            .join(", ")
-        : links.user;
+    const linkOpts = { serverUrl: GITHUB_SERVER_URL, repo };
+    const linkRefs = (line: string) => linkifyIssueRefs(line, linkOpts);
+    const linkHints = (line: string) => linkifyIssueHints(line, linkOpts);
 
-    const prefix = [
-      links.pull == null ? "" : ` ${links.pull}`,
-      links.commit == null ? "" : ` ${links.commit}`,
-      users == null ? "" : ` Thanks ${users}!`,
-    ].join("");
+    const authors = usersFromSummary.length
+      ? usersFromSummary.map(
+          (user) => `[@${user}](${GITHUB_SERVER_URL}/${user})`,
+        )
+      : links.user
+        ? [links.user]
+        : [];
 
-    return `\n\n-${prefix ? `${prefix} -` : ""} ${linkifyIssueRefs(firstLine, {
-      serverUrl: GITHUB_SERVER_URL,
-      repo,
-    })}\n${futureLines
-      .map(
-        (l) =>
-          `  ${linkifyIssueRefs(l, {
-            serverUrl: GITHUB_SERVER_URL,
-            repo,
-          })}`,
+    const result = compose({
+      summary: firstLine,
+      pr: links.pull ?? "",
+      commit: links.commit ?? "",
+      authors,
+      linkRefs,
+      linkHints,
+    });
+
+    const { separator, line } =
+      typeof result === "string"
+        ? { separator: "\n\n", line: result }
+        : { separator: result.separator ?? "\n\n", line: result.line };
+
+    const continuation =
+      "\n" + futureLines.map((l) => `  ${linkRefs(l)}`).join("\n");
+
+    return `${separator}${line}${continuation}`;
+  };
+}
+
+const changelogFunctions: ChangelogFunctions = {
+  getDependencyReleaseLine: async (
+    changesets,
+    dependenciesUpdated,
+    options,
+  ) => {
+    const repo = options?.repo;
+    if (!repo || typeof repo !== "string") {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
+      );
+    }
+    if (dependenciesUpdated.length === 0) return "";
+
+    const changesetLink = `- Updated dependencies [${(
+      await Promise.all(
+        changesets.map(async (cs) => {
+          if (cs.commit) {
+            const { links } = await getInfo({
+              repo,
+              commit: cs.commit,
+            });
+            return links.commit;
+          }
+        }),
       )
-      .join("\n")}`;
+    )
+      .filter((_) => _)
+      .join(", ")}]:`;
+
+    const updatedDepenenciesList = dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+    );
+
+    return [changesetLink, ...updatedDepenenciesList].join("\n");
   },
+  getReleaseLine: composeReleaseLine(defaultReleaseLine),
 };
 
 // ChangelogFunctions require a default export


### PR DESCRIPTION
Compose changelog lines in JS via a local module (`summary`, `pr`, `commit`, `authors[]`, `linkRefs`/`linkHints`, optional `separator`). Default output unchanged.

BREAKING: removes `disableThanks`.