### PR TITLE
Auto-create the directory for the target publish plan file when executing `changeset publish-plan --output <file>`

### DIFF
--- a/.changeset/public-pianos-judge.md
+++ b/.changeset/public-pianos-judge.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Auto-create the directory for the target publish plan file when executing `changeset publish-plan --output <file>`

--- a/packages/cli/src/commands/publish-plan/index.ts
+++ b/packages/cli/src/commands/publish-plan/index.ts
@@ -32,6 +32,8 @@ export async function publishPlan(
   const tagReleases = entries.filter((release) => release.kind === "tag-only");
 
   if (options?.output) {
+    const outputPath = path.resolve(cwd, options.output);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
     await fs.writeFile(
       path.resolve(cwd, options.output),
       JSON.stringify(


### PR DESCRIPTION
required for https://github.com/changesets/action/pull/663