### PR TITLE
Remove unnecessary ignores config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,6 @@
   "baseBranch": "main",
   "commit": false,
   "access": "public",
-  "ignore": ["@changesets/test-utils", "@changesets/color"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   }


### PR DESCRIPTION
We should've disabled `privatePackages` instead, but it's now disabled by default, so we can remove the ignores config.