### PR TITLE
Do not run `publish` workflow on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ permissions: {} # each job should define its own permission explicitly
 jobs:
   select-mode:
     name: Select Mode
+    if: ${{ github.repository_owner == 'changesets' }}
     runs-on: ubuntu-latest
     environment: version
     timeout-minutes: 20


### PR DESCRIPTION
I recently noticed a [failing run](https://github.com/trueberryless/changesets-changesets/actions/runs/28496329397/job/84463376048) in my fork of changesets because I updated my `main` branch (which strictly speaking would never be necessary, but I do it sometimes).

To avoid this always failing run, I decided to add a check in the workflow to prevent any runs in forks. Subsequent jobs are also skipped because they are dependent on the first job, which is now also skipped.