### PR TITLE
docs: intructions to mitigate GitHub Actions permissions issues

### DIFF
--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -52,10 +52,44 @@ If you want to merge a change without doing any releases (such as when you only 
 
 ## How do I run the version and publish commands?
 
+### Automatic setup
+
 You can set up the [Changesets GitHub Action](https://github.com/changesets/action) to automate this process:
 
 - It creates a `version` PR, then keeps it up to date, recreating it when merged.
 - Optionally, if publishing is set up, it automatically publishes the release whenever the PR is merged.
+
+#### GitHub permissions issues
+
+One important step to not miss is to enable appropriate permissions for the action to work :
+
+1. Add writing permissions for the GitHub access token used by the job that triggers `changesets/action` :
+
+```yml
+# In .github/workflows/release.yml or similar
+
+jobs:
+  release:
+    # ...
+    permissions:
+      contents: write # For changesets to create/update PRs
+      pull-requests: write # For changesets to push tags
+    steps:
+      # ...
+      - name: Create Release PR
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+```
+
+2. In your GitHub repository's settings, go to `Code and automation > Actions > General` and enable the option `Allow GitHub Actions to create and approve pull requests` at the end.
+
+::: details Errors you may encounter if you skip these steps
+
+- `remote: Permission to xxx.git denied to github-actions[bot]`
+- `GitHub Actions is not permitted to create or approve pull requests`
+
+:::
+
+### Manual setup
 
 If you do not want to use this action, the manual workflow we recommend is:
 

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -61,7 +61,7 @@ You can set up the [Changesets GitHub Action](https://github.com/changesets/acti
 
 #### GitHub permissions issues
 
-One important step to not miss is to enable appropriate permissions for the action to work :
+GitHub requires manually enabling actions to manage pull requests:
 
 1. Add writing permissions for the GitHub access token used by the job that triggers `changesets/action` :
 

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -72,8 +72,10 @@ jobs:
   release:
     # ...
     permissions:
-      contents: write # For changesets to create/update PRs
-      pull-requests: write # For changesets to push tags
+      contents: write # to create git tags, GitHub Releases
+      pull-requests: write # to create/update Pull Requests
+      # optional, for npm Trusted Publishing
+      id-token: write # allow creating OIDC token
     steps:
       # ...
       - name: Create Release PR

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -63,7 +63,7 @@ You can set up the [Changesets GitHub Action](https://github.com/changesets/acti
 
 GitHub requires manually enabling actions to manage pull requests:
 
-1. Add writing permissions for the GitHub access token used by the job that triggers `changesets/action` :
+1. Add write permissions for the GitHub token used by the job that executes `changesets/action` :
 
 ```yml
 # In .github/workflows/release.yml or similar


### PR DESCRIPTION
applying changes of #2046 (because its base branch was closed without merging the PR)