### PR TITLE
Ensure `changeset publish` and `changeset tag` create the `CHANGESETS_OUTPUT` file even when there is nothing to publish or tag

### DIFF
--- a/.changeset/early-outputs-report.md
+++ b/.changeset/early-outputs-report.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Ensure `changeset publish` and `changeset tag` create the `CHANGESETS_OUTPUT` file even when there is nothing to publish or tag.

--- a/packages/cli/src/commands/git-tag/__tests__/index.test.ts
+++ b/packages/cli/src/commands/git-tag/__tests__/index.test.ts
@@ -81,6 +81,29 @@ describe("git-tag command", () => {
       );
     });
 
+    it("creates an empty output file when there is nothing to tag", async () => {
+      const cwd = await testdir({
+        "package.json": JSON.stringify({
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        "package-lock.json": "",
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "pkg-a",
+          version: "1.0.0",
+        }),
+        ".changeset/config.json": JSON.stringify({}),
+      });
+      const outputFile = path.join(cwd, "output.ndjson");
+
+      (git.getAllTags as Mock).mockReturnValue(new Set(["pkg-a@1.0.0"]));
+      vi.mocked(git.tagExists).mockResolvedValueOnce(true);
+
+      await gitTag({ cwd, output: outputFile });
+
+      await expect(fs.readFile(outputFile, "utf8")).resolves.toBe("");
+    });
+
     it("skips tags that already exist", async () => {
       const cwd = await testdir({
         "package.json": JSON.stringify({

--- a/packages/cli/src/commands/git-tag/index.ts
+++ b/packages/cli/src/commands/git-tag/index.ts
@@ -29,6 +29,7 @@ export interface GitTagOptions {
 }
 
 export async function gitTag(options?: GitTagOptions) {
+  await using reporter = await createOutputReport(options?.output);
   const cwd = options?.cwd ?? process.cwd();
   const packages = await getPackages(cwd);
   await ensureChangesetFolder(packages.rootDir);
@@ -59,8 +60,6 @@ export async function gitTag(options?: GitTagOptions) {
 
   const p = progress({ max: untaggedPackages.length - skippedTags.length });
   p.start("Creating tags...");
-
-  await using reporter = await createOutputReport(options?.output);
 
   for (const pkg of untaggedPackages) {
     const tag = buildTag(packages.tool, pkg);

--- a/packages/cli/src/commands/publish/__tests__/index.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/index.test.ts
@@ -365,6 +365,39 @@ describe("Publish command", () => {
     );
   });
 
+  it("creates an empty output file when there is nothing to publish or tag", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+    const outputFile = path.join(cwd, "output.ndjson");
+
+    mockExecImplementation(async (_command, args) => {
+      if (args[0] === "info") {
+        return execResult(
+          JSON.stringify({
+            version: "1.0.0",
+            versions: ["1.0.0"],
+          }),
+        );
+      }
+      throw new Error(`Unexpected exec args: ${args.join(" ")}`);
+    });
+
+    await publishCommand({ cwd, output: outputFile });
+
+    await expect(fs.readFile(outputFile, "utf8")).resolves.toBe("");
+    expect(git.tag).not.toHaveBeenCalled();
+  });
+
   it("stops publishing after a failed chunk", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -50,6 +50,7 @@ export interface PublishOptions {
 }
 
 export async function publish(options?: PublishOptions) {
+  await using reporter = await createOutputReport(options?.output);
   const cwd = options?.cwd ?? process.cwd();
   const artifactDir = options?.fromPackDir
     ? path.resolve(cwd, options.fromPackDir)
@@ -93,8 +94,6 @@ To resolve this exit the pre mode by running ${c.cyan("changeset pre exit")}.
     log.warn("No unpublished projects to publish.");
     return;
   }
-
-  await using reporter = await createOutputReport(options?.output);
 
   for (let index = 0; index < plan.length; index++) {
     const chunk = plan[index];


### PR DESCRIPTION
Just so the caller can count on this file being created when "requested" through an env variable