### PR TITLE
feat: make init command interactive

### DIFF
--- a/.changeset/fuzzy-taxes-switch.md
+++ b/.changeset/fuzzy-taxes-switch.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Made the `init` command interactive. Running `changeset init` will now guide you through a set of intuitive prompts to configure your changelog generator, commit preferences, publish access, and base branch, rather than silently writing the default configuration file.

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -294,14 +294,14 @@ describe("init", () => {
 
     expect(keys).toEqual([
       "$schema",
-      "changelog",
       "baseBranch",
-      "commit",
       "access",
+      "format",
+      "changelog",
+      "commit",
       "ignore",
       "fixed",
       "linked",
-      "format",
       "updateInternalDependencies",
     ]);
   });

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -56,9 +56,33 @@ describe("init", () => {
 
     expect(existsSync(readmePath)).toBe(false);
     expect(existsSync(configPath)).toBe(false);
+
     await initializeCommand({ cwd });
+
     expect(existsSync(readmePath)).toBe(true);
     expect(existsSync(configPath)).toBe(true);
+  });
+
+  it("should use process.cwd() if options are not provided", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    const { readmePath, configPath } = getPaths(cwd);
+
+    expect(existsSync(readmePath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
+
+    await initializeCommand();
+
+    expect(existsSync(readmePath)).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
+
+    cwdSpy.mockRestore();
   });
 
   it("should be written with the default config if it doesn't exist", async () => {
@@ -72,11 +96,51 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    expect(
-      JSON.parse(
-        await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-      ),
-    ).toEqual(defaultWrittenConfig);
+    const { readmePath, configPath } = getPaths(cwd);
+
+    expect(existsSync(readmePath)).toBe(true);
+    expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual(
+      defaultWrittenConfig,
+    );
+  });
+
+  it("should be written with the config and README if the .changeset folder already exists but is empty", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+      ".changeset": {},
+    });
+
+    const { readmePath, configPath } = getPaths(cwd);
+    expect(existsSync(readmePath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
+
+    await initializeCommand({ cwd });
+
+    expect(existsSync(readmePath)).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
+  });
+
+  it("should not overwrite README.md if it already exists and config.json is missing", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+      ".changeset/README.md": "custom readme content",
+    });
+
+    const { readmePath, configPath } = getPaths(cwd);
+    expect(existsSync(readmePath)).toBe(true);
+    expect(existsSync(configPath)).toBe(false);
+
+    await initializeCommand({ cwd });
+
+    expect(existsSync(configPath)).toBe(true);
+    const readmeContent = await fs.readFile(readmePath, "utf8");
+    expect(readmeContent).toBe("custom readme content");
   });
 
   it("should be appended with a newline at the end of the config", async () => {
@@ -91,7 +155,7 @@ describe("init", () => {
 
     await initializeCommand({ cwd });
 
-    const configPath = path.join(cwd, ".changeset/config.json");
+    const { configPath } = getPaths(cwd);
     const config = (await fs.readFile(configPath)).toString();
     const lastCharacter = config.slice(-1);
 
@@ -112,11 +176,9 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    expect(
-      JSON.parse(
-        await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-      ),
-    ).toEqual({
+
+    const { configPath } = getPaths(cwd);
+    expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual({
       changelog: false,
     });
   });
@@ -147,10 +209,11 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    const config = JSON.parse(
-      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-    );
 
+    const { readmePath, configPath } = getPaths(cwd);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+
+    expect(existsSync(readmePath)).toBe(true);
     expect(config.changelog).toEqual([
       "@changesets/changelog-github",
       { repo: "my-org/my-repo" },
@@ -176,10 +239,11 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    const config = JSON.parse(
-      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-    );
 
+    const { readmePath, configPath } = getPaths(cwd);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+
+    expect(existsSync(readmePath)).toBe(true);
     expect(config.changelog).toEqual("@changesets/changelog-git");
   });
 
@@ -209,9 +273,9 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    const config = JSON.parse(
-      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-    );
+
+    const { configPath } = getPaths(cwd);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
 
     expect(config.commit).toBe(true);
     expect(config.access).toBe("public");
@@ -234,9 +298,9 @@ describe("init", () => {
     });
 
     await initializeCommand({ cwd });
-    const config = JSON.parse(
-      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
-    );
+
+    const { configPath } = getPaths(cwd);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
 
     expect(config.baseBranch).toBe("main");
   });

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -3,17 +3,49 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { defaultWrittenConfig } from "@changesets/config";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as cli from "../../../utils/cli-utilities.ts";
 import { init as initializeCommand } from "../index.ts";
+
+vi.mock("../../../utils/cli-utilities.ts");
+const mockedUtils = vi.mocked(cli);
 
 const getPaths = (cwd: string) => ({
   readmePath: path.join(cwd, ".changeset/README.md"),
   configPath: path.join(cwd, ".changeset/config.json"),
 });
 
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+
+  mockedUtils.askList.mockImplementation(async (message) => {
+    if (message.includes("changelog")) {
+      return "@changesets/cli/changelog";
+    }
+    if (message.includes("published")) {
+      return "restricted";
+    }
+    return "";
+  });
+
+  mockedUtils.askConfirm.mockResolvedValue(false);
+
+  mockedUtils.askQuestion.mockImplementation(async (message) => {
+    if (message.includes("GitHub repository")) {
+      return "changesets/changesets";
+    }
+    if (message.includes("base branch")) {
+      return "";
+    }
+    return "";
+  });
+});
+
 describe("init", () => {
   silenceLogsInBlock();
-  it("should initialize in a project without a .changeset folder", async () => {
+
+  it("should be initialized in a project without a .changeset folder", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
@@ -28,7 +60,8 @@ describe("init", () => {
     expect(existsSync(readmePath)).toBe(true);
     expect(existsSync(configPath)).toBe(true);
   });
-  it("should write the default config if it doesn't exist", async () => {
+
+  it("should be written with the default config if it doesn't exist", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
@@ -45,7 +78,8 @@ describe("init", () => {
       ),
     ).toEqual(defaultWrittenConfig);
   });
-  it("should add newline at the end of config", async () => {
+
+  it("should be appended with a newline at the end of the config", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
@@ -63,7 +97,8 @@ describe("init", () => {
 
     expect(lastCharacter).toBe("\n");
   });
-  it("shouldn't overwrite a config if it does exist", async () => {
+
+  it("should not be overwritten if a config already exists", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
@@ -84,5 +119,125 @@ describe("init", () => {
     ).toEqual({
       changelog: false,
     });
+  });
+
+  it("should be written with GitHub changelog config and prompt for repo when chosen", async () => {
+    mockedUtils.askList.mockImplementation(async (message) => {
+      if (message.includes("changelog")) {
+        return "@changesets/changelog-github";
+      }
+      if (message.includes("published")) {
+        return "restricted";
+      }
+      return "";
+    });
+
+    mockedUtils.askQuestion.mockImplementation(async (message) => {
+      if (message.includes("GitHub repository")) {
+        return "my-org/my-repo";
+      }
+      return "";
+    });
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+    const config = JSON.parse(
+      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
+    );
+
+    expect(config.changelog).toEqual([
+      "@changesets/changelog-github",
+      { repo: "my-org/my-repo" },
+    ]);
+  });
+
+  it("should be written with Git changelog config when chosen", async () => {
+    mockedUtils.askList.mockImplementation(async (message) => {
+      if (message.includes("changelog")) {
+        return "@changesets/changelog-git";
+      }
+      if (message.includes("published")) {
+        return "restricted";
+      }
+      return "";
+    });
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+    const config = JSON.parse(
+      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
+    );
+
+    expect(config.changelog).toEqual("@changesets/changelog-git");
+  });
+
+  it("should be written with public access, commit enabled, and custom branch when chosen", async () => {
+    mockedUtils.askConfirm.mockResolvedValue(true);
+    mockedUtils.askList.mockImplementation(async (message) => {
+      if (message.includes("changelog")) {
+        return "@changesets/cli/changelog";
+      }
+      if (message.includes("published")) {
+        return "public";
+      }
+      return "";
+    });
+    mockedUtils.askQuestion.mockImplementation(async (message) => {
+      if (message.includes("base branch")) {
+        return "master";
+      }
+      return "";
+    });
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+    const config = JSON.parse(
+      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
+    );
+
+    expect(config.commit).toBe(true);
+    expect(config.access).toBe("public");
+    expect(config.baseBranch).toBe("master");
+  });
+
+  it("should be fallen back to main branch when an empty string is provided", async () => {
+    mockedUtils.askQuestion.mockImplementation(async (message) => {
+      if (message.includes("base branch")) {
+        return "";
+      }
+      return "";
+    });
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+    const config = JSON.parse(
+      await fs.readFile(path.join(cwd, ".changeset/config.json"), "utf8"),
+    );
+
+    expect(config.baseBranch).toBe("main");
   });
 });

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -276,4 +276,33 @@ describe("init", () => {
 
     expect(config.baseBranch).toBe("main");
   });
+
+  it("should be written with consistently ordered properties", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+
+    const { configPath } = getPaths(cwd);
+    const configContent = await fs.readFile(configPath, "utf8");
+    const parsedConfig = JSON.parse(configContent);
+    const keys = Object.keys(parsedConfig);
+
+    expect(keys).toEqual([
+      "$schema",
+      "changelog",
+      "baseBranch",
+      "commit",
+      "access",
+      "ignore",
+      "fixed",
+      "linked",
+      "format",
+      "updateInternalDependencies",
+    ]);
+  });
 });

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -20,16 +20,21 @@ beforeEach(() => {
   vi.restoreAllMocks();
 
   mockedUtils.askList.mockImplementation(async (message) => {
-    if (message.includes("changelog")) {
-      return "@changesets/cli/changelog";
-    }
     if (message.includes("published")) {
       return "restricted";
     }
     return "";
   });
 
-  mockedUtils.askConfirm.mockResolvedValue(false);
+  mockedUtils.askConfirm.mockImplementation(async (message) => {
+    if (message.includes("GitHub integration")) {
+      return false;
+    }
+    if (message.includes("automatically committed")) {
+      return false;
+    }
+    return false;
+  });
 
   mockedUtils.askQuestion.mockImplementation(async (message) => {
     if (message.includes("GitHub repository")) {
@@ -184,14 +189,11 @@ describe("init", () => {
   });
 
   it("should be written with GitHub changelog config and prompt for repo when chosen", async () => {
-    mockedUtils.askList.mockImplementation(async (message) => {
-      if (message.includes("changelog")) {
-        return "@changesets/changelog-github";
+    mockedUtils.askConfirm.mockImplementation(async (message) => {
+      if (message.includes("GitHub integration")) {
+        return true;
       }
-      if (message.includes("published")) {
-        return "restricted";
-      }
-      return "";
+      return false;
     });
 
     mockedUtils.askQuestion.mockImplementation(async (message) => {
@@ -220,39 +222,9 @@ describe("init", () => {
     ]);
   });
 
-  it("should be written with Git changelog config when chosen", async () => {
-    mockedUtils.askList.mockImplementation(async (message) => {
-      if (message.includes("changelog")) {
-        return "@changesets/changelog-git";
-      }
-      if (message.includes("published")) {
-        return "restricted";
-      }
-      return "";
-    });
-
-    const cwd = await testdir({
-      "package.json": JSON.stringify({
-        private: true,
-        name: "root-pkg",
-      }),
-    });
-
-    await initializeCommand({ cwd });
-
-    const { readmePath, configPath } = getPaths(cwd);
-    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
-
-    expect(existsSync(readmePath)).toBe(true);
-    expect(config.changelog).toEqual("@changesets/changelog-git");
-  });
-
   it("should be written with public access, commit enabled, and custom branch when chosen", async () => {
     mockedUtils.askConfirm.mockResolvedValue(true);
     mockedUtils.askList.mockImplementation(async (message) => {
-      if (message.includes("changelog")) {
-        return "@changesets/cli/changelog";
-      }
       if (message.includes("published")) {
         return "public";
       }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -21,32 +21,20 @@ export type AccessType = "public" | "restricted";
 async function getInteractiveConfig() {
   const config = { ...defaultWrittenConfig };
 
-  const changelogChoice = await cli.askList(
-    "Which changelog entry generator should be used?",
-    [
-      {
-        label: "Standard changelogs",
-        value: "@changesets/cli/changelog",
-      },
-      {
-        label: "Changelogs with GitHub info",
-        value: "@changesets/changelog-github",
-      },
-      {
-        label: "Changelogs with commit info",
-        value: "@changesets/changelog-git",
-      },
-    ],
+  const useGithub = await cli.askConfirm(
+    "Should the GitHub integration be used for changelogs?",
+    false,
   );
 
-  if (changelogChoice === "@changesets/changelog-github") {
+  if (useGithub) {
+    const changelogChoice = "@changesets/changelog-github";
     const repo = await cli.askQuestion(
       "What is the GitHub repository? (e.g. org/repo)",
       { placeholder: "org/repo", notEmpty: true },
     );
     config.changelog = [changelogChoice, { repo }];
   } else {
-    config.changelog = changelogChoice;
+    config.changelog = "@changesets/cli/changelog";
   }
 
   config.commit = await cli.askConfirm(
@@ -55,10 +43,10 @@ async function getInteractiveConfig() {
   );
 
   config.access = (await cli.askList(
-    "Should packages be published publicly or privately?",
+    "Should packages be published publicly or privately by default?",
     [
-      { label: "Privately", value: "restricted" },
-      { label: "Publicly", value: "public" },
+      { label: "Private", value: "restricted" },
+      { label: "Public", value: "public" },
     ],
   )) as AccessType | "private";
 
@@ -78,65 +66,41 @@ export async function init(options?: InitOptions): Promise<void> {
   const packages = await getPackages(cwd);
   const changesetBase = path.resolve(packages.rootDir, ".changeset");
 
-  if (existsSync(changesetBase)) {
-    if (!existsSync(path.join(changesetBase, "config.json"))) {
-      log.info(
-        `A new ${c.blue("Changeset")} configuration is being initialized...\n`,
-      );
+  if (existsSync(path.join(changesetBase, "config.json"))) {
+    log.success(
+      `
+${c.green("Changesets")} has already been initialized.
+Changeset commands can be run with no problems.
+      `.trim(),
+    );
+    return;
+  }
 
-      const newConfigStr = await getInteractiveConfig();
+  log.info(
+    `A new ${c.blue("Changeset")} configuration is being initialized...\n`,
+  );
 
-      await fs.writeFile(
-        path.resolve(changesetBase, "config.json"),
-        newConfigStr,
-      );
+  if (!existsSync(changesetBase)) {
+    await fs.mkdir(changesetBase, { recursive: true });
+  }
 
-      if (!existsSync(path.join(changesetBase, "README.md"))) {
-        await fs.copyFile(
-          path.resolve(pkgPath, "./default-files/README.md"),
-          path.resolve(changesetBase, "README.md"),
-        );
-      }
+  const newConfigStr = await getInteractiveConfig();
 
-      log.success(
-        `
+  await fs.writeFile(path.resolve(changesetBase, "config.json"), newConfigStr);
+
+  if (!existsSync(path.join(changesetBase, "README.md"))) {
+    await fs.copyFile(
+      path.resolve(pkgPath, "./default-files/README.md"),
+      path.resolve(changesetBase, "README.md"),
+    );
+  }
+
+  log.success(
+    `
 ${c.green("Changesets")} initialization is complete.
 The ${c.blue(".changeset")} folder has been updated with:
 - ${c.blue("config.json")} (customized based on the provided preferences)
 - ${c.blue("README.md")} (a quick guide for using changesets)
-
-Versioning and publishing can now be managed!
-        `.trim(),
-      );
-    } else {
-      log.success(
-        `
-${c.green("Changesets")} has already been initialized.
-Changeset commands can be run with no problems.
-        `.trim(),
-      );
-    }
-  } else {
-    await fs.cp(path.resolve(pkgPath, "./default-files"), changesetBase, {
-      recursive: true,
-    });
-
-    const newConfigStr = await getInteractiveConfig();
-
-    await fs.writeFile(
-      path.resolve(changesetBase, "config.json"),
-      newConfigStr,
-    );
-
-    log.success(
-      `
-${c.green("Changesets")} initialization is complete.
-The ${c.blue(".changeset")} folder has been successfully created with:
-- ${c.blue("config.json")} (customized based on the provided preferences)
-- ${c.blue("README.md")} (a quick guide for using changesets)
-
-Versioning and publishing can now be managed!
-      `.trim(),
-    );
-  }
+    `.trim(),
+  );
 }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -41,13 +41,13 @@ async function getInteractiveConfig() {
     false,
   );
 
-  config.access = (await cli.askList(
+  config.access = await cli.askList<AccessType>(
     "Should packages be published publicly or privately by default?",
     [
       { label: "Private", value: "restricted" },
       { label: "Public", value: "public" },
     ],
-  )) as AccessType;
+  );
 
   const baseBranchInput = await cli.askQuestion(
     "Which base branch should be used?",

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -6,18 +6,73 @@ import c from "@changesets/color";
 import { defaultWrittenConfig } from "@changesets/config";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
+import * as cli from "../../utils/cli-utilities.ts";
 
 const pkgPath = path.dirname(
   fileURLToPath(import.meta.resolve("@changesets/cli/package.json")),
 );
 
-const defaultConfig = `${JSON.stringify(defaultWrittenConfig, null, 2)}\n`;
-
 export interface InitOptions {
   cwd?: string;
 }
 
-export async function init(options?: InitOptions) {
+export type AccessType = "public" | "restricted";
+
+async function getInteractiveConfig() {
+  const config = { ...defaultWrittenConfig };
+
+  const changelogChoice = await cli.askList(
+    "Which changelog entry generator should be used?",
+    [
+      {
+        label: "Standard changelogs",
+        value: "@changesets/cli/changelog",
+      },
+      {
+        label: "Changelogs with GitHub info",
+        value: "@changesets/changelog-github",
+      },
+      {
+        label: "Changelogs with commit info",
+        value: "@changesets/changelog-git",
+      },
+    ],
+  );
+
+  if (changelogChoice === "@changesets/changelog-github") {
+    const repo = await cli.askQuestion(
+      "What is the GitHub repository? (e.g. org/repo)",
+      { placeholder: "org/repo", notEmpty: true },
+    );
+    config.changelog = [changelogChoice, { repo }];
+  } else {
+    config.changelog = changelogChoice;
+  }
+
+  config.commit = await cli.askConfirm(
+    "Should changeset files and version bumps be automatically committed?",
+    false,
+  );
+
+  config.access = (await cli.askList(
+    "Should packages be published publicly or privately?",
+    [
+      { label: "Privately", value: "restricted" },
+      { label: "Publicly", value: "public" },
+    ],
+  )) as AccessType | "private";
+
+  const baseBranchInput = await cli.askQuestion(
+    "Which base branch should be used?",
+    { placeholder: "main" },
+  );
+
+  config.baseBranch = baseBranchInput || "main";
+
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export async function init(options?: InitOptions): Promise<void> {
   const cwd = options?.cwd ?? process.cwd();
 
   const packages = await getPackages(cwd);
@@ -25,38 +80,62 @@ export async function init(options?: InitOptions) {
 
   if (existsSync(changesetBase)) {
     if (!existsSync(path.join(changesetBase, "config.json"))) {
-      log.success(
-        `
-It looks like you don't have a config file
-The default config file will be written to ${c.blue(".changeset/config.json")}
-        `.trim(),
+      log.info(
+        `A new ${c.blue("Changeset")} configuration is being initialized...\n`,
       );
+
+      const newConfigStr = await getInteractiveConfig();
 
       await fs.writeFile(
         path.resolve(changesetBase, "config.json"),
-        defaultConfig,
+        newConfigStr,
+      );
+
+      if (!existsSync(path.join(changesetBase, "README.md"))) {
+        await fs.copyFile(
+          path.resolve(pkgPath, "./default-files/README.md"),
+          path.resolve(changesetBase, "README.md"),
+        );
+      }
+
+      log.success(
+        `
+${c.green("Changesets")} initialization is complete.
+The ${c.blue(".changeset")} folder has been updated with:
+- ${c.blue("config.json")} (customized based on the provided preferences)
+- ${c.blue("README.md")} (a quick guide for using changesets)
+
+Versioning and publishing can now be managed!
+        `.trim(),
       );
     } else {
       log.success(
-        `It looks like you already have ${c.green("Changesets")} initialized.\nYou should be able to run changeset commands no problems.`,
+        `
+${c.green("Changesets")} has already been initialized.
+Changeset commands can be run with no problems.
+        `.trim(),
       );
     }
   } else {
     await fs.cp(path.resolve(pkgPath, "./default-files"), changesetBase, {
       recursive: true,
     });
+
+    const newConfigStr = await getInteractiveConfig();
+
     await fs.writeFile(
       path.resolve(changesetBase, "config.json"),
-      defaultConfig,
+      newConfigStr,
     );
 
     log.success(
       `
-Thanks for choosing ${c.green("Changesets")} to help manage your versioning and publishing.
-You should be set up to start using changesets now!
-We have created a \`.changeset\` folder, and a couple of files to help you out:
-- ${c.blue(".changeset/config.json")} with the default config options
-- ${c.blue(".changeset/README.md")} with information about using changesets
+${c.green("Changesets")} initialization is complete.
+The ${c.blue(".changeset")} folder has been successfully created with:
+- ${c.blue("config.json")} (customized based on the provided preferences)
+- ${c.blue("README.md")} (a quick guide for using changesets)
+
+Versioning and publishing can now be managed!
       `.trim(),
     );
   }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -56,7 +56,34 @@ async function getInteractiveConfig() {
 
   config.baseBranch = baseBranchInput || "main";
 
-  return `${JSON.stringify(config, null, 2)}\n`;
+  const priorityOrder = [
+    "$schema",
+    "changelog",
+    "baseBranch",
+    "commit",
+    "access",
+    "ignore",
+    "fixed",
+    "linked",
+    "format",
+    "updateInternalDependencies",
+  ];
+
+  const sortedConfig: Record<string, any> = {};
+
+  for (const key of priorityOrder) {
+    if (key in config) {
+      sortedConfig[key] = (config as Record<string, any>)[key];
+    }
+  }
+
+  for (const key of Object.keys(config)) {
+    if (!(key in sortedConfig)) {
+      sortedConfig[key] = (config as Record<string, any>)[key];
+    }
+  }
+
+  return `${JSON.stringify(sortedConfig, null, 2)}\n`;
 }
 
 export async function init(options?: InitOptions): Promise<void> {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -58,14 +58,14 @@ async function getInteractiveConfig() {
 
   const priorityOrder = [
     "$schema",
-    "changelog",
     "baseBranch",
-    "commit",
     "access",
+    "format",
+    "changelog",
+    "commit",
     "ignore",
     "fixed",
     "linked",
-    "format",
     "updateInternalDependencies",
   ];
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import c from "@changesets/color";
 import { defaultWrittenConfig } from "@changesets/config";
+import type { AccessType } from "@changesets/types";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
 import * as cli from "../../utils/cli-utilities.ts";
@@ -15,8 +16,6 @@ const pkgPath = path.dirname(
 export interface InitOptions {
   cwd?: string;
 }
-
-export type AccessType = "public" | "restricted";
 
 async function getInteractiveConfig() {
   const config = { ...defaultWrittenConfig };
@@ -48,7 +47,7 @@ async function getInteractiveConfig() {
       { label: "Private", value: "restricted" },
       { label: "Public", value: "public" },
     ],
-  )) as AccessType | "private";
+  )) as AccessType;
 
   const baseBranchInput = await cli.askQuestion(
     "Which base branch should be used?",

--- a/packages/cli/src/utils/cli-utilities.ts
+++ b/packages/cli/src/utils/cli-utilities.ts
@@ -46,6 +46,7 @@ type QuestionOptions = {
   placeholder?: string;
   notEmpty?: boolean;
 };
+
 async function askQuestion(
   message: string,
   { placeholder, notEmpty }: QuestionOptions = {},
@@ -60,11 +61,14 @@ async function askQuestion(
   );
 }
 
-async function askConfirm(message: string): Promise<boolean> {
+async function askConfirm(
+  message: string,
+  initialValue: boolean = true,
+): Promise<boolean> {
   return cancelable(() =>
     confirm({
       message,
-      initialValue: true,
+      initialValue,
     }),
   );
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,7 +101,7 @@ export type WrittenConfig = {
   commit?: boolean | readonly [string, null | Record<string, unknown>] | string;
   fixed?: Fixed;
   linked?: Linked;
-  access?: AccessType | "private";
+  access?: AccessType;
   baseBranch?: string;
   changedFilePatterns?: readonly string[];
   format?: "auto" | "prettier" | "oxfmt" | "deno" | "dprint" | false;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,7 +101,7 @@ export type WrittenConfig = {
   commit?: boolean | readonly [string, null | Record<string, unknown>] | string;
   fixed?: Fixed;
   linked?: Linked;
-  access?: AccessType;
+  access?: AccessType | "private";
   baseBranch?: string;
   changedFilePatterns?: readonly string[];
   format?: "auto" | "prettier" | "oxfmt" | "deno" | "dprint" | false;


### PR DESCRIPTION
#### Description

This PR adds support for making the `init` command interactive. 

The new command flow uses the `clack` utilities and has the following flow:

1. Should the GitHub integration be used for changelogs? 
   (Options: Yes / No, defaults to No)
   
   1a. [If Yes]: What is the GitHub repository? (e.g. org/repo)
       (Text input: requires a non-empty string)

2. Should changeset files and version bumps be automatically committed? 
   (Options: Yes / No, defaults to No)

3. Should packages be published publicly or privately by default? 
   (Options: Private, Public, defaults to Private since the `access` option defaults to `"restricted"`)

4. Which base branch should be used? 
   (Text input: defaults to "main" if left blank)

---

I have also added new test cases to confirm the behaviour and tested it manually after running `pnpm build`.

I also ran `pnpm check-all` before committing.
I hope targeting `main` is correct. Please let me know if `next` should be the branch target.

I did the docs in #2088 since it needs to target `next-docs`. To be honest, I am a little confused about the correct workflow 😅 

- [x] This PR includes AI generated code but it is all verified by me.

- Closes #160
