### PR TITLE
Clarify ignore publish caveats

### DIFF
--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -95,7 +95,7 @@ changeset version --ignore PACKAGE_NAME
 This command is used to allow you to skip packages from being published. This allows you to run partial publishes of the repository. Using ignore has some safety rails:
 
 1. If the package is mentioned in a changeset that also includes a package that is not ignored, publishing will fail.
-2. If the package requires one of its dependencies to be updated as part of a publish.
+2. If the package requires one of its dependencies to be updated as part of a publish, publishing will also fail.
 
 These restrictions exist to ensure your repository or published code does not end up in a broken state. For additional information on the intricacies of publishing, check out our guide on [problems publishing in monorepos](./problems-publishing-in-monorepos.md).
 

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -76,7 +76,7 @@ This option allows you to specify some packages that will not be published, even
 There are two caveats to this.
 
 1. If the package is mentioned in a changeset that also includes a package that is not ignored, publishing will fail.
-2. If the package requires one of its dependencies to be updated as part of a publish.
+2. If the package requires one of its dependencies to be updated as part of a publish, publishing will also fail.
 
 These restrictions exist to ensure your repository or published code do not end up in a broken state. For a more detailed intricacies of publishing, check out our guide on [problems publishing in monorepos](./problems-publishing-in-monorepos.md).
 

--- a/site/guide/cli.md
+++ b/site/guide/cli.md
@@ -56,7 +56,10 @@ $ git commit -m "Version packages"
 
 ### Ignoring packages
 
-The `--ignore` flag allows you to skip packages from being published. This allows you to run partial publishes of the repository. This extends the [`ignore`](./config.md#ignore) option with the same documented caveats.
+The `--ignore` flag allows you to skip packages from being published. This allows you to run partial publishes of the repository. This extends the [`ignore`](./config.md#ignore) option with the same safety rails:
+
+1. If an ignored package is mentioned in a changeset that also includes a package that is not ignored, publishing will fail.
+2. If an ignored package requires one of its dependencies to be updated as part of a publish, publishing will also fail.
 
 ```bash
 $ changeset version --ignore pkg-a --ignore pkg-b


### PR DESCRIPTION
## Summary
- clarify that `--ignore` also fails when an ignored package needs dependency updates during publish
- mirror that explanation in the legacy docs and the current site CLI guide

Fixes #1534

## Testing
- `pnpm format`
- `pnpm build`
- `pnpm site:build`
- `git diff --check`

Note: `pnpm lint` currently fails on existing unrelated TypeScript lint errors in packages outside this docs-only change.