### PR TITLE
fix: [#2184] Handle pnpm publish already-published errors

### DIFF
--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -333,7 +333,7 @@ async function internalPublish(
     if (json?.error) {
       if (
         json.error.code === "E403" &&
-        isAlreadyPublishedError(json.error.summary)
+        isAlreadyPublishedError(json.error.summary ?? json.error.message)
       ) {
         // we don't need to log anything here, it just turned out the version was already published so we gracefully exit the publish process
         return { result: "skipped" };


### PR DESCRIPTION
Fixes #2184. pnpm publish --json returns errors as `{code, message}` whereas npm uses `{summary, detail}`. isAlreadyPublishedError was only reading `summary`, causing a TypeError for pnpm publishes. Use `json.error.summary ?? json.error.message` to handle both formats.