### PR TITLE
change peer dependent bump type to `patch`

### DIFF
--- a/.changeset/wide-feet-lie.md
+++ b/.changeset/wide-feet-lie.md
@@ -1,0 +1,10 @@
+---
+"@changesets/assemble-release-plan": major
+"@changesets/cli": major
+---
+
+Peer dependencies now bump packages that depend on them by `patch` instead of `major`.
+
+This means a peer dependency update is no longer assumed (forced) to be a breaking change.
+
+If the dependent package is not compatible with the peer's new release you should manually add a `major` changeset describing why and how to migrate.

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -88,20 +88,6 @@ export function determineDependents({
             if (nextRelease.type === "none") {
               continue;
             } else if (
-              shouldBumpMajor({
-                dependent,
-                depType,
-                versionRange,
-                releases,
-                nextRelease,
-                preInfo,
-                onlyUpdatePeerDependentsWhenOutOfRange:
-                  config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-                    .onlyUpdatePeerDependentsWhenOutOfRange,
-              })
-            ) {
-              type = "major";
-            } else if (
               (!releases.has(dependent) ||
                 releases.get(dependent)!.type === "none") &&
               (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
@@ -239,36 +225,4 @@ function getDependencyVersionRanges(
     });
   }
   return dependencyVersionRanges;
-}
-
-function shouldBumpMajor({
-  dependent,
-  depType,
-  versionRange,
-  releases,
-  nextRelease,
-  preInfo,
-  onlyUpdatePeerDependentsWhenOutOfRange,
-}: {
-  dependent: string;
-  depType: DependencyType;
-  versionRange: string;
-  releases: Map<string, InternalRelease>;
-  nextRelease: InternalRelease;
-  preInfo: PreInfo | undefined;
-  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-}) {
-  // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
-  return (
-    depType === "peerDependencies" &&
-    nextRelease.type !== "none" &&
-    nextRelease.type !== "patch" &&
-    // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
-    // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
-    (!onlyUpdatePeerDependentsWhenOutOfRange ||
-      !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange)) &&
-    // bump major only if the dependent doesn't already has a major release.
-    (!releases.has(dependent) ||
-      (releases.has(dependent) && releases.get(dependent)!.type !== "major"))
-  );
 }

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -1024,28 +1024,25 @@ describe("dependent bumping", () => {
     Record<VersionType, Record<Range, string>>
   >;
 
+  const defaultBumps: ExpectationTable[DepKind] = {
+    none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
+    patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.1" },
+    minor: { "^": "1.0.0", "~": "1.0.1", "=": "1.0.1" },
+    major: { "^": "1.0.1", "~": "1.0.1", "=": "1.0.1" },
+  }
+
   // oxfmt-ignore
   const baseExpectations: ExpectationTable = {
-    // direct dependent has to be bumped only when dependency falls out of allowed range
+    // direct and peer dependents have to be bumped only when dependency falls out of allowed range
     // otherwise, installing the latest versions of dependent and dependency would result in duplicate dependency package in the tree
-    dep: {
-      none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
-      patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.1" },
-      minor: { "^": "1.0.0", "~": "1.0.1", "=": "1.0.1" },
-      major: { "^": "1.0.1", "~": "1.0.1", "=": "1.0.1" },
-    },
+    dep: defaultBumps,
+    peer: defaultBumps,
     // devDependent should stay untouched, given the dev dependency doesn't affect production installations
     dev: {
       none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
       patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
       minor: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
       major: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
-    },
-    peer: {
-      none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
-      patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.1" },
-      minor: { "^": "1.0.0", "~": "1.0.1", "=": "1.0.1" },
-      major: { "^": "1.0.1", "~": "1.0.1", "=": "1.0.1" },
     },
   };
 
@@ -1232,19 +1229,17 @@ describe("dependent bumping", () => {
       },
       peer: {
         patch: { "^": "1.0.1", "~": "1.0.1" },
-        minor: { "^": "1.0.1", },
+        minor: { "^": "1.0.1" },
       },
     },
   });
 
+  // should not affect dependent bumps
   describeDependentBumping("onlyUpdatePeerDependentsWhenOutOfRange: true", {
     config: {
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: true,
       },
-    },
-    overrides: {
-      peer: { minor: { "^": "1.0.0" } },
     },
   });
 

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -738,6 +738,54 @@ describe("assembleReleasePlan", () => {
         },
       ]);
     });
+
+    // https://github.com/changesets/changesets/issues/963
+    // https://github.com/changesets/changesets/issues/1759
+    it("should not bump fixed packages due to peer dependents", () => {
+      const setup = new FakeFullState({ changesets: [] });
+
+      setup.addPackage("@ex/core", "0.1.0");
+      setup.addPackage("@ex/errors", "0.1.0");
+      setup.addPackage("@ex/api", "0.1.0");
+      setup.addPackage("some-peer", "0.1.0"); // optional peer
+      setup.addPackage("@ex/components", "0.1.0");
+
+      setup.updateDependencies("@ex/api", [
+        { name: "@ex/core", range: "0.1.0" },
+        { name: "@ex/errors", range: "0.1.0" },
+        { name: "some-peer", range: "0.1.0", type: "peer" },
+      ]);
+      setup.updateDependencies("@ex/components", [
+        { name: "@ex/api", range: "0.1.0" },
+        { name: "some-peer", range: "0.1.0" },
+      ]);
+
+      setup.addChangeset({ releases: [{ name: "@ex/core", type: "minor" }] });
+
+      const result = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          fixed: [
+            [
+              "@ex/core",
+              "@ex/errors",
+              "@ex/api",
+              "some-peer",
+              "@ex/components",
+            ],
+          ],
+        },
+        undefined,
+      );
+
+      expect(result.releases).toHaveLength(5);
+      expect(
+        result.releases.every((release) => release.newVersion === "0.2.0"),
+        "every bump should be to 0.2.0",
+      ).toBe(true);
+    });
   });
 
   describe("pre mode", () => {

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -595,7 +595,7 @@ describe("assembleReleasePlan", () => {
         },
         {
           name: "pkg-b",
-          newVersion: "2.0.0",
+          newVersion: "1.0.1",
         },
       ]);
     });
@@ -734,7 +734,7 @@ describe("assembleReleasePlan", () => {
         },
         {
           name: "pkg-b",
-          newVersion: "2.0.0",
+          newVersion: "1.0.1",
         },
       ]);
     });
@@ -1044,8 +1044,8 @@ describe("dependent bumping", () => {
     peer: {
       none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
       patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.1" },
-      minor: { "^": "2.0.0", "~": "2.0.0", "=": "2.0.0" },
-      major: { "^": "2.0.0", "~": "2.0.0", "=": "2.0.0" },
+      minor: { "^": "1.0.0", "~": "1.0.1", "=": "1.0.1" },
+      major: { "^": "1.0.1", "~": "1.0.1", "=": "1.0.1" },
     },
   };
 
@@ -1232,6 +1232,7 @@ describe("dependent bumping", () => {
       },
       peer: {
         patch: { "^": "1.0.1", "~": "1.0.1" },
+        minor: { "^": "1.0.1", },
       },
     },
   });

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -1025,11 +1025,11 @@ describe("dependent bumping", () => {
   >;
 
   const defaultBumps: ExpectationTable[DepKind] = {
-    none:  { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
+    none: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.0" },
     patch: { "^": "1.0.0", "~": "1.0.0", "=": "1.0.1" },
     minor: { "^": "1.0.0", "~": "1.0.1", "=": "1.0.1" },
     major: { "^": "1.0.1", "~": "1.0.1", "=": "1.0.1" },
-  }
+  };
 
   // oxfmt-ignore
   const baseExpectations: ExpectationTable = {

--- a/packages/assemble-release-plan/src/test-utils.ts
+++ b/packages/assemble-release-plan/src/test-utils.ts
@@ -102,10 +102,31 @@ export class FakeFullState {
       (a) => a.packageJson.name === dependent,
     );
     if (!pkg) throw new Error(`No "${dependent}" package`);
-    if (!pkg.packageJson.dependencies) {
-      pkg.packageJson.dependencies = {};
-    }
+    pkg.packageJson.dependencies ??= {};
     pkg.packageJson.dependencies[dependency] = versionRange;
+  }
+  updateDependencies(
+    dependent: string,
+    deps: Array<{
+      name: string;
+      range: string;
+      type?: "direct" | "peer" | "dev";
+    }>,
+  ) {
+    const pkg = this.packages.packages.find(
+      (p) => p.packageJson.name === dependent,
+    );
+    if (!pkg) throw new Error(`No "${dependent}" package`);
+    for (const { name, range, type } of deps) {
+      const property =
+        type === "dev"
+          ? "devDependencies"
+          : type === "peer"
+            ? "peerDependencies"
+            : "dependencies";
+      pkg.packageJson[property] ??= {};
+      pkg.packageJson[property][name] = range;
+    }
   }
   updateDevDependency(
     dependent: string,
@@ -116,9 +137,7 @@ export class FakeFullState {
       (a) => a.packageJson.name === dependent,
     );
     if (!pkg) throw new Error(`No "${dependent}" package`);
-    if (!pkg.packageJson.devDependencies) {
-      pkg.packageJson.devDependencies = {};
-    }
+    pkg.packageJson.devDependencies ??= {};
     pkg.packageJson.devDependencies[dependency] = versionRange;
   }
   updatePeerDependency(
@@ -130,9 +149,7 @@ export class FakeFullState {
       (a) => a.packageJson.name === dependent,
     );
     if (!pkg) throw new Error(`No "${dependent}" package`);
-    if (!pkg.packageJson.peerDependencies) {
-      pkg.packageJson.peerDependencies = {};
-    }
+    pkg.packageJson.peerDependencies ??= {};
     pkg.packageJson.peerDependencies[dependency] = versionRange;
   }
 

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -1391,6 +1391,7 @@ describe("workspace range", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -1347,7 +1347,7 @@ describe("workspace range", () => {
     `);
   });
 
-  it("should bump major bump peer-dependent when workspace:~ dependency gets a minor bump (without onlyUpdatePeerDependentsWhenOutOfRange)", async () => {
+  it("should patch bump peer-dependent when workspace:~ dependency gets a minor bump (without onlyUpdatePeerDependentsWhenOutOfRange)", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({
         private: true,
@@ -1362,7 +1362,7 @@ describe("workspace range", () => {
       "packages/pkg-b/package.json": JSON.stringify({
         name: "pkg-b",
         version: "1.0.0",
-        peerDependencies: { "pkg-a": "workspace:^" },
+        peerDependencies: { "pkg-a": "workspace:~" },
       }),
       ".changeset/config.json": JSON.stringify(modifiedDefaultConfig),
     });
@@ -1390,8 +1390,7 @@ describe("workspace range", () => {
     expect(await getChangelog("pkg-b", cwd)).toMatchInlineSnapshot(`
       "# pkg-b
 
-      ## 2.0.0
-
+      ## 1.0.1
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]


### PR DESCRIPTION
this PR changes the bump type for peer dependents from `major` to `patch`.

i think this is the best default behavior. the previous `major` bump is motivated due to Changesets not being able to know whether the changes in the peerDep are passed through the dependent, therefore we assume all changes are.

with this new bump strategy, we hand over the responsibility for knowing how the dependent should be bumped to the maintainers, rather than forcing `major` onto them.

if the change is not surfaced in the dependent, they can keep the `patch` bump.

if the change _does_ require action from the users, this _is_ a breaking change for the dependent (no matter how Changesets bumps it automatically), and the maintainer should add a changeset describing it (like always).

closes #524
closes #822
closes #827 (bring for v3.1 or v4: `updatePeerDependentsAs`)
closes #963
closes #1011
closes #1126
closes #1132 (bring for v3.1 or v4 discussion)
closes #1228
closes #1279
closes #1600 (bring for v3.1 or v4 discussion)
closes #1759
closes #1887