### PR TITLE
Run CI for windows and macos for active node lts only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,13 @@ jobs:
     strategy:
       matrix:
         node_version: [22, 24, 26]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
+        include:
+          # Active LTS + other OS
+          - node_version: 24
+            os: macos-latest
+          - node_version: 24
+            os: windows-latest
       fail-fast: false
     steps:
       - name: Check out repo


### PR DESCRIPTION
I followed the [setup from Vite](https://github.com/vitejs/vite/blob/2ad9ec262a7bd8e30788df537eb217abe9af82ab/.github/workflows/ci.yml#L65-L74). This should reduce the likeliness for CI to fail when windows flake