### PR TITLE
Handle missing commit author data

### DIFF
--- a/.changeset/dirty-islands-bathe.md
+++ b/.changeset/dirty-islands-bathe.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-github-info": patch
+---
+
+Handle missing commit author data

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -229,10 +229,7 @@ export async function getInfo(request: {
   }
 
   const data = await GHDataLoader.load({ kind: "commit", ...request });
-  let user = null;
-  if (data?.author?.user) {
-    user = data.author.user;
-  }
+  let user = data?.author?.user;
 
   const associatedPullRequest =
     data.associatedPullRequests &&

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -230,7 +230,7 @@ export async function getInfo(request: {
 
   const data = await GHDataLoader.load({ kind: "commit", ...request });
   let user = null;
-  if (data.author && data.author.user) {
+  if (data?.author?.user) {
     user = data.author.user;
   }
 


### PR DESCRIPTION
fix #795 

Did a very simple fix only since the pr variant also handles similarly

https://github.com/changesets/changesets/blob/c0e6d14e22b81cbf7aefe9c30a7aac374891bf0c/packages/get-github-info/src/index.ts#L300-L301

Could look into better warnings or types later maybe.