### PR TITLE
Support light-dark theme for site icon

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -1,4 +1,4 @@
-import { type DefaultTheme, defineConfig, MarkdownRenderer } from "vitepress";
+import { type DefaultTheme, defineConfig } from "vitepress";
 import { graphvizMarkdownPlugin } from "vitepress-plugin-graphviz";
 import {
   groupIconMdPlugin,
@@ -27,7 +27,22 @@ export default defineConfig({
   title: siteTitle,
   description: siteDescription,
   head: [
-    ["link", { rel: "icon", href: "logo-light.svg" }],
+    [
+      "link",
+      {
+        rel: "icon",
+        href: "logo-light.svg",
+        media: "(prefers-color-scheme: light)",
+      },
+    ],
+    [
+      "link",
+      {
+        rel: "icon",
+        href: "logo-dark.svg",
+        media: "(prefers-color-scheme: dark)",
+      },
+    ],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:site_name", content: siteTitle }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -1,4 +1,4 @@
-import { type DefaultTheme, defineConfig } from "vitepress";
+import { type DefaultTheme, defineConfig, MarkdownRenderer } from "vitepress";
 import { graphvizMarkdownPlugin } from "vitepress-plugin-graphviz";
 import {
   groupIconMdPlugin,


### PR DESCRIPTION
So it looks a bit better:

Left: Old. Right: New.
<img width="481" height="47" alt="image" src="https://github.com/user-attachments/assets/f68036b5-309b-4678-b7da-ebc376547e27" />
