### PR TITLE
Improve default changelog new lines handling

### DIFF
--- a/.changeset/quick-sheep-vanish.md
+++ b/.changeset/quick-sheep-vanish.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": minor
+---
+
+Improve the default unformatted changelog new lines handling to ensure consistent spacing after the heading and the spacing between release lines

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@changesets/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.1.0",
-    "outdent": "^0.8.0",
     "tinyexec": "^1.2.4"
   },
   "engines": {

--- a/packages/apply-release-plan/src/get-changelog-entry.test.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { generateMarkdownForVersionType } from "./get-changelog-entry.ts";
+
+describe("generateMarkdownForVersionType", () => {
+  it("returns undefined when there are empty lines", () => {
+    expect(generateMarkdownForVersionType("patch", ["", ""])).toBeUndefined();
+  });
+
+  it("returns proper heading based on version type", () => {
+    expect.soft(generateMarkdownForVersionType("major", ["- something"]))
+      .toMatchInlineSnapshot(`
+      "### Major Changes
+
+      - something"
+    `);
+    expect.soft(generateMarkdownForVersionType("minor", ["- something"]))
+      .toMatchInlineSnapshot(`
+      "### Minor Changes
+
+      - something"
+    `);
+    expect.soft(generateMarkdownForVersionType("patch", ["- something"]))
+      .toMatchInlineSnapshot(`
+      "### Patch Changes
+
+      - something"
+    `);
+  });
+
+  it("trims surrounding whitespace from release lines", () => {
+    expect(generateMarkdownForVersionType("minor", ["\n  - something  \n"]))
+      .toMatchInlineSnapshot(`
+			"### Minor Changes
+
+			- something"
+		`);
+  });
+
+  it("keeps preferred spacing between entries clamped between one and two new lines", () => {
+    expect(
+      generateMarkdownForVersionType("patch", [
+        "trimmed",
+        "\nleading one",
+        "\n\nleading two",
+        "\n\n\nleading three",
+        "trailing one\n",
+        "trailing two\n\n",
+        "trailing three\n\n\n",
+        "\nmixed one\n",
+        "\n\nmixed two\n\n",
+        "\n\n\nmixed three\n\n\n",
+      ]),
+    ).toMatchInlineSnapshot(`
+      "### Patch Changes
+
+      trimmed
+      leading one
+
+      leading two
+
+      leading three
+      trailing one
+      trailing two
+
+      trailing three
+
+      mixed one
+
+      mixed two
+
+      mixed three"
+    `);
+  });
+});

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -12,17 +12,6 @@ type ChangelogLines = {
   patch: Array<Promise<string>>;
 };
 
-async function generateChangesForVersionTypeMarkdown(
-  obj: ChangelogLines,
-  type: keyof ChangelogLines,
-) {
-  let releaseLines = await Promise.all(obj[type]);
-  releaseLines = releaseLines.filter((x) => x);
-  if (releaseLines.length) {
-    return `### ${capitalize(type)} Changes\n\n${releaseLines.join("\n")}\n`;
-  }
-}
-
 // release is the package and version we are releasing
 export async function getChangelogEntry(
   cwd: string,
@@ -113,12 +102,48 @@ export async function getChangelogEntry(
     ),
   );
 
+  const resolvedChangelogLines = {
+    major: await Promise.all(changelogLines.major),
+    minor: await Promise.all(changelogLines.minor),
+    patch: await Promise.all(changelogLines.patch),
+  };
+
   return [
     `## ${release.newVersion}`,
-    await generateChangesForVersionTypeMarkdown(changelogLines, "major"),
-    await generateChangesForVersionTypeMarkdown(changelogLines, "minor"),
-    await generateChangesForVersionTypeMarkdown(changelogLines, "patch"),
+    generateMarkdownForVersionType("major", resolvedChangelogLines.major),
+    generateMarkdownForVersionType("minor", resolvedChangelogLines.minor),
+    generateMarkdownForVersionType("patch", resolvedChangelogLines.patch),
   ]
     .filter((line) => line)
-    .join("\n");
+    .join("\n\n");
+}
+
+// Exported for test only
+export function generateMarkdownForVersionType(
+  type: keyof ChangelogLines,
+  lines: Array<string>,
+) {
+  const releaseLines = lines.filter((l) => l);
+  if (!releaseLines.length) return;
+
+  let content = `### ${capitalize(type)} Changes`;
+  // Track the new lines to be added between release lines. Start with two as we
+  // want the extra spacing after the heading.
+  let newLines = 2;
+
+  for (const line of releaseLines) {
+    // Factor in the starting new lines preferred by the release line
+    const startNewLinesCount = line.match(/^\n*/)?.[0].length ?? 0;
+    newLines += startNewLinesCount;
+
+    // Ensure a minimum of one new line and maximum of two new lines between release lines
+    const newLinesContent = "\n".repeat(Math.min(Math.max(newLines, 1), 2));
+    content += newLinesContent + line.trim();
+
+    // Count the ending new lines preferred by the release line for the next run
+    const endNewLinesCount = line.match(/\n*$/)?.[0].length ?? 0;
+    newLines = endNewLinesCount;
+  }
+
+  return content;
 }

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -17,7 +17,6 @@ import type {
   PreState,
 } from "@changesets/types";
 import { getPackages } from "@manypkg/get-packages";
-import { outdent } from "outdent";
 import { exec } from "tinyexec";
 import { describe, expect, it, test } from "vitest";
 import { applyReleasePlan } from "./index.ts";
@@ -2110,13 +2109,15 @@ describe("apply release plan", () => {
       if (!readmePath) throw new Error(`could not find an updated changelog`);
       const readme = await fs.readFile(readmePath, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.1.0
+        ## 1.1.0
 
-      ### Minor Changes
+        ### Minor Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
     });
 
     it("should insert new entry before existing version heading when no package title is present", async () => {
@@ -2216,21 +2217,25 @@ describe("apply release plan", () => {
       const readme = await fs.readFile(readmePath, "utf-8");
       const readmeB = await fs.readFile(readmePathB, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.1.0
+        ## 1.1.0
 
-      ### Minor Changes
+        ### Minor Changes
 
-      - Hey, let's have fun with testing!
+        - Hey, let's have fun with testing!
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - pkg-b@2.0.0`);
+        - pkg-b@2.0.0"
+      `);
 
-      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+      expect(readmeB.trim()).toMatchInlineSnapshot(`
+        "# pkg-b
 
-      ## 2.0.0`);
+        ## 2.0.0"
+      `);
     });
 
     it("should not update the changelog if only devDeps changed", async () => {
@@ -2351,20 +2356,21 @@ describe("apply release plan", () => {
 
       if (!readmePath) throw new Error(`could not find an updated changelog`);
       const readme = await fs.readFile(readmePath, "utf-8");
-      expect(readme.trim()).toEqual(
-        [
-          "# pkg-a\n",
-          "## 1.1.0\n",
-          "### Minor Changes\n",
-          "- Hey, let's have fun with testing!",
-          "- Random stuff",
-          "  ",
-          "  get it while it's hot!",
-          "- New feature, much wow",
-          "  ",
-          "  look at this shiny stuff!",
-        ].join("\n"),
-      );
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
+
+        ## 1.1.0
+
+        ### Minor Changes
+
+        - Hey, let's have fun with testing!
+        - Random stuff
+          
+          get it while it's hot!
+        - New feature, much wow
+          
+          look at this shiny stuff!"
+      `);
     });
 
     it("should add an updated dependencies line when dependencies have been updated", async () => {
@@ -2454,25 +2460,29 @@ describe("apply release plan", () => {
       const readme = await fs.readFile(readmePath, "utf-8");
       const readmeB = await fs.readFile(readmePathB, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.0.4
+        ## 1.0.4
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!
-      - Updated dependencies
-        - pkg-b@1.2.1`);
+        - Hey, let's have fun with testing!
+        - Updated dependencies
+          - pkg-b@1.2.1"
+      `);
 
-      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+      expect(readmeB.trim()).toMatchInlineSnapshot(`
+        "# pkg-b
 
-      ## 1.2.1
+        ## 1.2.1
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!
-      - Updated dependencies
-        - pkg-a@1.0.4`);
+        - Hey, let's have fun with testing!
+        - Updated dependencies
+          - pkg-a@1.0.4"
+      `);
     });
 
     it("should NOT add updated dependencies line if dependencies have NOT been updated", async () => {
@@ -2562,21 +2572,25 @@ describe("apply release plan", () => {
       const readme = await fs.readFile(readmePath, "utf-8");
       const readmeB = await fs.readFile(readmePathB, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.0.4
+        ## 1.0.4
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
 
-      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+      expect(readmeB.trim()).toMatchInlineSnapshot(`
+        "# pkg-b
 
-      ## 1.2.1
+        ## 1.2.1
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
     });
 
     it("should only add updated dependencies line for dependencies that have been updated", async () => {
@@ -2686,31 +2700,37 @@ describe("apply release plan", () => {
       const readmeB = await fs.readFile(readmePathB, "utf-8");
       const readmeC = await fs.readFile(readmePathC, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.0.4
+        ## 1.0.4
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
 
-      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+      expect(readmeB.trim()).toMatchInlineSnapshot(`
+        "# pkg-b
 
-      ## 1.2.1
+        ## 1.2.1
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!
-      - Updated dependencies
-        - pkg-c@2.1.0`);
+        - Hey, let's have fun with testing!
+        - Updated dependencies
+          - pkg-c@2.1.0"
+      `);
 
-      expect(readmeC.trim()).toEqual(outdent`# pkg-c
+      expect(readmeC.trim()).toMatchInlineSnapshot(`
+        "# pkg-c
 
-      ## 2.1.0
+        ## 2.1.0
 
-      ### Minor Changes
+        ### Minor Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
     });
 
     it("should still add updated dependencies line for dependencies that have a bump type less than the minimum internal bump range but leave semver range", async () => {
@@ -2820,31 +2840,37 @@ describe("apply release plan", () => {
       const readmeB = await fs.readFile(readmePathB, "utf-8");
       const readmeC = await fs.readFile(readmePathC, "utf-8");
 
-      expect(readme.trim()).toEqual(outdent`# pkg-a
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# pkg-a
 
-      ## 1.0.4
+        ## 1.0.4
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
 
-      expect(readmeB.trim()).toEqual(outdent`# pkg-b
+      expect(readmeB.trim()).toMatchInlineSnapshot(`
+        "# pkg-b
 
-      ## 1.2.1
+        ## 1.2.1
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!
-      - Updated dependencies
-        - pkg-c@2.0.1`);
+        - Hey, let's have fun with testing!
+        - Updated dependencies
+          - pkg-c@2.0.1"
+      `);
 
-      expect(readmeC.trim()).toEqual(outdent`# pkg-c
+      expect(readmeC.trim()).toMatchInlineSnapshot(`
+        "# pkg-c
 
-      ## 2.0.1
+        ## 2.0.1
 
-      ### Patch Changes
+        ### Patch Changes
 
-      - Hey, let's have fun with testing!`);
+        - Hey, let's have fun with testing!"
+      `);
     });
   });
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2113,6 +2113,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - Hey, let's have fun with testing!`);
@@ -2150,6 +2151,7 @@ describe("apply release plan", () => {
 
       expect(readme).toMatchInlineSnapshot(`
         "## 1.1.0
+
         ### Minor Changes
 
         - Hey, let's have fun with testing!
@@ -2217,13 +2219,14 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - Hey, let's have fun with testing!
 
       ### Patch Changes
 
-        - pkg-b@2.0.0`);
+      - pkg-b@2.0.0`);
 
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
@@ -2351,7 +2354,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(
         [
           "# pkg-a\n",
-          "## 1.1.0",
+          "## 1.1.0\n",
           "### Minor Changes\n",
           "- Hey, let's have fun with testing!",
           "- Random stuff",
@@ -2454,6 +2457,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.0.4
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!
@@ -2463,6 +2467,7 @@ describe("apply release plan", () => {
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
       ## 1.2.1
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!
@@ -2560,6 +2565,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.0.4
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);
@@ -2567,6 +2573,7 @@ describe("apply release plan", () => {
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
       ## 1.2.1
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);
@@ -2682,6 +2689,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.0.4
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);
@@ -2689,6 +2697,7 @@ describe("apply release plan", () => {
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
       ## 1.2.1
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!
@@ -2698,6 +2707,7 @@ describe("apply release plan", () => {
       expect(readmeC.trim()).toEqual(outdent`# pkg-c
 
       ## 2.1.0
+
       ### Minor Changes
 
       - Hey, let's have fun with testing!`);
@@ -2813,6 +2823,7 @@ describe("apply release plan", () => {
       expect(readme.trim()).toEqual(outdent`# pkg-a
 
       ## 1.0.4
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);
@@ -2820,6 +2831,7 @@ describe("apply release plan", () => {
       expect(readmeB.trim()).toEqual(outdent`# pkg-b
 
       ## 1.2.1
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!
@@ -2829,6 +2841,7 @@ describe("apply release plan", () => {
       expect(readmeC.trim()).toEqual(outdent`# pkg-c
 
       ## 2.0.1
+
       ### Patch Changes
 
       - Hey, let's have fun with testing!`);

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -632,6 +632,7 @@ Awesome feature, hidden behind a feature flag
       "# pkg-a
 
       ## 2.0.0
+
       ### Major Changes
 
       - g1th4sh: a summary with special replacement patterns \`react$\` $'
@@ -936,13 +937,14 @@ describe("fixed", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
 
       ### Patch Changes
 
-        - pkg-b@1.1.0
+      - pkg-b@1.1.0
       "
     `);
     expect(await getChangelog("pkg-b", cwd)).toMatchInlineSnapshot(`
@@ -968,22 +970,24 @@ describe("fixed", () => {
       "# pkg-a
 
       ## 1.2.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
 
       ### Patch Changes
 
-        - pkg-b@1.2.0
+      - pkg-b@1.2.0
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
 
       ### Patch Changes
 
-        - pkg-b@1.1.0
+      - pkg-b@1.1.0
       "
     `);
     expect(await getChangelog("pkg-b", cwd)).toMatchInlineSnapshot(`
@@ -1323,6 +1327,7 @@ describe("workspace range", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
@@ -1333,6 +1338,7 @@ describe("workspace range", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]
@@ -1374,6 +1380,7 @@ describe("workspace range", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
@@ -1384,6 +1391,7 @@ describe("workspace range", () => {
       "# pkg-b
 
       ## 2.0.0
+
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]
@@ -1431,6 +1439,7 @@ describe("workspace range", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
@@ -2069,6 +2078,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-a
 
       ## 1.0.1
+
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]
@@ -2079,6 +2089,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - g1th4sh: This is not a summary
@@ -2154,6 +2165,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
@@ -2230,6 +2242,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - g1th4sh: This is some fix
@@ -2297,6 +2310,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: This is a summary
@@ -2307,6 +2321,7 @@ describe("updateInternalDependents: always", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - g1th4sh: This is some fix
@@ -2454,6 +2469,7 @@ describe("pre", () => {
       "# pkg-a
 
       ## 1.1.0
+
       ### Minor Changes
 
       - g1th4sh: a very useful summary for the third change
@@ -2466,21 +2482,25 @@ describe("pre", () => {
         - pkg-b@1.0.1
 
       ## 1.1.0-next.3
+
       ### Minor Changes
 
       - g1th4sh: a very useful summary for the third change
 
       ## 1.0.1-next.2
+
       ### Patch Changes
 
       - g1th4sh: a very useful summary for the second change
 
       ## 1.0.1-next.1
+
       ### Patch Changes
 
       - g1th4sh: a very useful summary
 
       ## 1.0.1-next.0
+
       ### Patch Changes
 
       - Updated dependencies [g1th4sh]
@@ -2496,11 +2516,13 @@ describe("pre", () => {
       "# pkg-b
 
       ## 1.0.1
+
       ### Patch Changes
 
       - g1th4sh: a very useful summary for the first change
 
       ## 1.0.1-next.0
+
       ### Patch Changes
 
       - g1th4sh: a very useful summary for the first change

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       '@manypkg/get-packages':
         specifier: ^3.1.0
         version: 3.1.0
-      outdent:
-        specifier: ^0.8.0
-        version: 0.8.0
       tinyexec:
         specifier: ^1.2.4
         version: 1.2.4


### PR DESCRIPTION
fixes #748

Uses a slightly sophisticated handling when joining release lines to ensure there's a minimum of one new line and maximum of two new lines between the release lines.

One new line means there's only one `\n`, so there's no spacing in between. Two new lines is `\n\n` so there's a spacing in between.

Also ensure that headings such as `### Major changes` and `## 1.0.0` are followed with `\n\n`. This should look more proper to how most formatters format it.

## Context and thought process

I did this change in the `getChangelogEntry` side instead of the changelog generator side (e.g. `changelog-github`), because it's possible that some generators prefer lines to be followed together or with spacing in between. For example:

`changelog-git`:
```md
- change one
- change two
```

`changelog-github`:
```md
- [abc123] change one (#1234)

- [def456] change two (#5678)
```

But at the same time, we limit to a maximum of 2 new lines in between (one spacing) because there's not a lot of reason in practice to want more than that. So `getChangelogEntry` has a little opinion on that, but in return generators don't need to think too deeply on how new lines would be combined in the changelog. Maybe we want to discuss this magic a bit.