### PR TITLE
allow unmatched globs in `ignore` config

### DIFF
--- a/.changeset/whole-gifts-accept.md
+++ b/.changeset/whole-gifts-accept.md
@@ -1,0 +1,6 @@
+---
+"@changesets/cli": minor
+"@changesets/config": minor
+---
+
+Allow unmatched glob patterns in the `ignore` config option.

--- a/packages/config/src/parse.test.ts
+++ b/packages/config/src/parse.test.ts
@@ -324,6 +324,12 @@ describe("validateConfig", () => {
         expected: { ...defaultConfig, ignore: ["pkg-a", "@pkg/a", "@pkg/b"] },
       },
       {
+        name: "ignore: allows unmatched globs",
+        pkgs: ["pkg-a", "pkg-b"],
+        config: { ignore: ["not-a-valid-package"] },
+        expected: { ...defaultConfig, ignore: [] },
+      },
+      {
         name: "privatePackages: false",
         config: { privatePackages: false },
         expected: {
@@ -521,18 +527,6 @@ describe("validateConfig", () => {
         name: "ignore: array of non-string",
         config: { ignore: [123, "pkg-a"] },
         errors: ["Expected string"],
-      },
-      {
-        name: "rule: ignoredPatternsExist",
-        pkgs: [],
-        config: { ignore: ["pkg-a"] },
-        errors: ['Invalid path: The package or glob "pkg-a" does not match'],
-      },
-      {
-        name: "rule: ignoredPatternsExist: glob",
-        pkgs: [],
-        config: { ignore: ["pkg-*"] },
-        errors: ['Invalid path: The package or glob "pkg-*" does not match'],
       },
       // privatePackages
       {

--- a/packages/config/src/rules.ts
+++ b/packages/config/src/rules.ts
@@ -114,20 +114,6 @@ const noFixedAndLinkedPackages: Rule = ({ config, errors }) => {
   }
 };
 
-const ignoredPatternsExist: Rule = ({
-  writtenConfig,
-  packageNames,
-  errors,
-}) => {
-  if (writtenConfig.ignore == null || writtenConfig.ignore.length === 0) return;
-
-  errors.push(
-    ...getUnmatchedPatterns(writtenConfig.ignore, packageNames).map(
-      (pkgOrGlob) => `ignore: ${invalidPathOrGlobMessage(pkgOrGlob)}`,
-    ),
-  );
-};
-
 // Validate that dependents of skipped packages are also skipped.
 // A package is "skipped" if it's in the ignore list, or if it's private
 // and privatePackages.version is false.
@@ -201,7 +187,6 @@ const rules: Rule[] = [
   linkedGroupsExist,
   noDuplicateLinkedPackages,
   noFixedAndLinkedPackages,
-  ignoredPatternsExist,
   alsoSkipDependentsOfSkipped,
   noPrivateTagWithoutPrivateVersion,
 ];


### PR DESCRIPTION
fixes #1794
closes #1964 (supersedes)