### PR TITLE
Use a different publish tag for `maintenance/v2` branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "changeset": "packages/cli/bin.js",
     "check-all": "yarn test && yarn types:check && yarn lint && yarn format",
     "version-packages": "changeset version && yarn format:fix",
-    "release": "yarn build && changeset publish --tag v2"
+    "release": "yarn build && changeset publish --tag maintenance-v2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We have to use a different tag because of this:
https://github.com/npm/cli/blob/7b1f6c173d17b3bf30e45426f6df39473c6a1163/lib/commands/publish.js#L89-L91