### PR TITLE
Do not accumulate changesets in prerelease mode

### DIFF
--- a/.changeset/legal-papers-train.md
+++ b/.changeset/legal-papers-train.md
@@ -1,0 +1,14 @@
+---
+"@changesets/apply-release-plan": major
+"@changesets/assemble-release-plan": major
+"@changesets/cli": major
+"@changesets/pre": major
+"@changesets/release-utils": major
+"@changesets/types": major
+---
+
+When exiting prerelease mode, the final changelog will now not include all changesets made since `pre enter`. This change was made as often changes during prereleases are not relevant to the final release, and it's not possible to query the entire Git and GitHub metadata when the backlog of changesets become sufficiently large.
+
+As a result, the `pre.json` file also no longer tracks changesets added since `pre enter`, and `version` commands during prereleases will clear all changesets same as a normal release.
+
+If you're migrating to Changesets v3 during prerelease mode, this new behavior will be automatically applied the next time you run the `version` command. Specifically, the `pre.json` `"changesets"` field will be cleared, and all of its referenced changesets will be deleted in `.changeset/*.md`.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -3273,7 +3273,6 @@ describe("apply release plan", () => {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
         },
-        changesets: [],
       };
 
       const { tempDir } = await testSetup(

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -160,40 +160,38 @@ export async function applyReleasePlan(
     await formatter(filesToFormat);
   }
 
-  if (releasePlan.preState == null || releasePlan.preState.mode === "exit") {
-    const changesetFolder = path.resolve(cwd, ".changeset");
-    await Promise.all(
-      changesets.map(async (changeset) => {
-        const changesetPath = path.resolve(
-          changesetFolder,
-          `${changeset.id}.md`,
-        );
+  await Promise.all(
+    changesets.map(async (changeset) => {
+      const changesetPath = path.resolve(
+        cwd,
+        ".changeset",
+        `${changeset.id}.md`,
+      );
+      if (
+        await fs.access(changesetPath).then(
+          () => true,
+          () => false,
+        )
+      ) {
+        // DO NOT remove changeset for skipped packages
+        // Mixed changeset that contains both skipped packages and not skipped packages are disallowed
+        // At this point, we know there is no such changeset, because otherwise the program would've already failed,
+        // so we just check if any skipped package exists in this changeset, and only remove it if none exists
+        // options to skip packages were added in v2, so we don't need to do it for v1 changesets
         if (
-          await fs.access(changesetPath).then(
-            () => true,
-            () => false,
+          !changeset.releases.some((release) =>
+            shouldSkipPackage(packagesByName.get(release.name)!, {
+              ignore: config.ignore,
+              allowPrivatePackages: config.privatePackages.version,
+            }),
           )
         ) {
-          // DO NOT remove changeset for skipped packages
-          // Mixed changeset that contains both skipped packages and not skipped packages are disallowed
-          // At this point, we know there is no such changeset, because otherwise the program would've already failed,
-          // so we just check if any skipped package exists in this changeset, and only remove it if none exists
-          // options to skip packages were added in v2, so we don't need to do it for v1 changesets
-          if (
-            !changeset.releases.some((release) =>
-              shouldSkipPackage(packagesByName.get(release.name)!, {
-                ignore: config.ignore,
-                allowPrivatePackages: config.privatePackages.version,
-              }),
-            )
-          ) {
-            touchedFiles.push(changesetPath);
-            await fs.rm(changesetPath, { recursive: true, force: true });
-          }
+          touchedFiles.push(changesetPath);
+          await fs.rm(changesetPath, { recursive: true, force: true });
         }
-      }),
-    );
-  }
+      }
+    }),
+  );
 
   // We return the touched files to be committed in the cli
   return touchedFiles;

--- a/packages/assemble-release-plan/src/increment.test.ts
+++ b/packages/assemble-release-plan/src/increment.test.ts
@@ -18,7 +18,6 @@ describe("incrementVersion", () => {
           mode: "pre",
           tag: "next",
           initialVersions: {},
-          changesets: [],
         },
       };
 

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -749,7 +749,6 @@ describe("assembleReleasePlan", () => {
           ...defaultConfig,
         },
         {
-          changesets: [],
           tag: "next",
           initialVersions: {},
           mode: "exit",
@@ -773,7 +772,6 @@ describe("assembleReleasePlan", () => {
           ...defaultConfig,
         },
         {
-          changesets: ["strange-words-combine"],
           tag: "next",
           initialVersions: {
             "pkg-a": "1.0.0",
@@ -803,7 +801,6 @@ describe("assembleReleasePlan", () => {
           ignore: ["pkg-b"],
         },
         {
-          changesets: ["strange-words-combine"],
           tag: "next",
           initialVersions: {
             "pkg-a": "1.0.0",
@@ -821,16 +818,6 @@ describe("assembleReleasePlan", () => {
     });
 
     it("should return a release with the highest bump type within the current release despite of having a higher release among previous prereleases", () => {
-      // previous release
-      setup.addChangeset({
-        id: "major-bumping-one",
-        releases: [
-          {
-            name: "pkg-a",
-            type: "major",
-          },
-        ],
-      });
       setup.updatePackage("pkg-a", "2.0.0-next.0");
 
       // current release
@@ -850,7 +837,6 @@ describe("assembleReleasePlan", () => {
           ...defaultConfig,
         },
         {
-          changesets: ["major-bumping-one"],
           tag: "next",
           initialVersions: {
             "pkg-a": "1.0.0",

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -139,10 +139,9 @@ export function assembleReleasePlan(
     changesets,
     packagesByName,
     config,
-    preState,
   );
 
-  const preInfo = getPreInfo(changesets, packagesByName, config, preState);
+  const preInfo = getPreInfo(packagesByName, config, preState);
 
   // releases is, at this point a list of all packages we are going to releases,
   // flattened down to one release per package, having a reference back to their
@@ -236,7 +235,6 @@ function getRelevantChangesets(
   changesets: NewChangeset[],
   packagesByName: Map<string, Package>,
   config: Config,
-  preState: PreState | undefined,
 ): NewChangeset[] {
   for (const changeset of changesets) {
     // Using the following 2 arrays to decide whether a changeset
@@ -273,13 +271,6 @@ function getRelevantChangesets(
     }
   }
 
-  if (preState && preState.mode !== "exit") {
-    const usedChangesetIds = new Set(preState.changesets);
-    return changesets.filter(
-      (changeset) => !usedChangesetIds.has(changeset.id),
-    );
-  }
-
   return changesets;
 }
 
@@ -306,7 +297,6 @@ function getHighestPreVersion(
 }
 
 function getPreInfo(
-  changesets: NewChangeset[],
   packagesByName: Map<string, Package>,
   config: Config,
   preState: PreState | undefined,
@@ -317,7 +307,6 @@ function getPreInfo(
 
   const updatedPreState = {
     ...preState,
-    changesets: changesets.map((changeset) => changeset.id),
     initialVersions: {
       ...preState.initialVersions,
     },

--- a/packages/cli/src/commands/pre/index.test.ts
+++ b/packages/cli/src/commands/pre/index.test.ts
@@ -29,7 +29,6 @@ describe("enterPre", () => {
         await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8"),
       ),
     ).toMatchObject({
-      changesets: [],
       initialVersions: {},
       mode: "pre",
       tag: "next",
@@ -50,7 +49,6 @@ describe("enterPre", () => {
       }),
       "package-lock.json": "",
       ".changeset/pre.json": JSON.stringify({
-        changesets: [],
         initialVersions: {},
         mode: "pre",
         tag: "next",
@@ -82,7 +80,6 @@ describe("enterPre", () => {
       }),
       "package-lock.json": "",
       ".changeset/pre.json": JSON.stringify({
-        changesets: [],
         initialVersions: {},
         mode: "exit",
         tag: "beta",
@@ -95,7 +92,6 @@ describe("enterPre", () => {
         await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8"),
       ),
     ).toEqual({
-      changesets: [],
       initialVersions: {},
       mode: "pre",
       tag: "next",
@@ -119,7 +115,6 @@ describe("exitPre", () => {
       }),
       "package-lock.json": "",
       ".changeset/pre.json": JSON.stringify({
-        changesets: [],
         initialVersions: {},
         mode: "pre",
         tag: "next",
@@ -132,7 +127,6 @@ describe("exitPre", () => {
         await fs.readFile(path.join(cwd, ".changeset", "pre.json"), "utf8"),
       ),
     ).toEqual({
-      changesets: [],
       initialVersions: {},
       mode: "exit",
       tag: "next",

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -64,10 +64,8 @@ export async function version(options: VersionOptions) {
     throw new ExitError(1);
   }
 
-  const [changesets, preState] = await Promise.all([
-    readChangesets(cwd),
-    readPreState(cwd),
-  ]);
+  const preState = await readPreState(cwd);
+  const changesets = await readChangesets(cwd);
 
   if (preState?.mode === "pre") {
     if (options.snapshot != null) {

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -2454,15 +2454,8 @@ describe("pre", () => {
       "# pkg-a
 
       ## 1.1.0
-      ### Minor Changes
-
-      - g1th4sh: a very useful summary for the third change
-
       ### Patch Changes
 
-      - g1th4sh: a very useful summary
-      - g1th4sh: a very useful summary for the second change
-      - Updated dependencies [g1th4sh]
         - pkg-b@1.0.1
 
       ## 1.1.0-next.3
@@ -2496,9 +2489,6 @@ describe("pre", () => {
       "# pkg-b
 
       ## 1.0.1
-      ### Patch Changes
-
-      - g1th4sh: a very useful summary for the first change
 
       ## 1.0.1-next.0
       ### Patch Changes

--- a/packages/get-release-plan/src/index.ts
+++ b/packages/get-release-plan/src/index.ts
@@ -23,8 +23,8 @@ export async function getReleasePlan(
     ? { ...configResult.config, ...passedConfig }
     : configResult.config;
 
-  const changesets = await readChangesets(packages.rootDir, sinceRef);
   const preState = await readPreState(packages.rootDir);
+  const changesets = await readChangesets(packages.rootDir, sinceRef);
 
   return assembleReleasePlan(changesets, packages, config, preState);
 }

--- a/packages/pre/src/index.test.ts
+++ b/packages/pre/src/index.test.ts
@@ -37,7 +37,6 @@ describe("enterPre", () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "changesets": [],
         "initialVersions": {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -67,7 +66,6 @@ describe("enterPre", () => {
         version: "1.0.0",
       }),
       ".changeset/pre.json": JSON.stringify({
-        changesets: [],
         initialVersions: {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -100,7 +98,6 @@ describe("enterPre", () => {
         version: "1.0.0",
       }),
       ".changeset/pre.json": JSON.stringify({
-        changesets: ["slimy-dingos-whisper"],
         initialVersions: {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -116,9 +113,6 @@ describe("enterPre", () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "changesets": [
-          "slimy-dingos-whisper",
-        ],
         "initialVersions": {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -151,7 +145,6 @@ describe("exitPre", () => {
         version: "1.0.0",
       }),
       ".changeset/pre.json": JSON.stringify({
-        changesets: [],
         initialVersions: {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -168,7 +161,6 @@ describe("exitPre", () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "changesets": [],
         "initialVersions": {
           "pkg-a": "1.0.0",
           "pkg-b": "1.0.0",
@@ -223,7 +215,6 @@ test("readPreState reads the pre state", async () => {
       version: "1.0.0",
     }),
     ".changeset/pre.json": JSON.stringify({
-      changesets: [],
       initialVersions: {
         "pkg-a": "1.0.0",
         "pkg-b": "1.0.0",
@@ -234,7 +225,6 @@ test("readPreState reads the pre state", async () => {
   });
   expect(await readPreState(cwd)).toMatchInlineSnapshot(`
     {
-      "changesets": [],
       "initialVersions": {
         "pkg-a": "1.0.0",
         "pkg-b": "1.0.0",

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -33,6 +33,10 @@ export async function readPreState(
       throw err;
     }
   }
+
+  // The "changesets" property is not needed for v3, even if migrated from v2
+  preState = preState ? await migratePreState(rootDir, preState) : undefined;
+
   return preState;
 }
 
@@ -63,10 +67,30 @@ export async function enterPre(rootDir: string, tag: string) {
     mode: "pre",
     tag,
     initialVersions: {},
-    changesets: preState?.changesets ?? [],
   };
   for (const pkg of packages.packages) {
     newPreState.initialVersions[pkg.packageJson.name] = pkg.packageJson.version;
   }
   await outputFile(preStatePath, JSON.stringify(newPreState, null, 2) + "\n");
+}
+
+// "changesets" property is no longer needed in v3, but may exist for those migrating from v2
+async function migratePreState(
+  rootDir: string,
+  preState: PreState & { changesets?: string[] },
+): Promise<PreState> {
+  if (preState.changesets == null) {
+    return preState;
+  }
+
+  for (const changesetId of preState.changesets) {
+    await fs
+      .rm(path.resolve(rootDir, ".changeset", changesetId + ".json"))
+      .catch(() => {
+        // It's possible to specify an unknown id before without errors, so we
+        // don't throw an error here if the file doesn't exist.
+      });
+  }
+
+  return preState;
 }

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -85,12 +85,18 @@ async function migratePreState(
 
   for (const changesetId of preState.changesets) {
     await fs
-      .rm(path.resolve(rootDir, ".changeset", changesetId + ".json"))
+      .rm(path.resolve(rootDir, ".changeset", changesetId + ".md"))
       .catch(() => {
         // It's possible to specify an unknown id before without errors, so we
         // don't throw an error here if the file doesn't exist.
       });
   }
+
+  delete preState.changesets;
+  await outputFile(
+    path.resolve(rootDir, ".changeset", "pre.json"),
+    JSON.stringify(preState, null, 2) + "\n",
+  );
 
   return preState;
 }

--- a/packages/release-utils/src/readChangesetState.ts
+++ b/packages/release-utils/src/readChangesetState.ts
@@ -12,13 +12,7 @@ export async function readChangesetState(
 ): Promise<ChangesetState> {
   const preState = await readPreState(cwd);
   const isInPreMode = preState != null && preState.mode === "pre";
-
-  let changesets = await readChangesets(cwd);
-
-  if (isInPreMode && preState != null) {
-    const changesetsToFilter = new Set(preState.changesets);
-    changesets = changesets.filter((x) => !changesetsToFilter.has(x.id));
-  }
+  const changesets = await readChangesets(cwd);
 
   return {
     preState: isInPreMode ? preState : undefined,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -173,7 +173,6 @@ export type PreState = {
   initialVersions: {
     [pkgName: string]: string;
   };
-  changesets: string[];
 };
 
 export interface Package {


### PR DESCRIPTION
close https://github.com/changesets/changesets/issues/1688
close https://github.com/changesets/changesets/issues/240
fix #1050

No tracking of changesets in `pre.json`, and clear changesets during version in prerelease like normal. The final pre exit release will not contain changelog of all previous prerelease changelog. 

I'm still thinking whether to handle `pre.json` "changesets" still (filtering) so it's more compatible, but in this PR I took the more drastic approach for now and remove it entirely, and rely on `readPreState` to automatically apply the migration. The migration is mainly for those migrating from v2 while still in prerelease mode.

Any calls to `readPreState` will delete the `"changesets"` property and its referenced changeset files. This may be a little surprising.