### PR TITLE
Fix `lint-staged:setup` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "check-all": "pnpm build && pnpm test run && pnpm types:check && pnpm lint && pnpm format",
     "version-packages": "changeset version && pnpm format:fix",
     "release": "changeset publish",
-    "lint-staged:setup": "pnpm run --sequential /lint-staged:setup:\\d/",
+    "lint-staged:setup": "pnpm run --sequential \"/lint-staged:setup:\\d/\"",
     "lint-staged:setup:1": "git config set hook.\"lint-staged\".event pre-commit",
     "lint-staged:setup:2": "git config set hook.\"lint-staged\".command \"node node_modules/lint-staged/bin/lint-staged.js\""
   },


### PR DESCRIPTION
`\` was being lost on my unix machine and then the script was misinterpreted