### PR TITLE
Add `--type` flag to `add` command

### DIFF
--- a/.changeset/tall-months-shout.md
+++ b/.changeset/tall-months-shout.md
@@ -1,0 +1,13 @@
+---
+"@changesets/cli": minor
+---
+
+Add `--type` flag to the `add` command
+
+The `add` command now supports a `--type` flag that provides the semver bump type (`patch`, `minor` or `major`) from the command line instead of prompting for it. The bump type is applied to all packages that have changed since the base branch (or the ref provided with `--since`).
+
+When combined with `--message`, the changeset is created without any prompts, which makes it possible to add changesets from scripts and other automation:
+
+```sh
+changeset add --type patch --message 'Fix crash on startup'
+```

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -3,7 +3,7 @@
 The command line for changesets is the main way of interacting with it. There are 4 main commands. If you are looking for how we recommend you setup and manage changesets with the commands, check out our [intro to using changesets](./intro-to-using-changesets.md)
 
 - init
-- add [--empty] [--open] [--since <ref>] [--message <text>]
+- add [--empty] [--open] [--since <ref>] [--message <text>] [--type <type>]
 - version [--ignore, --snapshot]
 - publish [--otp=code, --tag]
 - status [--since=master --verbose --output=JSON_FILE.json]
@@ -66,6 +66,12 @@ If you set the commit option in the config, the command will add the updated cha
 
 - `--open` - opens the created changeset in an external editor
 - `--message` (or `-m`) - provides the changeset summary from the command line instead of prompting for it.
+
+- `--type` - provides the semver bump type (`patch`, `minor` or `major`) from the command line instead of prompting for it. The bump type is applied to all packages that have changed since the base branch (or the ref provided with `--since`). When combined with `--message`, the changeset is created without any prompts, which is useful for scripts and other automation.
+
+```
+changeset add --type patch --message 'Fix crash on startup'
+```
 
 - `--since` - uses the provided branch, tag, or git ref (such as `main` or a git commit hash) to detect which packages have changed when populating the list of changed packages in the CLI. This is useful in gitflow workflows where you have multiple target branches and `baseBranch` in the config doesn't cover all use cases. If not provided, the command falls back to the `baseBranch` value in your `.changeset/config.json`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,13 +96,13 @@ To publish public packages to NPM, you'll need to edit `.changeset/config.json` 
 ### add
 
 ```shell
-changeset [--empty] [--open] [--message <text>]
+changeset [--empty] [--open] [--since <ref>] [--message <text>] [--type <type>]
 ```
 
 or
 
 ```shell
-changeset add [--empty] [--open] [--message <text>]
+changeset add [--empty] [--open] [--since <ref>] [--message <text>] [--type <type>]
 ```
 
 This command will ask you a series of questions, first about what packages you want to release, then what semver bump type for each package, then it will ask for a summary of the entire changeset. At the final step it will show the changeset it will generate, and confirm that you want to add it.
@@ -134,6 +134,8 @@ If you set the `commit` option in the config, the command will add the updated c
 
 - `--open` - opens the created changeset in an external editor
 - `--message` (or `-m`) - provides the changeset summary from the command line instead of prompting for it.
+- `--type` - provides the semver bump type (`patch`, `minor` or `major`) from the command line instead of prompting for it. The bump type is applied to all packages that have changed since the base branch (or the ref provided with `--since`). When combined with `--message`, the changeset is created without any prompts, which is useful for scripts and other automation.
+- `--since` - uses the provided branch, tag, or git ref (such as `main` or a git commit hash) to detect which packages have changed. If not provided, the command falls back to the `baseBranch` value in your `.changeset/config.json`.
 
 ### version
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -61,6 +61,13 @@ const tests: CommandTest[] = [
           since: "next",
         },
       },
+      {
+        args: ["--type", "patch", "-m", "hello"],
+        options: {
+          type: "patch",
+          message: "hello",
+        },
+      },
     ],
   },
   {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -61,6 +61,7 @@ cli
   .usage("[command] [options]")
   .example("  $ changeset -m 'Description'")
   .example("  $ changeset --open --since main")
+  .example("  $ changeset --type patch -m 'Description'")
   .alias("!") // special alias for default command
   .option("--empty", "Add an empty changeset")
   .option("--open", "Open the changeset in the editor after creating it")
@@ -69,6 +70,10 @@ cli
     "Detect changed packages since the provided git ref",
   )
   .option("-m, --message <text>", "Directly provide a message to the changeset")
+  .option(
+    "--type <type>",
+    "Directly provide a bump type (patch, minor or major) for the changed packages",
+  )
   .action(async (options) => {
     normalizeOptions(options);
     const { add } = await import("./commands/add/index.ts");

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -650,6 +650,371 @@ describe("Add command", () => {
     );
   });
 
+  it("should create a changeset for the changed packages without prompting when type and message are provided", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await exec("git", ["checkout", "-b", "feature"], { nodeOptions: { cwd } });
+    await outputFile(
+      path.join(cwd, "packages/pkg-b/b.js"),
+      'export default "b"',
+    );
+    await git.add(".", cwd);
+    await git.commit("update pkg-b", cwd);
+
+    await addChangeset({
+      cwd,
+      since: "main",
+      type: "patch",
+      message: "non-interactive summary",
+    });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "non-interactive summary",
+        releases: [{ name: "pkg-b", type: "patch" }],
+      }),
+    );
+    expect(mockedUtils.askMultiselect).not.toHaveBeenCalled();
+    expect(mockedUtils.askList).not.toHaveBeenCalled();
+    expect(mockedUtils.askQuestion).not.toHaveBeenCalled();
+    expect(mockedUtils.askConfirm).not.toHaveBeenCalled();
+    expect(mockedAskWithEditor).not.toHaveBeenCalled();
+  });
+
+  it("should apply the type to all changed packages sorted by name", async () => {
+    // pkg-b lives in a longer directory, so the changed packages are detected
+    // in the reverse order of the expected one
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b-long-dir/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await exec("git", ["checkout", "-b", "feature"], { nodeOptions: { cwd } });
+    await outputFile(
+      path.join(cwd, "packages/pkg-b-long-dir/b.js"),
+      'export default "b"',
+    );
+    await outputFile(
+      path.join(cwd, "packages/pkg-a/a.js"),
+      'export default "a"',
+    );
+    await git.add(".", cwd);
+    await git.commit("update pkg-a and pkg-b", cwd);
+
+    await addChangeset({
+      cwd,
+      since: "main",
+      type: "minor",
+      message: "bump them all",
+    });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "bump them all",
+        releases: [
+          { name: "pkg-a", type: "minor" },
+          { name: "pkg-b", type: "minor" },
+        ],
+      }),
+    );
+  });
+
+  it("should not apply the type to changed packages ignored by the config", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({
+        ...defaultConfig,
+        ignore: ["pkg-b"],
+      }),
+    });
+
+    await exec("git", ["checkout", "-b", "feature"], { nodeOptions: { cwd } });
+    await outputFile(
+      path.join(cwd, "packages/pkg-a/a.js"),
+      'export default "a"',
+    );
+    await outputFile(
+      path.join(cwd, "packages/pkg-b/b.js"),
+      'export default "b"',
+    );
+    await git.add(".", cwd);
+    await git.commit("update pkg-a and pkg-b", cwd);
+
+    await addChangeset({
+      cwd,
+      since: "main",
+      type: "patch",
+      message: "bump the changed packages",
+    });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "bump the changed packages",
+        releases: [{ name: "pkg-a", type: "patch" }],
+      }),
+    );
+  });
+
+  it("should create a changeset without prompting in a single package repo when type and message are provided", async () => {
+    const loggerWarnSpy = vi.spyOn(clack.log, "warn");
+
+    // not a git repo, but a single package repo doesn't need to detect the changed packages
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "single-package",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await addChangeset({ cwd, type: "minor", message: "single package bump" });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "single package bump",
+        releases: [{ name: "single-package", type: "minor" }],
+      }),
+    );
+    expect(mockedUtils.askList).not.toHaveBeenCalled();
+    expect(mockedUtils.askQuestion).not.toHaveBeenCalled();
+    expect(mockedUtils.askConfirm).not.toHaveBeenCalled();
+    expect(mockedAskWithEditor).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not ask for confirmation of a first major release when type is provided", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "single-package",
+        version: "0.5.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await addChangeset({ cwd, type: "major", message: "breaking change" });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "breaking change",
+        releases: [{ name: "single-package", type: "major" }],
+      }),
+    );
+    expect(mockedUtils.askConfirm).not.toHaveBeenCalled();
+  });
+
+  it("should only prompt for the summary when type is provided without message", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await exec("git", ["checkout", "-b", "feature"], { nodeOptions: { cwd } });
+    await outputFile(
+      path.join(cwd, "packages/pkg-b/b.js"),
+      'export default "b"',
+    );
+    await git.add(".", cwd);
+    await git.commit("update pkg-b", cwd);
+
+    mockedUtils.askQuestion.mockResolvedValue("typed summary");
+    mockedUtils.askConfirm.mockResolvedValue(true);
+
+    await addChangeset({ cwd, since: "main", type: "patch" });
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets.length).toBe(1);
+    expect(changesets[0]).toEqual(
+      expect.objectContaining({
+        summary: "typed summary",
+        releases: [{ name: "pkg-b", type: "patch" }],
+      }),
+    );
+    expect(mockedUtils.askMultiselect).not.toHaveBeenCalled();
+    expect(mockedUtils.askList).not.toHaveBeenCalled();
+    expect(mockedUtils.askConfirm).toHaveBeenCalledWith(
+      "Is this your desired changeset?",
+    );
+  });
+
+  it("should exit with an error when an invalid type is provided", async () => {
+    const loggerErrorSpy = vi.spyOn(clack.log, "error");
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "single-package",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await expect(() =>
+      addChangeset({ cwd, type: "invalid", message: "some summary" }),
+    ).rejects.toThrow("The process exited with code: 1");
+
+    expect(loggerErrorSpy).toHaveBeenCalledOnce();
+    expect(stripVTControlCharacters(loggerErrorSpy.mock.calls[0][0])).toBe(
+      "Only patch, minor or major is accepted as the bump type",
+    );
+  });
+
+  it("should exit with an error when type is used together with empty", async () => {
+    const loggerErrorSpy = vi.spyOn(clack.log, "error");
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "single-package",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await expect(() =>
+      addChangeset({ cwd, type: "patch", empty: true }),
+    ).rejects.toThrow("The process exited with code: 1");
+
+    expect(loggerErrorSpy).toHaveBeenCalledOnce();
+    expect(stripVTControlCharacters(loggerErrorSpy.mock.calls[0][0])).toBe(
+      "The --type option cannot be used with --empty",
+    );
+  });
+
+  it("should exit with an error in a monorepo when changed packages cannot be detected and type is provided", async () => {
+    const loggerErrorSpy = vi.spyOn(clack.log, "error");
+
+    // not a git repo, so detecting the changed packages fails
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await expect(() =>
+      addChangeset({ cwd, type: "patch", message: "some summary" }),
+    ).rejects.toThrow("The process exited with code: 1");
+
+    expect(loggerErrorSpy).toHaveBeenCalledOnce();
+    expect(stripVTControlCharacters(loggerErrorSpy.mock.calls[0][0])).toContain(
+      "Failed to identify which packages have changed",
+    );
+  });
+
+  it("should exit with an error in a monorepo when no packages have changed and type is provided", async () => {
+    const loggerErrorSpy = vi.spyOn(clack.log, "error");
+
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "yarn.lock": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify(defaultConfig),
+    });
+
+    await expect(() =>
+      addChangeset({
+        cwd,
+        since: "main",
+        type: "patch",
+        message: "some summary",
+      }),
+    ).rejects.toThrow("The process exited with code: 1");
+
+    expect(loggerErrorSpy).toHaveBeenCalledOnce();
+    expect(stripVTControlCharacters(loggerErrorSpy.mock.calls[0][0])).toBe(
+      "No changed packages found since main to apply the bump type to",
+    );
+  });
+
   it("should throw when .changeset folder is missing when called from subdirectory", async () => {
     const loggerErrorSpy = vi.spyOn(clack.log, "error");
 

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -7,6 +7,13 @@ import { askWithEditor } from "../../utils/askWithEditor.ts";
 import * as cli from "../../utils/cli-utilities.ts";
 import { importantWarning } from "../../utils/cli-utilities.ts";
 
+const bumpTypes = ["patch", "minor", "major"] as const;
+export type BumpType = (typeof bumpTypes)[number];
+
+export function isBumpType(value: string): value is BumpType {
+  return (bumpTypes as readonly string[]).includes(value);
+}
+
 async function confirmMajorRelease({ name, version }: PackageJSON) {
   if (semverLt(version, "1.0.0")) {
     importantWarning(
@@ -170,7 +177,7 @@ ${c.gray(patchBumpedPackages.join(", "))}
     const pkg = allPackages[0];
     const type = await cli.askList(
       `What kind of change is this for ${c.blue(pkg.packageJson.name)}? ${c.gray(`(current version is ${pkg.packageJson.version})`)}`,
-      ["patch", "minor", "major"],
+      [...bumpTypes],
     );
     if (type === "major") {
       const shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
@@ -189,6 +196,16 @@ ${c.gray(patchBumpedPackages.join(", "))}
     };
   }
 
+  return {
+    ...(await askSummary()),
+    releases,
+  };
+}
+
+export async function askSummary(): Promise<{
+  confirmed: boolean;
+  summary: string;
+}> {
   let summary = await cli.askQuestion(
     "Please enter a summary for this change (this will be in the changelogs).",
     { placeholder: "  (submit nothing to open an external editor)" },
@@ -203,7 +220,6 @@ ${c.gray(patchBumpedPackages.join(", "))}
         return {
           confirmed: true,
           summary,
-          releases,
         };
       }
     } catch {
@@ -224,6 +240,5 @@ ${c.gray(patchBumpedPackages.join(", "))}
   return {
     confirmed: false,
     summary,
-    releases,
   };
 }

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -14,7 +14,7 @@ import { importantWarning } from "../../utils/cli-utilities.ts";
 import { readConfig } from "../../utils/read-config.ts";
 import { getVersionableChangedPackages } from "../../utils/versionablePackages.ts";
 import { ensureChangesetFolder } from "../shared.ts";
-import { createChangeset } from "./createChangeset.ts";
+import { askSummary, createChangeset, isBumpType } from "./createChangeset.ts";
 import { printConfirmationMessage } from "./messages.ts";
 
 export interface AddOptions {
@@ -23,10 +23,25 @@ export interface AddOptions {
   open?: boolean;
   since?: string;
   message?: string;
+  type?: string;
 }
 
 export async function add(options?: AddOptions): Promise<void> {
   const cwd = options?.cwd ?? process.cwd();
+
+  const typeFromCli = options?.type;
+  if (typeFromCli != null && !isBumpType(typeFromCli)) {
+    log.error(
+      `Only ${c.cyan("patch")}, ${c.cyan("minor")} or ${c.cyan("major")} is accepted as the bump type`,
+    );
+    throw new ExitError(1);
+  }
+  if (typeFromCli != null && options?.empty) {
+    log.error(
+      `The ${c.cyan("--type")} option cannot be used with ${c.cyan("--empty")}`,
+    );
+    throw new ExitError(1);
+  }
 
   const packages = await getPackages(cwd);
   await ensureChangesetFolder(packages.rootDir);
@@ -68,30 +83,65 @@ No versionable packages found
       summary: options?.message ?? "",
     };
   } else {
+    // With a single versionable package there is nothing to select from, so there is no need to
+    // detect the changed packages
     let changedPackagesNames: string[] = [];
-    try {
-      changedPackagesNames = (
-        await getVersionableChangedPackages(config, {
-          cwd: packages.rootDir,
-          ref: options?.since,
-        })
-      ).map((pkg) => pkg.packageJson.name);
-    } catch (error) {
-      // NOTE: Getting the changed packages is best effort as it's only being used for easier selection
-      // in the CLI. So if any error happens while we try to do so, we only log a warning and continue
-      log.warn(
-        `
+    if (versionablePackages.length > 1) {
+      try {
+        changedPackagesNames = (
+          await getVersionableChangedPackages(config, {
+            cwd: packages.rootDir,
+            ref: options?.since,
+          })
+        ).map((pkg) => pkg.packageJson.name);
+      } catch (error) {
+        const errorMessage = `
 Failed to identify which packages have changed since the ${options?.since ? "ref" : "base branch"} due to an error:
 ${(error as Error).toString()}
-`.trim(),
-      );
+`.trim();
+
+        // With `--type` the changed packages determine what gets released, so we can't continue without them
+        if (typeFromCli != null) {
+          log.error(errorMessage);
+          throw new ExitError(1);
+        }
+
+        // NOTE: Getting the changed packages is best effort as it's only being used for easier selection
+        // in the CLI. So if any error happens while we try to do so, we only log a warning and continue
+        log.warn(errorMessage);
+      }
+
+      if (typeFromCli != null && changedPackagesNames.length === 0) {
+        log.error(
+          `No changed packages found since ${c.cyan(options?.since ?? config.baseBranch)} to apply the bump type to`,
+        );
+        throw new ExitError(1);
+      }
     }
 
-    newChangeset = await createChangeset(
-      changedPackagesNames,
-      versionablePackages,
-      options?.message,
-    );
+    if (typeFromCli != null) {
+      const packagesToRelease =
+        versionablePackages.length > 1
+          ? changedPackagesNames.toSorted((a, b) => a.localeCompare(b))
+          : [versionablePackages[0].packageJson.name];
+
+      newChangeset = {
+        ...(options?.message != null
+          ? // when both the type and the message are provided there is nothing left to ask about
+            { confirmed: true, summary: options.message }
+          : await askSummary()),
+        releases: packagesToRelease.map((name) => ({
+          name,
+          type: typeFromCli,
+        })),
+      };
+    } else {
+      newChangeset = await createChangeset(
+        changedPackagesNames,
+        versionablePackages,
+        options?.message,
+      );
+    }
     printConfirmationMessage(newChangeset, versionablePackages.length > 1);
 
     if (!newChangeset.confirmed) {


### PR DESCRIPTION
Reworks #1890 based on the feedback there: based on `next`, scoped down to only the `add` command (no `changed` command), and simplified to take just a bump type and a message instead of multiple `--package` flags.

The `add` command now supports a `--type` flag that provides the semver bump type (`patch`, `minor` or `major`) from the command line instead of prompting for it. The bump type is applied to all packages that have changed since the base branch (or the ref provided with `--since`). Combined with `--message`, the changeset is created without any prompts, so scripts, CI and AI agents can add changesets non-interactively:

```sh
changeset add --type patch --message 'Fix crash on startup'
```

Notes:

- `--type` composes with the existing flags like `--message` does: on its own it only replaces the package selection and bump type prompts, and the summary is still asked for. Single package repos just use their sole package.
- In `--type` mode, failing to detect the changed packages (or detecting none) is a hard error instead of the interactive flow's best-effort warning, since the result now decides what gets released.
- Detecting changed packages is now skipped in single package repos, where the result was never used. This also removes a spurious warning when running `changeset` in a non-git single package repo.
- While documenting `--type` I noticed the CLI README never documented `--since`, so I added it there too.

Tested with unit tests for all the new paths and end-to-end against a real monorepo (27+ packages), including the error paths and exit codes.

Refs #979, #1604