### PR TITLE
Fixed handling of the npm 12 info output

### DIFF
--- a/.changeset/tidy-eyes-repair.md
+++ b/.changeset/tidy-eyes-repair.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Fixed already-published version detection with npm 12. npm 12 wraps all successful `npm info --json` output in an array and reports zero-match queries as an E404 "No match found for version" error instead of empty stdout, which made `changeset publish` treat every package as unpublished and fail attempting to republish existing versions.

--- a/.changeset/tidy-eyes-repair.md
+++ b/.changeset/tidy-eyes-repair.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-Fixed already-published version detection with npm 12. npm 12 wraps all successful `npm info --json` output in an array and reports zero-match queries as an E404 "No match found for version" error instead of empty stdout, which made `changeset publish` treat every package as unpublished and fail attempting to republish existing versions.
+Fixed already-published version detection with npm 12, which always wraps successful `npm info --json` output in an array. The unwrapped output made `changeset publish` treat every package as unpublished and fail attempting to republish existing versions.

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -109,6 +109,109 @@ describe("publishPackages", () => {
     ).toBe(false);
   });
 
+  it("detects already-published versions when npm 12 wraps info output in an array", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+    });
+
+    mockSpawnImplementation((cmd, args) => {
+      if (cmd === "npm" && args?.[0] === "info") {
+        return spawnResult(
+          JSON.stringify([
+            {
+              name: "pkg-a",
+              version: "1.0.0",
+              versions: ["1.0.0"],
+            },
+          ])
+        );
+      }
+      return spawnResult("", 1);
+    });
+
+    const result = await publishPackages({
+      packages: (await getPackages(cwd)).packages,
+      access: "public",
+      preState: undefined,
+    });
+
+    expect(result).toEqual([]);
+    expect(
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "npm" && args?.[0] === "publish"
+      )
+    ).toBe(false);
+  });
+
+  it("retries with an exact version when npm 12 reports no match for the bare query", async () => {
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+    });
+
+    mockSpawnImplementation((cmd, args) => {
+      if (cmd === "npm" && args?.[0] === "info") {
+        if (args?.[1] === "pkg-a") {
+          // npm 12 emits an E404 error instead of empty stdout when nothing
+          // matches `latest` (e.g. GitHub Packages without a `latest` dist-tag)
+          return spawnResult(
+            JSON.stringify({
+              error: {
+                code: "E404",
+                summary: "No match found for version latest",
+                detail: "",
+              },
+            }),
+            1
+          );
+        }
+        if (args?.[1] === "pkg-a@1.0.0") {
+          return spawnResult(
+            JSON.stringify([
+              {
+                name: "pkg-a",
+                version: "1.0.0",
+                versions: ["1.0.0"],
+              },
+            ])
+          );
+        }
+      }
+      return spawnResult("", 1);
+    });
+
+    const result = await publishPackages({
+      packages: (await getPackages(cwd)).packages,
+      access: "public",
+      preState: undefined,
+    });
+
+    expect(result).toEqual([]);
+    expect(
+      mockSpawn.mock.calls
+        .filter(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
+        .map(([, args]) => args?.[1])
+    ).toEqual(["pkg-a", "pkg-a@1.0.0"]);
+    expect(
+      mockSpawn.mock.calls.some(
+        ([cmd, args]) => cmd === "npm" && args?.[0] === "publish"
+      )
+    ).toBe(false);
+  });
+
   it("publishes a new prerelease when exact version fallback also 404s", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -150,68 +150,6 @@ describe("publishPackages", () => {
     ).toBe(false);
   });
 
-  it("retries with an exact version when npm 12 reports no match for the bare query", async () => {
-    const cwd = await testdir({
-      "package.json": JSON.stringify({
-        private: true,
-        workspaces: ["packages/*"],
-      }),
-      "packages/pkg-a/package.json": JSON.stringify({
-        name: "pkg-a",
-        version: "1.0.0",
-      }),
-    });
-
-    mockSpawnImplementation((cmd, args) => {
-      if (cmd === "npm" && args?.[0] === "info") {
-        if (args?.[1] === "pkg-a") {
-          // npm 12 emits an E404 error instead of empty stdout when nothing
-          // matches `latest` (e.g. GitHub Packages without a `latest` dist-tag)
-          return spawnResult(
-            JSON.stringify({
-              error: {
-                code: "E404",
-                summary: "No match found for version latest",
-                detail: "",
-              },
-            }),
-            1
-          );
-        }
-        if (args?.[1] === "pkg-a@1.0.0") {
-          return spawnResult(
-            JSON.stringify([
-              {
-                name: "pkg-a",
-                version: "1.0.0",
-                versions: ["1.0.0"],
-              },
-            ])
-          );
-        }
-      }
-      return spawnResult("", 1);
-    });
-
-    const result = await publishPackages({
-      packages: (await getPackages(cwd)).packages,
-      access: "public",
-      preState: undefined,
-    });
-
-    expect(result).toEqual([]);
-    expect(
-      mockSpawn.mock.calls
-        .filter(([cmd, args]) => cmd === "npm" && args?.[0] === "info")
-        .map(([, args]) => args?.[1])
-    ).toEqual(["pkg-a", "pkg-a@1.0.0"]);
-    expect(
-      mockSpawn.mock.calls.some(
-        ([cmd, args]) => cmd === "npm" && args?.[0] === "publish"
-      )
-    ).toBe(false);
-  });
-
   it("publishes a new prerelease when exact version fallback also 404s", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -161,19 +161,6 @@ function normalizeInfoJson(parsed: any) {
   return Array.isArray(parsed) ? parsed[0] : parsed;
 }
 
-// Bare query matched nothing in npm <=11 with empty stdout, npm >=12 with an E404 "No match found for version" error
-function isNoMatchResult(stdout: string): boolean {
-  if (stdout === "") {
-    return true;
-  }
-  const error = jsonParse(stdout)?.error;
-  return (
-    error?.code === "E404" &&
-    typeof error.summary === "string" &&
-    error.summary.startsWith("No match found for version")
-  );
-}
-
 export function getPackageInfo(packageJson: PackageJSON) {
   return npmRequestQueue.add(async () => {
     info(`npm info ${packageJson.name}`);
@@ -189,9 +176,9 @@ export function getPackageInfo(packageJson: PackageJSON) {
       "--json",
     ]);
 
-    // Bare query matched nothing — retry with exact version specifier
+    // Bare query returned nothing — retry with exact version specifier
     // to handle prerelease-only packages on registries without auto-`latest`.
-    if (isNoMatchResult(result.stdout.toString())) {
+    if (result.stdout.toString() === "") {
       result = await spawn("npm", [
         "info",
         `${packageJson.name}@${packageJson.version}`,

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -155,13 +155,10 @@ export async function getTokenIsRequired() {
 //   published with preState.tag rather than "latest".
 
 // npm 12 always wraps successful `npm info --json` output in an array.
-// Unwrap it so downstream consumers keep seeing a single manifest, if multiple versions matched, the last entry is
-// the highest one
+// Unwrap it so downstream consumers keep seeing a single manifest.
 function normalizeInfoJson(parsed: any) {
-  if (!Array.isArray(parsed)) {
-    return parsed;
-  }
-  return parsed.at(-1) ?? { error: { code: "E404" } };
+  // given we query the implicit `latest` tag or an exact version, the resulting array should have at most one element
+  return Array.isArray(parsed) ? parsed[0] : parsed;
 }
 
 // Bare query matched nothing in npm <=11 with empty stdout, npm >=12 with an E404 "No match found for version" error

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -153,6 +153,30 @@ export async function getTokenIsRequired() {
 //   queries return empty → no versions list → only-pre detection is not
 //   possible. Such packages (e.g. GitHub Packages with no auto-latest) are
 //   published with preState.tag rather than "latest".
+
+// npm 12 always wraps successful `npm info --json` output in an array.
+// Unwrap it so downstream consumers keep seeing a single manifest, if multiple versions matched, the last entry is
+// the highest one
+function normalizeInfoJson(parsed: any) {
+  if (!Array.isArray(parsed)) {
+    return parsed;
+  }
+  return parsed.at(-1) ?? { error: { code: "E404" } };
+}
+
+// Bare query matched nothing in npm <=11 with empty stdout, npm >=12 with an E404 "No match found for version" error
+function isNoMatchResult(stdout: string): boolean {
+  if (stdout === "") {
+    return true;
+  }
+  const error = jsonParse(stdout)?.error;
+  return (
+    error?.code === "E404" &&
+    typeof error.summary === "string" &&
+    error.summary.startsWith("No match found for version")
+  );
+}
+
 export function getPackageInfo(packageJson: PackageJSON) {
   return npmRequestQueue.add(async () => {
     info(`npm info ${packageJson.name}`);
@@ -168,9 +192,9 @@ export function getPackageInfo(packageJson: PackageJSON) {
       "--json",
     ]);
 
-    // Bare query returned nothing — retry with exact version specifier
+    // Bare query matched nothing — retry with exact version specifier
     // to handle prerelease-only packages on registries without auto-`latest`.
-    if (result.stdout.toString() === "") {
+    if (isNoMatchResult(result.stdout.toString())) {
       result = await spawn("npm", [
         "info",
         `${packageJson.name}@${packageJson.version}`,
@@ -189,7 +213,7 @@ export function getPackageInfo(packageJson: PackageJSON) {
         },
       };
     }
-    return jsonParse(result.stdout.toString());
+    return normalizeInfoJson(jsonParse(result.stdout.toString()));
   });
 }
 


### PR DESCRIPTION
In [npm v12 `npm view`/`npm info` always return an array](https://docs.npmjs.com/cli/v12/using-npm/changelog#:~:text=npm%20view%20%2D%2Djson%20now%20always%20returns%20an%20array).

This causes changesets to incorrectly interpret the packages as not published, and attempt to publish them, causing errors from the registry.
e.g.
<img width="1090" height="65" alt="image" src="https://github.com/user-attachments/assets/cde88741-1d91-4b43-9a62-9cbe787ae728" />

This PR fixes this by detecting if the output is an array, and grabbing the last element if it is. This should keep compatibility with v11 and v12 behaviour. 

The "error" state is also changed, so it now detects if empty string and E404. 