### PR TITLE
Add version providers with initial Ruby support

### DIFF
--- a/.changeset/fresh-ravens-provide.md
+++ b/.changeset/fresh-ravens-provide.md
@@ -1,0 +1,8 @@
+---
+"@changesets/apply-release-plan": minor
+"@changesets/cli": minor
+"@changesets/config": minor
+"@changesets/types": minor
+---
+
+Add version providers with initial Ruby support.

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -79,7 +79,7 @@ changeset add --since=develop
 changeset version
 ```
 
-This is one of two commands responsible for releasing packages. The version command takes changesets that have been made and updates versions and dependencies of packages, as well as writing changelogs. It is responsible for all file changes to versions before publishing to npm.
+This is one of two commands responsible for releasing packages. The version command takes changesets that have been made and updates versions and dependencies of packages, as well as writing changelogs. By default it updates `package.json` files, and the [`versionProvider`](./config-file-options.md#versionprovider-node--ruby--object) config can keep other ecosystem-specific version files in sync before publishing.
 
 > We recommend making sure changes made from this command are merged back into the base branch before you run publish.
 

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -244,6 +244,60 @@ When `tag` is set to `true`, Changesets will create a tag for private packages. 
 }
 ```
 
+## `versionProvider` (`"node"` | `"ruby"` | object)
+
+This option controls which provider reads and updates version files when `changeset version` applies a release plan. When unset, Changesets uses automatic provider selection.
+
+The `node` provider updates the package's `package.json` version and npm dependency ranges. This is the historical Changesets behavior.
+
+The `ruby` provider reads the current version from Ruby version files and updates them when they exist:
+
+- `lib/<gem-name>/version.rb` or a single discovered `lib/**/version.rb`
+- `<gem-name>.gemspec` or a single discovered root `*.gemspec`
+- `Gemfile.lock`
+
+When `versionProvider` is unset, Changesets selects the Ruby provider if it finds Ruby version files in the package directory. Otherwise it uses the Node provider. Package-specific entries in `packages` take precedence over the default provider.
+
+You can configure a single provider for every package:
+
+```json
+{
+  "versionProvider": "ruby"
+}
+```
+
+For mixed repositories, configure a default and package-specific overrides:
+
+```json
+{
+  "versionProvider": {
+    "packages": {
+      "my-gem": {
+        "type": "ruby",
+        "gemName": "my-gem",
+        "versionFile": "lib/my_gem/version.rb",
+        "gemspec": "my-gem.gemspec",
+        "gemfileLock": "Gemfile.lock"
+      }
+    }
+  }
+}
+```
+
+Set `versionFile`, `gemspec`, or `gemfileLock` to `false` to skip that Ruby file.
+
+### Ruby provider options
+
+- `type`: must be `"ruby"`.
+- `gemName`: the Ruby gem name used to find `<gem-name>.gemspec`, `lib/<gem-name>/version.rb`, and the `Gemfile.lock` entry. If omitted, Changesets derives it from the package name.
+- `versionFile`: path to a Ruby version file, relative to the package directory. If omitted, Changesets checks `lib/<gem-name>/version.rb`, `lib/<gem-name-with-underscores>/version.rb`, or a single discovered `lib/**/version.rb`.
+- `gemspec`: path to a `.gemspec` file, relative to the package directory. If omitted, Changesets checks `<gem-name>.gemspec`, `<gem-name-with-underscores>.gemspec`, or a single discovered root `.gemspec`.
+- `gemfileLock`: path to `Gemfile.lock`, relative to the package directory. If omitted, Changesets updates `Gemfile.lock` when it exists.
+
+Configured paths must exist. Auto-discovered files are optional; if multiple ambiguous `version.rb` or `.gemspec` files exist, Changesets leaves those files unchanged unless you configure the exact path.
+
+When updating `Gemfile.lock`, prerelease versions are converted to Bundler's lockfile format. For example, `2.0.0-beta.1` is written as `2.0.0.pre.beta.1`.
+
 ## `changedFilePatterns` (array of strings)
 
 Glob patterns for changed files that should mark a package as changed. Useful to fine-tune what counts as a change (e.g. only source files, ignoring test files, etc).

--- a/docs/versioning-apps.md
+++ b/docs/versioning-apps.md
@@ -2,12 +2,51 @@
 
 Changesets can also be used to manage application versions or non-npm packages (ie dotnet NuGet packages, ruby gems, docker images etc).
 
-The only requirement is that the project has a package.json file to manage the versions and dependencies within the repo.
+The only requirement is that the project has a `package.json` file with package metadata so Changesets can discover the package and calculate release plans.
 
 To enable this feature set `privatePackages` to `{ version: true, tag: true }` in your `.changesets/config.json` file. By default changesets will only update the changelog and version (ie `{ version: true, tag: false }`).
 
 > **Note**
-> Changesets only versions NPM package.json files, you can trigger releases for other package formats by creating workflows which trigger on tags/releases being created by changesets.
+> Changesets currently uses package metadata from `package.json` for package discovery. Version providers control where the current version is read from and which files are written when versions are applied. You should trigger non-npm publishes with your own workflows.
+
+## Ruby gems
+
+For Ruby gems, you can use the Ruby version provider to update common Ruby version files.
+
+If your gem has conventional file names, the default automatic provider selection will use the Ruby provider when it detects Ruby version files:
+
+```json
+{
+  "privatePackages": { "version": true, "tag": true }
+}
+```
+
+The Ruby provider reads the current version from Ruby files and updates:
+
+- `lib/<gem-name>/version.rb` or a single discovered `lib/**/version.rb`
+- `<gem-name>.gemspec` or a single discovered root `*.gemspec`
+- `Gemfile.lock`, converting prereleases such as `2.0.0-beta.1` to Bundler's `2.0.0.pre.beta.1` lockfile format
+
+For non-standard file names, configure package-specific paths:
+
+```json
+{
+  "privatePackages": { "version": true, "tag": true },
+  "versionProvider": {
+    "packages": {
+      "my-gem": {
+        "type": "ruby",
+        "gemName": "my-gem",
+        "versionFile": "lib/my_gem/version.rb",
+        "gemspec": "my-gem.gemspec",
+        "gemfileLock": "Gemfile.lock"
+      }
+    }
+  }
+}
+```
+
+Set `versionFile`, `gemspec`, or `gemfileLock` to `false` to skip that file. Publishing to RubyGems should still be handled by your own release workflow.
 
 ## Setting up a package
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -407,6 +407,100 @@ end
         ).resolves.toContain(`VERSION = "1.1.0"`);
       });
 
+      it("updates a single discovered root gemspec", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: {
+              type: "ruby",
+              versionFile: false,
+              gemfileLock: false,
+            },
+            packages: {},
+          },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "custom.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual(["custom.gemspec"]);
+        await expect(
+          fs.readFile(path.join(tempDir, "custom.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+      });
+
+      it("uses scoped package names to discover Ruby version files", async () => {
+        const releasePlan: ReleasePlan = {
+          changesets: [
+            {
+              id: "tame-rubies-serve",
+              summary: "Update scoped Ruby gem",
+              releases: [{ name: "@scope/my-gem", type: "minor" }],
+            },
+          ],
+          releases: [
+            {
+              name: "@scope/my-gem",
+              type: "minor",
+              oldVersion: "1.0.0",
+              newVersion: "1.1.0",
+              changesets: ["tame-rubies-serve"],
+            },
+          ],
+          preState: undefined,
+        };
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "@scope/my-gem",
+              private: true,
+              version: "1.0.0",
+            }),
+            "lib/my/gem/version.rb": `module My
+  module Gem
+    VERSION = "1.0.0"
+  end
+end
+`,
+            "my-gem.gemspec": `Gem::Specification.new do |spec|
+  spec.name = "my-gem"
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan,
+          {
+            versionProvider: { default: "ruby", packages: {} },
+          },
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual([
+          path.join("lib", "my", "gem", "version.rb"),
+          "my-gem.gemspec",
+        ]);
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/my/gem/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.1.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "my-gem.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+      });
+
       it("does not guess between multiple discovered Ruby version files", async () => {
         const releasePlan = new FakeReleasePlan([], [], {
           versionProvider: { default: "ruby", packages: {} },
@@ -458,6 +552,62 @@ end
         ).resolves.toContain(`Gem::Version.new("1.1.0")`);
       });
 
+      it("throws when a configured Ruby gemspec path is missing", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: {
+              type: "ruby",
+              versionFile: false,
+              gemspec: "missing.gemspec",
+              gemfileLock: false,
+            },
+            packages: {},
+          },
+        });
+
+        await expect(
+          testSetup(
+            {
+              "package.json": JSON.stringify({
+                name: "pkg-a",
+                private: true,
+                version: "1.0.0",
+              }),
+            },
+            releasePlan.getReleasePlan(),
+            releasePlan.config,
+          ),
+        ).rejects.toThrow("gemspec not found");
+      });
+
+      it("throws when a configured Gemfile.lock path is missing", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: {
+              type: "ruby",
+              versionFile: false,
+              gemspec: false,
+              gemfileLock: "bundler/Gemfile.lock",
+            },
+            packages: {},
+          },
+        });
+
+        await expect(
+          testSetup(
+            {
+              "package.json": JSON.stringify({
+                name: "pkg-a",
+                private: true,
+                version: "1.0.0",
+              }),
+            },
+            releasePlan.getReleasePlan(),
+            releasePlan.config,
+          ),
+        ).rejects.toThrow("Gemfile.lock not found");
+      });
+
       it("throws when a configured Ruby file path is missing", async () => {
         const releasePlan = new FakeReleasePlan([], [], {
           versionProvider: {
@@ -484,6 +634,28 @@ end
             releasePlan.config,
           ),
         ).rejects.toThrow("Ruby version file not found");
+      });
+
+      it("throws for an unknown configured version provider", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: "python" as "node",
+            packages: {},
+          },
+        });
+
+        await expect(
+          testSetup(
+            {
+              "package.json": JSON.stringify({
+                name: "pkg-a",
+                version: "1.0.0",
+              }),
+            },
+            releasePlan.getReleasePlan(),
+            releasePlan.config,
+          ),
+        ).rejects.toThrow("Unknown version provider: python");
       });
 
       it("does not update package.json dependency ranges when using the Ruby provider", async () => {

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -30,6 +30,18 @@ const changesetsCliCommitPath = path.resolve(
   "../../cli/dist/commit.mjs",
 );
 
+function getTestConfig(config: Partial<Config> = {}): Config {
+  return {
+    ...defaultConfig,
+    changelog: false,
+    snapshot: {
+      ...defaultConfig.snapshot,
+      prereleaseTemplate: null,
+    },
+    ...config,
+  };
+}
+
 class FakeReleasePlan {
   changesets: NewChangeset[];
   releases: ComprehensiveRelease[];
@@ -52,28 +64,7 @@ class FakeReleasePlan {
       newVersion: "1.1.0",
       changesets: ["quick-lions-devour"],
     };
-    this.config = {
-      changelog: false,
-      commit: false,
-      fixed: [],
-      linked: [],
-      access: "restricted",
-      changedFilePatterns: ["**"],
-      baseBranch: "main",
-      updateInternalDependencies: "patch",
-      ignore: [],
-      format: "auto",
-      privatePackages: { version: true, tag: false },
-      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: false,
-        updateInternalDependents: "out-of-range",
-      },
-      snapshot: {
-        useCalculatedVersion: false,
-        prereleaseTemplate: null,
-      },
-      ...config,
-    };
+    this.config = getTestConfig(config);
 
     this.changesets = [baseChangeset, ...changesets];
     this.releases = [baseRelease, ...releases];
@@ -91,40 +82,18 @@ class FakeReleasePlan {
 async function testSetup(
   fixture: Fixture,
   releasePlan: ReleasePlan,
-  config?: Config,
+  config?: Partial<Config>,
   snapshot?: string,
   setupFunc?: (tempDir: string) => Promise<unknown>,
 ) {
-  if (!config) {
-    config = {
-      changelog: false,
-      commit: false,
-      fixed: [],
-      linked: [],
-      access: "restricted",
-      changedFilePatterns: ["**"],
-      baseBranch: "main",
-      updateInternalDependencies: "patch",
-      ignore: [],
-      format: "auto",
-      privatePackages: { version: true, tag: false },
-      snapshot: {
-        useCalculatedVersion: false,
-        prereleaseTemplate: null,
-      },
-      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: false,
-        updateInternalDependents: "out-of-range",
-      },
-    };
-  }
+  const testConfig = getTestConfig(config);
   const tempDir = await testdir(fixture);
 
   if (setupFunc) {
     await setupFunc(tempDir);
   }
 
-  if (config.commit) {
+  if (testConfig.commit) {
     await exec("git", ["init"], { nodeOptions: { cwd: tempDir } });
     await git.add(".", tempDir);
     await git.commit("first commit", tempDir);
@@ -136,7 +105,7 @@ async function testSetup(
     changedFiles: await applyReleasePlan(
       releasePlan,
       packages,
-      config,
+      testConfig,
       snapshot,
     ),
     tempDir,
@@ -149,6 +118,454 @@ async function readJson(path: string) {
 
 describe("apply release plan", () => {
   describe("versioning", () => {
+    describe("version providers", () => {
+      it("updates Ruby version files with the Ruby provider", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: { default: "ruby", packages: {} },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "lib/pkg_a/version.rb": `module PkgA
+  VERSION = "1.0.0"
+end
+`,
+            "pkg-a.gemspec": `Gem::Specification.new do |spec|
+  spec.name = "pkg-a"
+  spec.version = "1.0.0"
+end
+`,
+            "Gemfile.lock": `PATH
+  remote: .
+  specs:
+    pkg-a (1.0.0)
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          await readJson(path.join(tempDir, "package.json")),
+        ).toMatchObject({
+          version: "1.0.0",
+        });
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/pkg_a/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.1.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "pkg-a.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "Gemfile.lock"), "utf8"),
+        ).resolves.toContain(`pkg-a (1.1.0)`);
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual([
+          path.join("lib", "pkg_a", "version.rb"),
+          "pkg-a.gemspec",
+          "Gemfile.lock",
+        ]);
+      });
+
+      it("uses Bundler prerelease formatting in Gemfile.lock", async () => {
+        const releasePlan = new FakeReleasePlan(
+          [],
+          [
+            {
+              name: "pkg-a",
+              type: "major",
+              oldVersion: "1.0.0",
+              newVersion: "2.0.0-beta.1",
+              changesets: ["quick-lions-devour"],
+            },
+          ],
+          {
+            versionProvider: {
+              default: {
+                type: "ruby",
+                versionFile: false,
+                gemspec: false,
+              },
+              packages: {},
+            },
+          },
+        );
+        releasePlan.releases.shift();
+
+        const { tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "Gemfile.lock": `PATH
+  remote: .
+  specs:
+    pkg-a (1.0.0)
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        await expect(
+          fs.readFile(path.join(tempDir, "Gemfile.lock"), "utf8"),
+        ).resolves.toContain(`pkg-a (2.0.0.pre.beta.1)`);
+      });
+
+      it("auto-detects the Ruby provider when Ruby version files exist", async () => {
+        const releasePlan = new FakeReleasePlan();
+        const { tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "pkg-a.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        await expect(
+          fs.readFile(path.join(tempDir, "pkg-a.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+      });
+
+      it("uses the Node provider when auto detection finds no Ruby files", async () => {
+        const releasePlan = new FakeReleasePlan();
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              version: "1.0.0",
+            }),
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual(["package.json"]);
+        expect(
+          await readJson(path.join(tempDir, "package.json")),
+        ).toMatchObject({
+          version: "1.1.0",
+        });
+      });
+
+      it("lets an explicit Node provider ignore Ruby files", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: { default: "node", packages: {} },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "pkg-a.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual(["package.json"]);
+        await expect(
+          fs.readFile(path.join(tempDir, "pkg-a.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.0.0"`);
+      });
+
+      it("uses package-specific providers before the default provider", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: "node",
+            packages: {
+              "pkg-a": "ruby",
+            },
+          },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "pkg-a.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual(["pkg-a.gemspec"]);
+        await expect(
+          fs.readFile(path.join(tempDir, "pkg-a.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+      });
+
+      it("updates configured Ruby file paths and skips disabled Ruby files", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: {
+              type: "ruby",
+              gemName: "custom-gem",
+              versionFile: "src/custom/version.rb",
+              gemspec: "custom.gemspec",
+              gemfileLock: false,
+            },
+            packages: {},
+          },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "src/custom/version.rb": `module Custom
+  VERSION = "1.0.0"
+end
+`,
+            "custom.gemspec": `Gem::Specification.new do |spec|
+  spec.name = "custom-gem"
+  spec.version = "1.0.0"
+end
+`,
+            "Gemfile.lock": `PATH
+  remote: .
+  specs:
+    custom-gem (1.0.0)
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual([path.join("src", "custom", "version.rb"), "custom.gemspec"]);
+        await expect(
+          fs.readFile(path.join(tempDir, "src/custom/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.1.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "custom.gemspec"), "utf8"),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "Gemfile.lock"), "utf8"),
+        ).resolves.toContain(`custom-gem (1.0.0)`);
+      });
+
+      it("updates a single discovered nested Ruby version file", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: { default: "ruby", packages: {} },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "lib/anything/version.rb": `module Anything
+  VERSION = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual([path.join("lib", "anything", "version.rb")]);
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/anything/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.1.0"`);
+      });
+
+      it("does not guess between multiple discovered Ruby version files", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: { default: "ruby", packages: {} },
+        });
+        const { changedFiles, tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "lib/one/version.rb": `VERSION = "1.0.0"\n`,
+            "lib/two/version.rb": `VERSION = "1.0.0"\n`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          changedFiles.map((file) => path.relative(tempDir, file)),
+        ).toEqual([]);
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/one/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.0.0"`);
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/two/version.rb"), "utf8"),
+        ).resolves.toContain(`VERSION = "1.0.0"`);
+      });
+
+      it("updates quoted versions in Ruby version files without a VERSION constant", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: { default: "ruby", packages: {} },
+        });
+        const { tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+            }),
+            "lib/pkg_a/version.rb": `Gem::Version.new("1.0.0")\n`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        await expect(
+          fs.readFile(path.join(tempDir, "lib/pkg_a/version.rb"), "utf8"),
+        ).resolves.toContain(`Gem::Version.new("1.1.0")`);
+      });
+
+      it("throws when a configured Ruby file path is missing", async () => {
+        const releasePlan = new FakeReleasePlan([], [], {
+          versionProvider: {
+            default: {
+              type: "ruby",
+              versionFile: "lib/missing/version.rb",
+              gemspec: false,
+              gemfileLock: false,
+            },
+            packages: {},
+          },
+        });
+
+        await expect(
+          testSetup(
+            {
+              "package.json": JSON.stringify({
+                name: "pkg-a",
+                private: true,
+                version: "1.0.0",
+              }),
+            },
+            releasePlan.getReleasePlan(),
+            releasePlan.config,
+          ),
+        ).rejects.toThrow("Ruby version file not found");
+      });
+
+      it("does not update package.json dependency ranges when using the Ruby provider", async () => {
+        const releasePlan = new FakeReleasePlan(
+          [
+            {
+              id: "slow-widgets-rest",
+              summary: "Update pkg-b",
+              releases: [{ name: "pkg-b", type: "patch" }],
+            },
+          ],
+          [
+            {
+              name: "pkg-b",
+              type: "patch",
+              oldVersion: "1.0.0",
+              newVersion: "1.0.1",
+              changesets: ["slow-widgets-rest"],
+            },
+          ],
+          {
+            versionProvider: { default: "ruby", packages: {} },
+          },
+        );
+        const { tempDir } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              name: "root",
+              private: true,
+              version: "0.0.0",
+            }),
+            "pnpm-workspace.yaml": "packages: ['packages/*']",
+            "pnpm-lock.yaml": "",
+            "packages/pkg-a/package.json": JSON.stringify({
+              name: "pkg-a",
+              private: true,
+              version: "1.0.0",
+              dependencies: {
+                "pkg-b": "^1.0.0",
+              },
+            }),
+            "packages/pkg-a/pkg-a.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+            "packages/pkg-b/package.json": JSON.stringify({
+              name: "pkg-b",
+              private: true,
+              version: "1.0.0",
+            }),
+            "packages/pkg-b/pkg-b.gemspec": `Gem::Specification.new do |spec|
+  spec.version = "1.0.0"
+end
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(
+          await readJson(path.join(tempDir, "packages/pkg-a/package.json")),
+        ).toMatchObject({
+          version: "1.0.0",
+          dependencies: {
+            "pkg-b": "^1.0.0",
+          },
+        });
+        await expect(
+          fs.readFile(
+            path.join(tempDir, "packages/pkg-a/pkg-a.gemspec"),
+            "utf8",
+          ),
+        ).resolves.toContain(`spec.version = "1.1.0"`);
+        await expect(
+          fs.readFile(
+            path.join(tempDir, "packages/pkg-b/pkg-b.gemspec"),
+            "utf8",
+          ),
+        ).resolves.toContain(`spec.version = "1.0.1"`);
+      });
+    });
+
     describe("formatting", () => {
       it("should not reformat a small array in a package.json", async () => {
         const releasePlan = new FakeReleasePlan();

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -18,12 +18,12 @@ import type {
   ReleasePlan,
 } from "@changesets/types";
 import { resolve } from "import-meta-resolve";
-import { editJson } from "./edit-json.ts";
 import { getChangelogEntry } from "./get-changelog-entry.ts";
 import {
   versionPackage,
   type ModCompWithPackageAndChangelog,
 } from "./version-package.ts";
+export { updatePackageVersionsFromVersionProviders } from "./version-providers/index.ts";
 
 function importResolveFromDir(specifier: string, dir: string) {
   return resolve(specifier, pathToFileURL(path.join(dir, "x.mjs")).toString());
@@ -124,28 +124,30 @@ export async function applyReleasePlan(
   );
 
   // iterate over releases updating packages
-  const finalisedRelease = releaseWithChangelogs.map((release) => {
-    return versionPackage(release, versionsToUpdate, {
-      cwd,
-      updateInternalDependencies: config.updateInternalDependencies,
-      onlyUpdatePeerDependentsWhenOutOfRange:
-        config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          .onlyUpdatePeerDependentsWhenOutOfRange,
-      bumpVersionsWithWorkspaceProtocolOnly:
-        config.bumpVersionsWithWorkspaceProtocolOnly,
-      snapshot,
-    });
-  });
+  const finalisedRelease = await Promise.all(
+    releaseWithChangelogs.map((release) => {
+      return versionPackage(release, versionsToUpdate, {
+        cwd,
+        updateInternalDependencies: config.updateInternalDependencies,
+        onlyUpdatePeerDependentsWhenOutOfRange:
+          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+            .onlyUpdatePeerDependentsWhenOutOfRange,
+        bumpVersionsWithWorkspaceProtocolOnly:
+          config.bumpVersionsWithWorkspaceProtocolOnly,
+        snapshot,
+        versionProvider: config.versionProvider,
+      });
+    }),
+  );
 
   const filesToFormat: string[] = [];
   for (const release of finalisedRelease) {
-    const { changelog, pkgJsonEdits, dir, name } = release;
+    const { changelog, versionedFiles, dir, name } = release;
 
-    const pkgJsonPath = path.resolve(dir, "package.json");
-    const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
-    const pkgUpdated = editJson(pkgRaw, pkgJsonEdits);
-    await fs.writeFile(pkgJsonPath, pkgUpdated);
-    touchedFiles.push(pkgJsonPath);
+    for (const file of versionedFiles) {
+      await fs.writeFile(file.path, file.content);
+      touchedFiles.push(file.path);
+    }
 
     if (changelog && changelog.length > 0) {
       const changelogPath = path.resolve(dir, "CHANGELOG.md");

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -1,132 +1,52 @@
-import type { ModCompWithPackage, VersionType } from "@changesets/types";
-import Range from "semver/classes/range.js";
-import semverPrerelease from "semver/functions/prerelease.js";
-import validRange from "semver/ranges/valid.js";
-import type { EditJsonOperation } from "./edit-json.ts";
-import { shouldUpdateDependencyBasedOnConfig } from "./utils.ts";
+import type { Config } from "@changesets/types";
+import { getVersionProvider } from "./version-providers/index.ts";
+import type {
+  ModCompWithPackageAndChangelog,
+  VersionProviderContext,
+  VersionedFile,
+  VersionToUpdate,
+} from "./version-providers/types.ts";
 
-const DEPENDENCY_TYPES = [
-  "dependencies",
-  "devDependencies",
-  "peerDependencies",
-  "optionalDependencies",
-] as const;
-
-export type ModCompWithPackageAndChangelog = ModCompWithPackage & {
-  changelog: string | null;
-};
+export type { ModCompWithPackageAndChangelog } from "./version-providers/types.ts";
 
 type ModCompWithPackageAndChangelogAndEdits = ModCompWithPackageAndChangelog & {
-  pkgJsonEdits: EditJsonOperation[];
+  versionedFiles: VersionedFile[];
 };
 
-export function versionPackage(
+type VersionPackageOptions = Omit<
+  VersionProviderContext,
+  "pkg" | "release" | "versionsToUpdate"
+> & {
+  versionProvider: Config["versionProvider"];
+};
+
+export async function versionPackage(
   release: ModCompWithPackageAndChangelog,
-  versionsToUpdate: Array<{
-    name: string;
-    version: string;
-    oldVersion: string;
-    type: VersionType;
-    dir: string;
-  }>,
-  {
-    cwd,
-    updateInternalDependencies,
-    onlyUpdatePeerDependentsWhenOutOfRange,
-    bumpVersionsWithWorkspaceProtocolOnly,
-    snapshot,
-  }: {
-    cwd: string;
-    updateInternalDependencies: "patch" | "minor";
-    onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-    bumpVersionsWithWorkspaceProtocolOnly?: boolean;
-    snapshot?: string | boolean | undefined;
-  },
-): ModCompWithPackageAndChangelogAndEdits {
-  const pkgJsonEdits: EditJsonOperation[] = [];
-  const { newVersion, packageJson } = release;
+  versionsToUpdate: VersionToUpdate[],
+  options: VersionPackageOptions,
+): Promise<ModCompWithPackageAndChangelogAndEdits> {
+  const context: VersionProviderContext = {
+    pkg: {
+      dir: release.dir,
+      packageJson: release.packageJson,
+    },
+    release,
+    versionsToUpdate,
+    cwd: options.cwd,
+    updateInternalDependencies: options.updateInternalDependencies,
+    onlyUpdatePeerDependentsWhenOutOfRange:
+      options.onlyUpdatePeerDependentsWhenOutOfRange,
+    bumpVersionsWithWorkspaceProtocolOnly:
+      options.bumpVersionsWithWorkspaceProtocolOnly,
+    snapshot: options.snapshot,
+  };
+  const { provider, options: providerOptions } = await getVersionProvider(
+    context,
+    options.versionProvider,
+  );
 
-  pkgJsonEdits.push({ keys: ["version"], value: newVersion });
-
-  for (const depType of DEPENDENCY_TYPES) {
-    const deps = packageJson[depType];
-    if (deps) {
-      for (const { name, version, oldVersion, type, dir } of versionsToUpdate) {
-        let depCurrentVersion = deps[name];
-        if (
-          !depCurrentVersion ||
-          depCurrentVersion.startsWith("file:") ||
-          depCurrentVersion.startsWith("link:") ||
-          !shouldUpdateDependencyBasedOnConfig(
-            cwd,
-            { version, oldVersion, type, dir },
-            {
-              depVersionRange: depCurrentVersion,
-              depType,
-            },
-            {
-              minReleaseType: updateInternalDependencies,
-              onlyUpdatePeerDependentsWhenOutOfRange,
-            },
-          )
-        ) {
-          continue;
-        }
-        const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
-
-        if (
-          !usesWorkspaceRange &&
-          (bumpVersionsWithWorkspaceProtocolOnly ||
-            validRange(depCurrentVersion) == null)
-        ) {
-          continue;
-        }
-
-        if (usesWorkspaceRange) {
-          const workspaceDepVersion = depCurrentVersion.replace(
-            /^workspace:/,
-            "",
-          );
-          if (
-            workspaceDepVersion === "*" ||
-            workspaceDepVersion === "^" ||
-            workspaceDepVersion === "~" ||
-            validRange(workspaceDepVersion) == null
-          ) {
-            continue;
-          }
-          depCurrentVersion = workspaceDepVersion;
-        }
-        if (
-          // an empty string is the normalised version of x/X/*
-          // we don't want to change these versions because they will match
-          // any version and if someone makes the range that
-          // they probably want it to stay like that...
-          new Range(depCurrentVersion).range !== "" ||
-          // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
-          // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
-          semverPrerelease(version) != null
-        ) {
-          let newNewRange = snapshot
-            ? version
-            : `${getVersionRangeType(depCurrentVersion)}${version}`;
-          if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
-          pkgJsonEdits.push({ keys: [depType, name], value: newNewRange });
-        }
-      }
-    }
-  }
-
-  return { ...release, pkgJsonEdits };
-}
-
-function getVersionRangeType(
-  versionRange: string,
-): "^" | "~" | ">=" | "<=" | ">" | "" {
-  if (versionRange.charAt(0) === "^") return "^";
-  if (versionRange.charAt(0) === "~") return "~";
-  if (versionRange.startsWith(">=")) return ">=";
-  if (versionRange.startsWith("<=")) return "<=";
-  if (versionRange.charAt(0) === ">") return ">";
-  return "";
+  return {
+    ...release,
+    versionedFiles: await provider.getVersionedFiles(context, providerOptions),
+  };
 }

--- a/packages/apply-release-plan/src/version-providers/index.ts
+++ b/packages/apply-release-plan/src/version-providers/index.ts
@@ -1,0 +1,90 @@
+import type {
+  Config,
+  Packages,
+  PackageVersionProvider,
+} from "@changesets/types";
+import { nodeVersionProvider } from "./node.ts";
+import { rubyVersionProvider } from "./ruby.ts";
+import type {
+  ResolvedVersionProviderOptions,
+  VersionProvider,
+  VersionProviderContext,
+  VersionProviderPackageContext,
+} from "./types.ts";
+
+const versionProviders: VersionProvider[] = [
+  rubyVersionProvider,
+  nodeVersionProvider,
+];
+
+export async function getVersionProvider(
+  context: VersionProviderContext,
+  config: Config["versionProvider"],
+) {
+  return getVersionProviderForPackage(context, config);
+}
+
+export async function updatePackageVersionsFromVersionProviders(
+  packages: Packages,
+  config: Config["versionProvider"],
+) {
+  await Promise.all(
+    packages.packages.map(async (pkg) => {
+      const context: VersionProviderPackageContext = {
+        pkg,
+        cwd: packages.rootDir,
+      };
+      const { provider, options } = await getVersionProviderForPackage(
+        context,
+        config,
+      );
+      const version = await provider.getCurrentVersion(context, options);
+      if (version) {
+        pkg.packageJson.version = version;
+      }
+    }),
+  );
+}
+
+async function getVersionProviderForPackage(
+  context: VersionProviderPackageContext,
+  config: Config["versionProvider"],
+) {
+  const configuredProvider =
+    config.packages[context.pkg.packageJson.name] ?? config.default ?? "auto";
+  const providerOptions = normalizeProviderOptions(configuredProvider);
+
+  if (providerOptions !== "auto") {
+    return {
+      provider: getProviderForType(providerOptions.type),
+      options: providerOptions,
+    };
+  }
+
+  for (const provider of versionProviders) {
+    if (await provider.detect(context)) {
+      return {
+        provider,
+        options: { type: provider.type } as ResolvedVersionProviderOptions,
+      };
+    }
+  }
+
+  throw new Error(
+    `No version provider found for ${context.pkg.packageJson.name}`,
+  );
+}
+
+function normalizeProviderOptions(
+  provider: PackageVersionProvider,
+): ResolvedVersionProviderOptions | "auto" {
+  if (provider === "auto") return "auto";
+  if (typeof provider === "string") return { type: provider };
+  return provider;
+}
+
+function getProviderForType(type: ResolvedVersionProviderOptions["type"]) {
+  const provider = versionProviders.find((provider) => provider.type === type);
+  if (!provider) throw new Error(`Unknown version provider: ${type}`);
+  return provider;
+}

--- a/packages/apply-release-plan/src/version-providers/node.ts
+++ b/packages/apply-release-plan/src/version-providers/node.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import Range from "semver/classes/range.js";
+import semverPrerelease from "semver/functions/prerelease.js";
+import validRange from "semver/ranges/valid.js";
+import { editJson, type EditJsonOperation } from "../edit-json.ts";
+import { shouldUpdateDependencyBasedOnConfig } from "../utils.ts";
+import type {
+  VersionProvider,
+  VersionProviderContext,
+  VersionedFile,
+} from "./types.ts";
+
+const DEPENDENCY_TYPES = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+export const nodeVersionProvider: VersionProvider = {
+  type: "node",
+  detect() {
+    return true;
+  },
+  getCurrentVersion(context, options) {
+    if (options.type !== "node") {
+      throw new Error(`Expected node version provider options`);
+    }
+
+    return context.pkg.packageJson.version;
+  },
+  async getVersionedFiles(context, options): Promise<VersionedFile[]> {
+    if (options.type !== "node") {
+      throw new Error(`Expected node version provider options`);
+    }
+
+    const pkgJsonPath = path.resolve(context.release.dir, "package.json");
+    const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
+    return [
+      {
+        path: pkgJsonPath,
+        content: editJson(pkgRaw, getPackageJsonEdits(context)),
+      },
+    ];
+  },
+};
+
+function getPackageJsonEdits({
+  release,
+  versionsToUpdate,
+  cwd,
+  updateInternalDependencies,
+  onlyUpdatePeerDependentsWhenOutOfRange,
+  bumpVersionsWithWorkspaceProtocolOnly,
+  snapshot,
+}: VersionProviderContext): EditJsonOperation[] {
+  const pkgJsonEdits: EditJsonOperation[] = [];
+  const { newVersion, packageJson } = release;
+
+  pkgJsonEdits.push({ keys: ["version"], value: newVersion });
+
+  for (const depType of DEPENDENCY_TYPES) {
+    const deps = packageJson[depType];
+    if (deps) {
+      for (const { name, version, oldVersion, type, dir } of versionsToUpdate) {
+        let depCurrentVersion = deps[name];
+        if (
+          !depCurrentVersion ||
+          depCurrentVersion.startsWith("file:") ||
+          depCurrentVersion.startsWith("link:") ||
+          !shouldUpdateDependencyBasedOnConfig(
+            cwd,
+            { version, oldVersion, type, dir },
+            {
+              depVersionRange: depCurrentVersion,
+              depType,
+            },
+            {
+              minReleaseType: updateInternalDependencies,
+              onlyUpdatePeerDependentsWhenOutOfRange,
+            },
+          )
+        ) {
+          continue;
+        }
+        const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
+
+        if (
+          !usesWorkspaceRange &&
+          (bumpVersionsWithWorkspaceProtocolOnly ||
+            validRange(depCurrentVersion) == null)
+        ) {
+          continue;
+        }
+
+        if (usesWorkspaceRange) {
+          const workspaceDepVersion = depCurrentVersion.replace(
+            /^workspace:/,
+            "",
+          );
+          if (
+            workspaceDepVersion === "*" ||
+            workspaceDepVersion === "^" ||
+            workspaceDepVersion === "~" ||
+            validRange(workspaceDepVersion) == null
+          ) {
+            continue;
+          }
+          depCurrentVersion = workspaceDepVersion;
+        }
+        if (
+          // an empty string is the normalised version of x/X/*
+          // we don't want to change these versions because they will match
+          // any version and if someone makes the range that
+          // they probably want it to stay like that...
+          new Range(depCurrentVersion).range !== "" ||
+          // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
+          // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
+          semverPrerelease(version) != null
+        ) {
+          let newNewRange = snapshot
+            ? version
+            : `${getVersionRangeType(depCurrentVersion)}${version}`;
+          if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
+          pkgJsonEdits.push({ keys: [depType, name], value: newNewRange });
+        }
+      }
+    }
+  }
+
+  return pkgJsonEdits;
+}
+
+function getVersionRangeType(
+  versionRange: string,
+): "^" | "~" | ">=" | "<=" | ">" | "" {
+  if (versionRange.charAt(0) === "^") return "^";
+  if (versionRange.charAt(0) === "~") return "~";
+  if (versionRange.startsWith(">=")) return ">=";
+  if (versionRange.startsWith("<=")) return "<=";
+  if (versionRange.charAt(0) === ">") return ">";
+  return "";
+}

--- a/packages/apply-release-plan/src/version-providers/ruby.ts
+++ b/packages/apply-release-plan/src/version-providers/ruby.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { RubyVersionProviderOptions } from "@changesets/types";
+import type { VersionProvider, VersionedFile } from "./types.ts";
+
+export const rubyVersionProvider: VersionProvider = {
+  type: "ruby",
+  async detect(context) {
+    return hasRubyVersionFiles(
+      context.pkg.dir,
+      getRubyGemName(context.pkg.packageJson.name),
+    );
+  },
+  async getCurrentVersion(context, options) {
+    if (options.type !== "ruby") {
+      throw new Error(`Expected ruby version provider options`);
+    }
+
+    const gemName =
+      options.gemName ?? getRubyGemName(context.pkg.packageJson.name);
+    const versionFile = await resolveRubyVersionFile(
+      context.pkg.dir,
+      gemName,
+      options,
+    );
+    if (versionFile) {
+      const version = readRubyVersionFile(
+        await fs.readFile(versionFile, "utf8"),
+      );
+      if (version) return version;
+    }
+
+    const gemspec = await resolveRubyGemspec(context.pkg.dir, gemName, options);
+    if (gemspec) {
+      const version = readRubyGemspec(await fs.readFile(gemspec, "utf8"));
+      if (version) return version;
+    }
+
+    const gemfileLock = await resolveOptionalFile(
+      context.pkg.dir,
+      options.gemfileLock,
+      "Gemfile.lock",
+    );
+    if (gemfileLock) {
+      const version = readRubyGemfileLock(
+        await fs.readFile(gemfileLock, "utf8"),
+        gemName,
+      );
+      if (version) return version;
+    }
+
+    return undefined;
+  },
+  async getVersionedFiles(context, options): Promise<VersionedFile[]> {
+    if (options.type !== "ruby") {
+      throw new Error(`Expected ruby version provider options`);
+    }
+
+    const files: VersionedFile[] = [];
+    const rubyVersion = context.release.newVersion;
+    const gemName = options.gemName ?? getRubyGemName(context.release.name);
+
+    const versionFile = await resolveRubyVersionFile(
+      context.release.dir,
+      gemName,
+      options,
+    );
+    if (versionFile) {
+      files.push({
+        path: versionFile,
+        content: updateRubyVersionFile(
+          await fs.readFile(versionFile, "utf8"),
+          rubyVersion,
+        ),
+      });
+    }
+
+    const gemspec = await resolveRubyGemspec(
+      context.release.dir,
+      gemName,
+      options,
+    );
+    if (gemspec) {
+      files.push({
+        path: gemspec,
+        content: updateRubyGemspec(
+          await fs.readFile(gemspec, "utf8"),
+          rubyVersion,
+        ),
+      });
+    }
+
+    const gemfileLock = await resolveOptionalFile(
+      context.release.dir,
+      options.gemfileLock,
+      "Gemfile.lock",
+    );
+    if (gemfileLock) {
+      files.push({
+        path: gemfileLock,
+        content: updateRubyGemfileLock(
+          await fs.readFile(gemfileLock, "utf8"),
+          gemName,
+          rubyVersion,
+        ),
+      });
+    }
+
+    return files;
+  },
+};
+
+async function hasRubyVersionFiles(dir: string, gemName: string) {
+  return (
+    (await resolveRubyVersionFile(dir, gemName, { type: "ruby" })) != null ||
+    (await resolveRubyGemspec(dir, gemName, { type: "ruby" })) != null ||
+    (await fileExists(path.resolve(dir, "Gemfile.lock")))
+  );
+}
+
+function getRubyGemName(packageName: string) {
+  const withoutScope = packageName.startsWith("@")
+    ? packageName.split("/").at(1)
+    : packageName;
+  return withoutScope ?? packageName;
+}
+
+async function resolveRubyVersionFile(
+  dir: string,
+  gemName: string,
+  provider: RubyVersionProviderOptions,
+) {
+  if (provider.versionFile === false) return undefined;
+  if (provider.versionFile) {
+    return resolveRequiredFile(dir, provider.versionFile, "Ruby version file");
+  }
+
+  const candidates = [
+    path.join("lib", gemName.replace(/-/g, "/"), "version.rb"),
+    path.join("lib", gemName.replace(/-/g, "_"), "version.rb"),
+  ];
+  for (const candidate of candidates) {
+    const filePath = path.resolve(dir, candidate);
+    if (await fileExists(filePath)) return filePath;
+  }
+
+  const discovered = await findFiles(path.resolve(dir, "lib"), "version.rb");
+  return discovered.length === 1 ? discovered[0] : undefined;
+}
+
+async function resolveRubyGemspec(
+  dir: string,
+  gemName: string,
+  provider: RubyVersionProviderOptions,
+) {
+  if (provider.gemspec === false) return undefined;
+  if (provider.gemspec) {
+    return resolveRequiredFile(dir, provider.gemspec, "gemspec");
+  }
+
+  const candidates = [
+    `${gemName}.gemspec`,
+    `${gemName.replace(/-/g, "_")}.gemspec`,
+  ];
+  for (const candidate of candidates) {
+    const filePath = path.resolve(dir, candidate);
+    if (await fileExists(filePath)) return filePath;
+  }
+
+  const discovered = (await fs.readdir(dir)).filter((file) =>
+    file.endsWith(".gemspec"),
+  );
+  return discovered.length === 1 ? path.resolve(dir, discovered[0]) : undefined;
+}
+
+async function resolveOptionalFile(
+  dir: string,
+  configuredPath: string | false | undefined,
+  defaultPath: string,
+) {
+  if (configuredPath === false) return undefined;
+  if (configuredPath)
+    return resolveRequiredFile(dir, configuredPath, defaultPath);
+
+  const filePath = path.resolve(dir, defaultPath);
+  return (await fileExists(filePath)) ? filePath : undefined;
+}
+
+async function resolveRequiredFile(
+  dir: string,
+  relativePath: string,
+  label: string,
+) {
+  const filePath = path.resolve(dir, relativePath);
+  if (!(await fileExists(filePath))) {
+    throw new Error(`${label} not found at ${relativePath}`);
+  }
+  return filePath;
+}
+
+async function fileExists(filePath: string) {
+  return fs.access(filePath).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function findFiles(dir: string, basename: string): Promise<string[]> {
+  if (!(await fileExists(dir))) return [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return findFiles(entryPath, basename);
+      return entry.isFile() && entry.name === basename ? [entryPath] : [];
+    }),
+  );
+  return files.flat();
+}
+
+function updateRubyVersionFile(content: string, version: string) {
+  const nextContent = content.replace(
+    /(\bVERSION\s*=\s*["'])([^"']+)(["'])/,
+    `$1${version}$3`,
+  );
+  if (nextContent !== content) return nextContent;
+
+  return content.replace(
+    /(["'])(\d+\.\d+\.\d+(?:[-.][^"']+)?)(["'])/,
+    `$1${version}$3`,
+  );
+}
+
+function readRubyVersionFile(content: string) {
+  return (
+    content.match(/\bVERSION\s*=\s*["']([^"']+)["']/)?.[1] ??
+    content.match(/["'](\d+\.\d+\.\d+(?:[-.][^"']+)?)["']/)?.[1]
+  );
+}
+
+function updateRubyGemspec(content: string, version: string) {
+  return content.replace(
+    /(\.version\s*=\s*["'])([^"']+)(["'])/,
+    `$1${version}$3`,
+  );
+}
+
+function readRubyGemspec(content: string) {
+  return content.match(/\.version\s*=\s*["']([^"']+)["']/)?.[1];
+}
+
+function updateRubyGemfileLock(
+  content: string,
+  gemName: string,
+  version: string,
+) {
+  const escapedName = gemName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const lockVersion = version.replace(/-/g, ".pre.");
+  return content.replace(
+    new RegExp(`(^\\s*)${escapedName} \\([^\\n)]+\\)`, "m"),
+    `$1${gemName} (${lockVersion})`,
+  );
+}
+
+function readRubyGemfileLock(content: string, gemName: string) {
+  const escapedName = gemName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const version = content.match(
+    new RegExp(`^\\s*${escapedName} \\(([^\\n)]+)\\)`, "m"),
+  )?.[1];
+  return version?.replace(".pre.", "-");
+}

--- a/packages/apply-release-plan/src/version-providers/types.ts
+++ b/packages/apply-release-plan/src/version-providers/types.ts
@@ -1,0 +1,55 @@
+import type {
+  ModCompWithPackage,
+  NodeVersionProviderOptions,
+  Package,
+  RubyVersionProviderOptions,
+  VersionType,
+} from "@changesets/types";
+
+export type ModCompWithPackageAndChangelog = ModCompWithPackage & {
+  changelog: string | null;
+};
+
+export type VersionedFile = {
+  path: string;
+  content: string;
+};
+
+export type VersionToUpdate = {
+  name: string;
+  version: string;
+  oldVersion: string;
+  type: VersionType;
+  dir: string;
+};
+
+export type VersionProviderPackageContext = {
+  pkg: Package;
+  cwd: string;
+};
+
+export type VersionProviderContext = VersionProviderPackageContext & {
+  release: ModCompWithPackageAndChangelog;
+  versionsToUpdate: VersionToUpdate[];
+  updateInternalDependencies: "patch" | "minor";
+  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+  bumpVersionsWithWorkspaceProtocolOnly?: boolean;
+  snapshot?: string | boolean | undefined;
+};
+
+export type ResolvedVersionProviderOptions =
+  | NodeVersionProviderOptions
+  | RubyVersionProviderOptions;
+
+export interface VersionProvider {
+  type: ResolvedVersionProviderOptions["type"];
+  detect(context: VersionProviderPackageContext): boolean | Promise<boolean>;
+  getCurrentVersion(
+    context: VersionProviderPackageContext,
+    options: ResolvedVersionProviderOptions,
+  ): string | undefined | Promise<string | undefined>;
+  getVersionedFiles(
+    context: VersionProviderContext,
+    options: ResolvedVersionProviderOptions,
+  ): Promise<VersionedFile[]>;
+}

--- a/packages/cli/src/commands/status/__tests__/status.test.ts
+++ b/packages/cli/src/commands/status/__tests__/status.test.ts
@@ -172,6 +172,82 @@ describe("status", { tags: ["slow"] }, () => {
     `);
   });
 
+  it("should read current versions from configured version providers", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/demo-ruby-gem/package.json": JSON.stringify({
+        name: "demo-ruby-gem",
+        version: "0.1.0",
+        private: true,
+      }),
+      "packages/demo-ruby-gem/lib/demo_ruby_gem/version.rb": `module DemoRubyGem
+  VERSION = "0.2.0"
+end
+`,
+      ".changeset/config.json": JSON.stringify({
+        versionProvider: {
+          default: "node",
+          packages: {
+            "demo-ruby-gem": "ruby",
+          },
+        },
+      }),
+    });
+
+    await exec("git", ["checkout", "-b", "new-branch"], {
+      nodeOptions: { cwd },
+    });
+
+    await outputFile(
+      path.join(cwd, "packages/demo-ruby-gem/lib/demo_ruby_gem.rb"),
+      'require_relative "demo_ruby_gem/version"',
+    );
+    await writeChangeset(
+      {
+        summary: "This is a Ruby summary",
+        releases: [{ name: "demo-ruby-gem", type: "patch" }],
+      },
+      cwd,
+    );
+    await git.add(".", cwd);
+    await git.commit("updated ruby gem", cwd);
+
+    const releaseObj = await status({ cwd, since: "main" });
+    expect(replaceHumanIds(releaseObj)).toMatchInlineSnapshot(`
+      {
+        "changesets": [
+          {
+            "id": "~changeset-1~",
+            "releases": [
+              {
+                "name": "demo-ruby-gem",
+                "type": "patch",
+              },
+            ],
+            "summary": "This is a Ruby summary",
+          },
+        ],
+        "preState": undefined,
+        "releases": [
+          {
+            "changesets": [
+              "~changeset-1~",
+            ],
+            "name": "demo-ruby-gem",
+            "newVersion": "0.2.1",
+            "oldVersion": "0.2.0",
+            "type": "patch",
+          },
+        ],
+      }
+    `);
+  });
+
   it("should exit early with a non-zero error code when there are changed packages but no changesets", async () => {
     const cwd = await gitdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { updatePackageVersionsFromVersionProviders } from "@changesets/apply-release-plan";
 import { assembleReleasePlan } from "@changesets/assemble-release-plan";
 import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
@@ -26,6 +27,10 @@ export async function status(options?: StatusOptions) {
   await ensureChangesetFolder(packages.rootDir);
 
   const config = await readConfig(packages);
+  await updatePackageVersionsFromVersionProviders(
+    packages,
+    config.versionProvider,
+  );
   const preState = await readPreState(packages.rootDir);
   const changesets = await readChangesets(packages.rootDir, options?.since);
 

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { applyReleasePlan } from "@changesets/apply-release-plan";
+import {
+  applyReleasePlan,
+  updatePackageVersionsFromVersionProviders,
+} from "@changesets/apply-release-plan";
 import { assembleReleasePlan } from "@changesets/assemble-release-plan";
 import c from "@changesets/color";
 import { ExitError } from "@changesets/errors";
@@ -55,6 +58,11 @@ export async function version(options: VersionOptions) {
     // Disable committing when in snapshot mode
     commit: options.snapshot ? false : config.commit,
   };
+
+  await updatePackageVersionsFromVersionProviders(
+    packages,
+    releaseConfig.versionProvider,
+  );
 
   validateIgnoredPackageNames(packages, options.ignore, messages);
   validateSkippedDependents(packages, releaseConfig, messages);

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -231,6 +231,90 @@ describe("running version in a simple project", () => {
         expect.objectContaining({ name: "pkg-b", version: "1.0.1" }),
       );
     });
+
+    it("should use the Ruby provider version as the source for consecutive releases", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "package-lock.json": "",
+        "packages/demo-ruby-gem/package.json": JSON.stringify({
+          name: "demo-ruby-gem",
+          private: true,
+          version: "0.1.0",
+        }),
+        "packages/demo-ruby-gem/lib/demo_ruby_gem/version.rb": `module DemoRubyGem
+  VERSION = "0.1.0"
+end
+`,
+        "packages/demo-ruby-gem/demo-ruby-gem.gemspec": `Gem::Specification.new do |spec|
+  spec.name = "demo-ruby-gem"
+  spec.version = "0.1.0"
+end
+`,
+        "packages/demo-ruby-gem/Gemfile.lock": `PATH
+  remote: .
+  specs:
+    demo-ruby-gem (0.1.0)
+`,
+        ".changeset/config.json": JSON.stringify({
+          ...modifiedDefaultConfig,
+          changelog: false,
+          privatePackages: { version: true, tag: false },
+        }),
+      });
+
+      await writeChangesets(
+        [
+          {
+            summary: "This is a summary",
+            releases: [{ name: "demo-ruby-gem", type: "minor" }],
+          },
+        ],
+        cwd,
+      );
+
+      await version({ cwd });
+
+      expect(await getPkgJSON("demo-ruby-gem", cwd)).toEqual(
+        expect.objectContaining({ name: "demo-ruby-gem", version: "0.1.0" }),
+      );
+      await expect(
+        getFile("demo-ruby-gem", "lib/demo_ruby_gem/version.rb", cwd),
+      ).resolves.toContain(`VERSION = "0.2.0"`);
+      await expect(
+        getFile("demo-ruby-gem", "demo-ruby-gem.gemspec", cwd),
+      ).resolves.toContain(`spec.version = "0.2.0"`);
+      await expect(
+        getFile("demo-ruby-gem", "Gemfile.lock", cwd),
+      ).resolves.toContain(`demo-ruby-gem (0.2.0)`);
+
+      await writeChangesets(
+        [
+          {
+            summary: "This is another summary",
+            releases: [{ name: "demo-ruby-gem", type: "patch" }],
+          },
+        ],
+        cwd,
+      );
+
+      await version({ cwd });
+
+      expect(await getPkgJSON("demo-ruby-gem", cwd)).toEqual(
+        expect.objectContaining({ name: "demo-ruby-gem", version: "0.1.0" }),
+      );
+      await expect(
+        getFile("demo-ruby-gem", "lib/demo_ruby_gem/version.rb", cwd),
+      ).resolves.toContain(`VERSION = "0.2.1"`);
+      await expect(
+        getFile("demo-ruby-gem", "demo-ruby-gem.gemspec", cwd),
+      ).resolves.toContain(`spec.version = "0.2.1"`);
+      await expect(
+        getFile("demo-ruby-gem", "Gemfile.lock", cwd),
+      ).resolves.toContain(`demo-ruby-gem (0.2.1)`);
+    });
   });
 
   it("should not touch package.json of an ignored package when it is not a dependent of any releasedPackages", async () => {

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -128,6 +128,237 @@
       "description": "Opt in to tracking non-npm / private packages",
       "default": {}
     },
+    "versionProvider": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "const": "auto"
+                },
+                {
+                  "const": "node"
+                },
+                {
+                  "const": "ruby"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "node"
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "ruby"
+                },
+                "gemName": {
+                  "type": "string"
+                },
+                "versionFile": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "const": false
+                    }
+                  ]
+                },
+                "gemspec": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "const": false
+                    }
+                  ]
+                },
+                "gemfileLock": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "const": false
+                    }
+                  ]
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "const": "auto"
+                    },
+                    {
+                      "const": "node"
+                    },
+                    {
+                      "const": "ruby"
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": "node"
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": "ruby"
+                    },
+                    "gemName": {
+                      "type": "string"
+                    },
+                    "versionFile": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "const": false
+                        }
+                      ]
+                    },
+                    "gemspec": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "const": false
+                        }
+                      ]
+                    },
+                    "gemfileLock": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "const": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                }
+              ],
+              "default": "auto"
+            },
+            "packages": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "anyOf": [
+                      {
+                        "const": "auto"
+                      },
+                      {
+                        "const": "node"
+                      },
+                      {
+                        "const": "ruby"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "node"
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "ruby"
+                      },
+                      "gemName": {
+                        "type": "string"
+                      },
+                      "versionFile": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "const": false
+                          }
+                        ]
+                      },
+                      "gemspec": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "const": false
+                          }
+                        ]
+                      },
+                      "gemfileLock": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "const": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "default": {}
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        }
+      ],
+      "description": "Determines which provider updates version files for each package.",
+      "default": "auto"
+    },
     "bumpVersionsWithWorkspaceProtocolOnly": {
       "type": "boolean",
       "description": "Determines whether Changesets should only bump dependency ranges that use workspace protocol of packages that are part of the workspace.",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -42,6 +42,26 @@ const CommitSchema = v.union(
 
 const AccessSchema = v.union([v.literal("public"), v.literal("restricted")]);
 
+const VersionProviderNameSchema = v.union([
+  v.literal("auto"),
+  v.literal("node"),
+  v.literal("ruby"),
+]);
+
+const PackageVersionProviderSchema = v.union([
+  VersionProviderNameSchema,
+  v.strictObject({
+    type: v.literal("node"),
+  }),
+  v.strictObject({
+    type: v.literal("ruby"),
+    gemName: v.optional(v.string()),
+    versionFile: v.optional(v.union([v.string(), v.literal(false)])),
+    gemspec: v.optional(v.union([v.string(), v.literal(false)])),
+    gemfileLock: v.optional(v.union([v.string(), v.literal(false)])),
+  }),
+]);
+
 export const WrittenConfigSchema = v.object({
   baseBranch: rootKey(
     v.string(),
@@ -102,6 +122,20 @@ export const WrittenConfigSchema = v.object({
     ]),
     "Opt in to tracking non-npm / private packages",
     {},
+  ),
+  versionProvider: rootKey(
+    v.union([
+      PackageVersionProviderSchema,
+      v.strictObject({
+        default: v.optional(PackageVersionProviderSchema, "auto"),
+        packages: v.optional(
+          v.record(v.string(), PackageVersionProviderSchema),
+          {},
+        ),
+      }),
+    ]),
+    "Determines which provider updates version files for each package.",
+    "auto",
   ),
   bumpVersionsWithWorkspaceProtocolOnly: rootKey(
     v.boolean(),
@@ -193,6 +227,20 @@ export function normalizeWrittenConfig({
     config.privatePackages = {
       version: writtenConfig.privatePackages.version ?? true,
       tag: writtenConfig.privatePackages.tag ?? false,
+    };
+  }
+
+  const versionProvider = writtenConfig.versionProvider ?? "auto";
+
+  if (typeof versionProvider === "string" || "type" in versionProvider) {
+    config.versionProvider = {
+      default: versionProvider,
+      packages: {},
+    };
+  } else {
+    config.versionProvider = {
+      default: versionProvider.default ?? "auto",
+      packages: versionProvider.packages ?? {},
     };
   }
 

--- a/packages/config/src/parse.test.ts
+++ b/packages/config/src/parse.test.ts
@@ -55,6 +55,10 @@ describe("readConfig", () => {
           "useCalculatedVersion": false,
         },
         "updateInternalDependencies": "patch",
+        "versionProvider": {
+          "default": "auto",
+          "packages": {},
+        },
       }
     `);
   });
@@ -137,6 +141,10 @@ describe("defaultConfig", () => {
           "useCalculatedVersion": false,
         },
         "updateInternalDependencies": "patch",
+        "versionProvider": {
+          "default": "auto",
+          "packages": {},
+        },
       }
     `);
   });
@@ -329,6 +337,96 @@ describe("validateConfig", () => {
         expected: {
           ...defaultConfig,
           privatePackages: { version: false, tag: false },
+        },
+      },
+      {
+        name: "versionProvider: ruby",
+        config: { versionProvider: "ruby" },
+        expected: {
+          ...defaultConfig,
+          versionProvider: { default: "ruby", packages: {} },
+        },
+      },
+      {
+        name: "versionProvider: node object",
+        config: { versionProvider: { type: "node" } },
+        expected: {
+          ...defaultConfig,
+          versionProvider: { default: { type: "node" }, packages: {} },
+        },
+      },
+      {
+        name: "versionProvider: ruby object",
+        config: {
+          versionProvider: {
+            type: "ruby",
+            gemName: "custom-gem",
+            versionFile: "lib/custom/version.rb",
+            gemspec: "custom.gemspec",
+            gemfileLock: false,
+          },
+        },
+        expected: {
+          ...defaultConfig,
+          versionProvider: {
+            default: {
+              type: "ruby",
+              gemName: "custom-gem",
+              versionFile: "lib/custom/version.rb",
+              gemspec: "custom.gemspec",
+              gemfileLock: false,
+            },
+            packages: {},
+          },
+        },
+      },
+      {
+        name: "versionProvider: packages only",
+        config: {
+          versionProvider: {
+            packages: {
+              "pkg-a": "ruby",
+            },
+          },
+        },
+        expected: {
+          ...defaultConfig,
+          versionProvider: {
+            default: "auto",
+            packages: {
+              "pkg-a": "ruby",
+            },
+          },
+        },
+      },
+      {
+        name: "versionProvider: per package",
+        config: {
+          versionProvider: {
+            default: "node",
+            packages: {
+              "pkg-a": {
+                type: "ruby",
+                versionFile: "lib/custom/version.rb",
+                gemspec: false,
+                gemfileLock: false,
+              },
+            },
+          },
+        },
+        expected: {
+          ...defaultConfig,
+          versionProvider: {
+            default: "node",
+            packages: {
+              "pkg-a": {
+                type: "ruby",
+                versionFile: "lib/custom/version.rb",
+                gemspec: false,
+                gemfileLock: false,
+              },
+            },
+          },
         },
       },
       {
@@ -538,6 +636,33 @@ describe("validateConfig", () => {
       {
         name: "privatePackages: should error when a public package depends on a private package skipped via privatePackages.version: false",
         config: { privatePackages: { version: false, tag: false } },
+      },
+      // versionProvider
+      {
+        name: "versionProvider: invalid string",
+        config: { versionProvider: "python" },
+        errors: ["Invalid type: Expected"],
+      },
+      {
+        name: "versionProvider: invalid object type",
+        config: { versionProvider: { type: "python" } },
+        errors: ["Invalid type: Expected"],
+      },
+      {
+        name: "versionProvider: invalid ruby versionFile",
+        config: { versionProvider: { type: "ruby", versionFile: true } },
+        errors: ["Invalid type: Expected"],
+      },
+      {
+        name: "versionProvider: invalid package provider",
+        config: {
+          versionProvider: {
+            packages: {
+              "pkg-a": "python",
+            },
+          },
+        },
+        errors: ["Invalid type: Expected"],
       },
       {
         name: "experimental: onlyUpdatePeerDependentsWhenOutOfRange: non-boolean",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,6 +66,30 @@ export interface PrivatePackages {
   tag: boolean;
 }
 
+export type VersionProviderName = "auto" | "node" | "ruby";
+
+export type NodeVersionProviderOptions = {
+  type: "node";
+};
+
+export type RubyVersionProviderOptions = {
+  type: "ruby";
+  gemName?: string;
+  versionFile?: string | false;
+  gemspec?: string | false;
+  gemfileLock?: string | false;
+};
+
+export type PackageVersionProvider =
+  | VersionProviderName
+  | NodeVersionProviderOptions
+  | RubyVersionProviderOptions;
+
+export type VersionProviderConfig = {
+  default: PackageVersionProvider;
+  packages: Record<string, PackageVersionProvider>;
+};
+
 export type Config = {
   changelog: false | readonly [string, null | Record<string, unknown>];
   commit: false | readonly [string, null | Record<string, unknown>];
@@ -81,6 +105,8 @@ export type Config = {
   format: "auto" | "prettier" | "oxfmt" | "deno" | "dprint" | false;
   /** Features enabled for Private packages */
   privatePackages: PrivatePackages;
+  /** Controls which files are updated when versions are applied */
+  versionProvider: VersionProviderConfig;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -111,6 +137,12 @@ export type WrittenConfig = {
     | {
         version?: boolean;
         tag?: boolean;
+      };
+  versionProvider?:
+    | PackageVersionProvider
+    | {
+        default?: PackageVersionProvider;
+        packages?: Record<string, PackageVersionProvider>;
       };
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";


### PR DESCRIPTION
First: thank you for Changesets. I personally really enjoy this project: it has a rare combination of being pragmatic, understandable, and flexible enough to fit many different release workflows. At OpenAI we use and encounter increasingly mixed-language repositories, and we would love to help expand Changesets' usefulness while preserving the package/release planning model that already works so well.

This PR is an exploratory but working step toward that: it adds a provider model for version-file updates, with the existing Node/npm behavior represented as the first provider and Ruby gems added as the first non-Node provider.

I am opening this as a draft because I would very much appreciate the maintainers' guidance on whether this shape feels aligned with the project before we go further. I am happy to reshape the API, naming, or provider boundaries based on your feedback.

## Motivation

Changesets already has a very good model for expressing release intent:

- a changeset names a package and bump type
- Changesets calculates the release plan
- `changeset version` applies the plan and consumes the changesets
- changelogs and release PRs communicate what will ship

The main limitation this PR tries to address is that applying a release plan currently assumes the version file is `package.json`. That works beautifully for npm packages, but it prevents the same release-planning model from being used naturally for packages whose canonical version lives elsewhere, such as Ruby gems, Python packages, Cargo crates, etc.

The goal here is not to make Changesets publish Ruby gems or Python packages. Publishing can stay external. The goal is narrower: let Changesets own the release-plan workflow and update the correct version files for a package.

## What This Adds

This PR introduces a `versionProvider` configuration option and provider interface.

The implemented providers are:

- `node`: preserves the existing package.json version/dependency update behavior.
- `ruby`: updates Ruby gem version files while allowing `package.json` to remain Changesets metadata.

For Ruby packages, the provider can update:

- `lib/<gem-name>/version.rb` or a configured/discovered `lib/**/version.rb`
- `<gem-name>.gemspec` or a configured/discovered root `.gemspec`
- `Gemfile.lock`

It also makes `changeset status` and `changeset version` read the current version from the configured provider before assembling/applying the release plan. That matters for non-Node packages because `package.json` may not contain the canonical package version.

## Configuration Shape

The new config is optional. If omitted, behavior remains the historical Node/npm behavior.

Examples:

```json
{
  "versionProvider": "ruby"
}
```

Or, for mixed repositories:

```json
{
  "versionProvider": {
    "default": "node",
    "packages": {
      "my-gem": {
        "type": "ruby",
        "gemName": "my-gem",
        "versionFile": "lib/my_gem/version.rb",
        "gemspec": "my-gem.gemspec",
        "gemfileLock": "Gemfile.lock"
      }
    }
  }
}
```

I intentionally avoided requiring users to write `"auto"` in their config. When the option is unset, Changesets behaves automatically using the default provider. The implementation still has internal resolution logic, but the public docs avoid making users spell out automatic behavior.

## Ruby Behavior

For a Ruby provider package, `changeset version` can now:

- read the current version from Ruby files
- compute the next version using the normal Changesets release plan
- update `VERSION = "..."`
- update `spec.version = "..."`
- update the package entry in `Gemfile.lock`
- write changelog entries
- consume the changeset files

It deliberately does not update `package.json` for Ruby packages. In this model, `package.json` is just the metadata file that lets Changesets discover and name the package; it is not treated as the canonical Ruby package version.

## Demo Evidence

I put together a standalone demo repository to prove the workflow end to end:

https://github.com/jbeckwith-oai/changesets-ruby-provider-demo

The generated release PR is here:

https://github.com/jbeckwith-oai/changesets-ruby-provider-demo/pull/1

That release PR demonstrates:

- multiple ordinary changesets merged to `main`
- a mixed minor + patch release plan
- generated changelog content
- Ruby version files moving from `0.2.1` to `0.3.0`
- no `package.json` version bump
- manual publishing expectations for the gem

One important note from the demo: `changesets/action@v1` currently builds its PR body by detecting `package.json` version changes after running `changeset version`. Since Ruby packages intentionally do not bump `package.json`, the stock action produced an empty `# Releases` section even though the CLI/provider behavior was correct. For the demo, I switched to explicit CLI orchestration:

- `changeset status --output`
- `changeset version`
- generate the PR body from the status/changelog data
- commit/push/create-or-update the release PR

I think a provider-aware follow-up to `changesets/action` would be useful, but I kept that out of this PR so we can discuss the core provider model first.

## Compatibility

This is intended to preserve existing behavior for current Changesets users:

- no config change is required for existing Node/npm projects
- the Node provider is the default
- dependency range updates remain in the Node provider
- existing `privatePackages` handling remains respected
- the new provider logic is contained behind the version-provider interface

## Tests And Validation

Added coverage includes:

- config parsing for string, object, package override, and provider-specific options
- JSON schema coverage for the new config
- Node provider package.json version/dependency behavior
- Ruby provider version file, gemspec, and Gemfile.lock updates
- Ruby provider path configuration and opt-out behavior
- Ruby provider prerelease conversion for Bundler lockfile format
- CLI `status` and `version` behavior when provider-managed versions differ from `package.json`
- docs for config and CLI behavior

Validation run locally on this branch:

- `pnpm vitest run packages/cli/src/commands/version/version.test.ts packages/apply-release-plan/src/index.test.ts packages/config/src/parse.test.ts packages/config/scripts/json-schema.test.ts`
  - 4 files passed
  - 200 tests passed
  - 1 existing todo
- `pnpm lint`
- `pnpm build`
- `pnpm types:check`
- `pnpm format`
- `git diff --check upstream/main...HEAD`

I also ran the full suite with `pnpm test run`. On my local machine, it produced baseline/environment failures unrelated to this change:

- `packages/cli/src/commands/publish/__tests__/npm-utils.test.ts` expected the default npm registry, but my OpenAI environment injects an internal socket-firewall npm registry. The same test passes when the npm registry env vars are cleared.
- `packages/git/src/index.test.ts` has three shallow-clone tests timing out at their 10s limit. I reproduced the same failures on an untouched `upstream/main` worktree after building it, so this appears to be local/baseline behavior rather than caused by this PR.

## Questions For Maintainers

The biggest things I would love feedback on:

- Is `versionProvider` the right conceptual boundary/name?
- Should the default provider resolution stay conservative as `node`, or should auto-detection be more prominent?
- Does keeping `package.json` as discovery metadata for non-Node packages feel acceptable?
- Should provider implementations live in `apply-release-plan`, or should the interface move somewhere more central?
- Would you prefer the Ruby provider to be in this PR as proof of the abstraction, or would you rather see the provider interface land first and Ruby support follow separately?
- Should provider-aware release PR rendering be considered part of Changesets core, `changesets/action`, or both?

Again, thank you for the project and for considering this direction. I would be very glad to iterate on the shape with you.
