### PR TITLE
Support Cargo.toml version syncing for mixed JS/Rust packages

### DIFF
--- a/.changeset/cargo-toml-version-sync.md
+++ b/.changeset/cargo-toml-version-sync.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": minor
+---
+
+Update the `version` field of a sibling `Cargo.toml` when versioning a package, if one exists in the package's directory. This lets `changeset version` keep a Rust crate's version (e.g. napi-rs/wasm-bindgen bindings living alongside their `package.json`) in sync with the npm package version. Workspace-inherited versions (`version.workspace = true`) are not supported and will cause `changeset version` to error for that package.

--- a/packages/apply-release-plan/package.json
+++ b/packages/apply-release-plan/package.json
@@ -21,7 +21,8 @@
     "@changesets/types": "workspace:^",
     "import-meta-resolve": "^4.2.0",
     "jsonc-parser": "^3.3.1",
-    "semver": "^7.8.1"
+    "semver": "^7.8.1",
+    "toml-eslint-parser": "^1.0.3"
   },
   "devDependencies": {
     "@changesets/test-utils": "workspace:*",

--- a/packages/apply-release-plan/src/edit-cargo-toml.test.ts
+++ b/packages/apply-release-plan/src/edit-cargo-toml.test.ts
@@ -50,7 +50,7 @@ version = "9.9.9"
   it("throws when the version is workspace-inherited", () => {
     const toml = `[package]\nname = "my-crate"\nversion.workspace = true\n`;
     expect(() => editCargoTomlVersion(toml, "0.2.0")).toThrow(
-      /workspace-inherited/,
+      /version\.workspace = true/,
     );
   });
 });

--- a/packages/apply-release-plan/src/edit-cargo-toml.test.ts
+++ b/packages/apply-release-plan/src/edit-cargo-toml.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { editCargoTomlVersion } from "./edit-cargo-toml.ts";
+
+describe("editCargoTomlVersion", () => {
+  it("updates the version field in the [package] section", () => {
+    const toml = `[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+`;
+    expect(editCargoTomlVersion(toml, "0.2.0")).toBe(`[package]
+name = "my-crate"
+version = "0.2.0"
+edition = "2021"
+`);
+  });
+
+  it("preserves comments and unrelated formatting", () => {
+    const toml = `# top comment
+[package]
+name = "my-crate" # crate name
+version = "0.1.0" # crate version
+
+[dependencies]
+version = "9.9.9"
+`;
+    expect(editCargoTomlVersion(toml, "1.0.0")).toBe(`# top comment
+[package]
+name = "my-crate" # crate name
+version = "1.0.0" # crate version
+
+[dependencies]
+version = "9.9.9"
+`);
+  });
+
+  it("supports single-quoted version strings", () => {
+    const toml = `[package]\nversion = '0.1.0'\n`;
+    expect(editCargoTomlVersion(toml, "0.2.0")).toBe(
+      `[package]\nversion = '0.2.0'\n`,
+    );
+  });
+
+  it("throws when there is no [package] section", () => {
+    expect(() =>
+      editCargoTomlVersion(`[workspace]\nmembers = ["."]\n`, "0.2.0"),
+    ).toThrow(/\[package\]/);
+  });
+
+  it("throws when the version is workspace-inherited", () => {
+    const toml = `[package]\nname = "my-crate"\nversion.workspace = true\n`;
+    expect(() => editCargoTomlVersion(toml, "0.2.0")).toThrow(
+      /workspace-inherited/,
+    );
+  });
+});

--- a/packages/apply-release-plan/src/edit-cargo-toml.ts
+++ b/packages/apply-release-plan/src/edit-cargo-toml.ts
@@ -1,6 +1,4 @@
-const PACKAGE_HEADER_RE = /^\[package\][ \t]*(\r?\n|$)/m;
-const NEXT_HEADER_RE = /^\[/m;
-const VERSION_FIELD_RE = /^([ \t]*version[ \t]*=[ \t]*)(["'])(.*?)\2/m;
+import { parseTOML, type AST } from "toml-eslint-parser";
 
 /**
  * Updates the `version` field in the `[package]` section of a Cargo.toml,
@@ -8,28 +6,47 @@ const VERSION_FIELD_RE = /^([ \t]*version[ \t]*=[ \t]*)(["'])(.*?)\2/m;
  * (`version.workspace = true`) are not supported.
  */
 export function editCargoTomlVersion(toml: string, newVersion: string): string {
-  const packageHeaderMatch = PACKAGE_HEADER_RE.exec(toml);
-  if (!packageHeaderMatch) {
+  const topLevelTable = parseTOML(toml).body[0];
+
+  const packageTable = topLevelTable.body.find(
+    (node): node is AST.TOMLTable =>
+      node.type === "TOMLTable" &&
+      node.kind === "standard" &&
+      node.resolvedKey.length === 1 &&
+      node.resolvedKey[0] === "package",
+  );
+  if (!packageTable) {
     throw new Error("Could not find a `[package]` section in Cargo.toml");
   }
-  const sectionStart = packageHeaderMatch.index + packageHeaderMatch[0].length;
 
-  const nextHeaderMatch = NEXT_HEADER_RE.exec(toml.slice(sectionStart));
-  const sectionEnd = nextHeaderMatch
-    ? sectionStart + nextHeaderMatch.index
-    : toml.length;
-  const section = toml.slice(sectionStart, sectionEnd);
-
-  const versionMatch = VERSION_FIELD_RE.exec(section);
-  if (!versionMatch) {
+  const versionEntry = packageTable.body.find(
+    (kv) => getKeyPath(kv) === "version",
+  );
+  if (!versionEntry) {
+    const isWorkspaceInherited = packageTable.body.some((kv) =>
+      getKeyPath(kv).startsWith("version."),
+    );
     throw new Error(
-      "Could not find a `version` field in the `[package]` section of Cargo.toml (workspace-inherited versions via `version.workspace = true` are not supported)",
+      isWorkspaceInherited
+        ? "Cannot update `version` in Cargo.toml: it is inherited via `version.workspace = true`, which is not supported"
+        : "Could not find a `version` field in the `[package]` section of Cargo.toml",
     );
   }
 
-  const valueStart =
-    sectionStart + versionMatch.index + versionMatch[1].length + 1;
-  const valueEnd = valueStart + versionMatch[3].length;
+  const { value } = versionEntry;
+  if (value.type !== "TOMLValue" || value.kind !== "string") {
+    throw new Error(
+      "Expected the `version` field in the `[package]` section of Cargo.toml to be a string",
+    );
+  }
 
-  return toml.slice(0, valueStart) + newVersion + toml.slice(valueEnd);
+  const [start, end] = value.range;
+  const quote = value.style === "literal" ? "'" : '"';
+  return toml.slice(0, start) + quote + newVersion + quote + toml.slice(end);
+}
+
+function getKeyPath(keyValue: AST.TOMLKeyValue): string {
+  return keyValue.key.keys
+    .map((key) => (key.type === "TOMLBare" ? key.name : key.value))
+    .join(".");
 }

--- a/packages/apply-release-plan/src/edit-cargo-toml.ts
+++ b/packages/apply-release-plan/src/edit-cargo-toml.ts
@@ -1,0 +1,35 @@
+const PACKAGE_HEADER_RE = /^\[package\][ \t]*(\r?\n|$)/m;
+const NEXT_HEADER_RE = /^\[/m;
+const VERSION_FIELD_RE = /^([ \t]*version[ \t]*=[ \t]*)(["'])(.*?)\2/m;
+
+/**
+ * Updates the `version` field in the `[package]` section of a Cargo.toml,
+ * preserving all other content and formatting. Workspace-inherited versions
+ * (`version.workspace = true`) are not supported.
+ */
+export function editCargoTomlVersion(toml: string, newVersion: string): string {
+  const packageHeaderMatch = PACKAGE_HEADER_RE.exec(toml);
+  if (!packageHeaderMatch) {
+    throw new Error("Could not find a `[package]` section in Cargo.toml");
+  }
+  const sectionStart = packageHeaderMatch.index + packageHeaderMatch[0].length;
+
+  const nextHeaderMatch = NEXT_HEADER_RE.exec(toml.slice(sectionStart));
+  const sectionEnd = nextHeaderMatch
+    ? sectionStart + nextHeaderMatch.index
+    : toml.length;
+  const section = toml.slice(sectionStart, sectionEnd);
+
+  const versionMatch = VERSION_FIELD_RE.exec(section);
+  if (!versionMatch) {
+    throw new Error(
+      "Could not find a `version` field in the `[package]` section of Cargo.toml (workspace-inherited versions via `version.workspace = true` are not supported)",
+    );
+  }
+
+  const valueStart =
+    sectionStart + versionMatch.index + versionMatch[1].length + 1;
+  const valueEnd = valueStart + versionMatch[3].length;
+
+  return toml.slice(0, valueStart) + newVersion + toml.slice(valueEnd);
+}

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -289,6 +289,95 @@ describe("apply release plan", () => {
       });
     });
 
+    describe("Cargo.toml", () => {
+      it("should update the version in a sibling Cargo.toml", async () => {
+        const releasePlan = new FakeReleasePlan();
+        const { changedFiles } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "package-lock.json": "",
+            "packages/pkg-a/package.json": JSON.stringify({
+              name: "pkg-a",
+              version: "1.0.0",
+            }),
+            "packages/pkg-a/Cargo.toml": `[package]
+name = "pkg-a"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0.0"
+`,
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+        const cargoTomlPath = changedFiles.find((a) =>
+          a.endsWith(`pkg-a${path.sep}Cargo.toml`),
+        );
+
+        if (!cargoTomlPath)
+          throw new Error(`could not find an updated Cargo.toml`);
+        const cargoToml = await fs.readFile(cargoTomlPath, "utf8");
+
+        expect(cargoToml).toBe(`[package]
+name = "pkg-a"
+version = "1.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0.0"
+`);
+      });
+
+      it("should not touch packages without a Cargo.toml", async () => {
+        const releasePlan = new FakeReleasePlan();
+        const { changedFiles } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "package-lock.json": "",
+            "packages/pkg-a/package.json": JSON.stringify({
+              name: "pkg-a",
+              version: "1.0.0",
+            }),
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+
+        expect(changedFiles.some((a) => a.endsWith("Cargo.toml"))).toBe(false);
+      });
+
+      it("should throw if the Cargo.toml has no [package] section", async () => {
+        const releasePlan = new FakeReleasePlan();
+
+        await expect(
+          testSetup(
+            {
+              "package.json": JSON.stringify({
+                private: true,
+                workspaces: ["packages/*"],
+              }),
+              "package-lock.json": "",
+              "packages/pkg-a/package.json": JSON.stringify({
+                name: "pkg-a",
+                version: "1.0.0",
+              }),
+              "packages/pkg-a/Cargo.toml": `[workspace]\nmembers = ["."]\n`,
+            },
+            releasePlan.getReleasePlan(),
+            releasePlan.config,
+          ),
+        ).rejects.toThrow(/\[package\]/);
+      });
+    });
+
     it("should not update ranges set to *", async () => {
       const releasePlan = new FakeReleasePlan(
         [

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -18,6 +18,7 @@ import type {
   ReleasePlan,
 } from "@changesets/types";
 import { resolve } from "import-meta-resolve";
+import { editCargoTomlVersion } from "./edit-cargo-toml.ts";
 import { editJson } from "./edit-json.ts";
 import { getChangelogEntry } from "./get-changelog-entry.ts";
 import {
@@ -139,13 +140,23 @@ export async function applyReleasePlan(
 
   const filesToFormat: string[] = [];
   for (const release of finalisedRelease) {
-    const { changelog, pkgJsonEdits, dir, name } = release;
+    const { changelog, pkgJsonEdits, dir, name, newVersion } = release;
 
     const pkgJsonPath = path.resolve(dir, "package.json");
     const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
     const pkgUpdated = editJson(pkgRaw, pkgJsonEdits);
     await fs.writeFile(pkgJsonPath, pkgUpdated);
     touchedFiles.push(pkgJsonPath);
+
+    const cargoTomlPath = path.resolve(dir, "Cargo.toml");
+    const cargoTomlRaw = await fs
+      .readFile(cargoTomlPath, "utf8")
+      .catch(() => null);
+    if (cargoTomlRaw != null) {
+      const cargoTomlUpdated = editCargoTomlVersion(cargoTomlRaw, newVersion);
+      await fs.writeFile(cargoTomlPath, cargoTomlUpdated);
+      touchedFiles.push(cargoTomlPath);
+    }
 
     if (changelog && changelog.length > 0) {
       const changelogPath = path.resolve(dir, "CHANGELOG.md");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       semver:
         specifier: ^7.8.1
         version: 7.8.4
+      toml-eslint-parser:
+        specifier: ^1.0.3
+        version: 1.0.3
     devDependencies:
       '@changesets/test-utils':
         specifier: workspace:*
@@ -1852,6 +1855,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toml-eslint-parser@1.0.3:
+    resolution: {integrity: sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3287,6 +3294,10 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
+
+  toml-eslint-parser@1.0.3:
+    dependencies:
+      eslint-visitor-keys: 5.0.1
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
## Summary

- `changeset version` now updates the `version` field of a sibling `Cargo.toml` (in the `[package]` section) whenever it versions a package, if one exists in that package's directory
- Enables mixed npm/Rust packages (e.g. napi-rs/wasm-bindgen bindings) to keep `Cargo.toml` and `package.json` versions in sync without a separate script
- Package discovery is unchanged — still driven by `package.json` / `@manypkg/get-packages`; only the version-write step gained Cargo.toml awareness
- Out of scope (see issue for rationale): standalone Rust-only package discovery, bumping internal `[dependencies]` between crates, and `version.workspace = true` inheritance (throws a clear error instead of silently doing nothing)

Closes #2140

## Test plan

- [x] `pnpm build`
- [x] `pnpm vitest run packages/apply-release-plan/src/edit-cargo-toml.test.ts packages/apply-release-plan/src/index.test.ts` — new unit tests for the TOML edit helper + integration tests in `applyReleasePlan` (update version, no-op when no Cargo.toml, error on missing `[package]` section)
- [x] `pnpm types:check`
- [x] `pnpm eslint` on changed files
- [x] `pnpm oxfmt` on changed files
- [x] Added a changeset (`.changeset/cargo-toml-version-sync.md`)