### PR TITLE
Remove "private" type from `WrittenConfig.access`

### DIFF
--- a/.changeset/light-friends-warn.md
+++ b/.changeset/light-friends-warn.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": major
+---
+
+Remove `"private"` type support for `WrittenConfig.access`. Only `"public"` and `"restricted"` are valid values. This change was also already made in [#2015](https://github.com/changesets/changesets/pull/2015) in the runtime.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,7 +101,7 @@ export type WrittenConfig = {
   commit?: boolean | readonly [string, null | Record<string, unknown>] | string;
   fixed?: Fixed;
   linked?: Linked;
-  access?: AccessType | "private";
+  access?: AccessType;
   baseBranch?: string;
   changedFilePatterns?: readonly string[];
   format?: "auto" | "prettier" | "oxfmt" | "deno" | "dprint" | false;


### PR DESCRIPTION
Separated from #2087 as I want its own changeset and PR linked.