### PR TITLE
Document environment approval for publish job

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -211,8 +211,8 @@ function getMainSidebar(): DefaultTheme.SidebarItem[] {
         },
         { text: "Snapshot Releases", link: "snapshot-releases" },
         { text: "Prereleases", link: "prereleases" },
-        { text: "Migrating from v2 to v3", link: "migration" },
         { text: "Beyond npm", link: "beyond-npm" },
+        { text: "Migrating from v2 to v3", link: "migration" },
       ],
     },
     {

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -117,6 +117,10 @@ Also, in contrary to npm's [workflow recommendation](https://docs.npmjs.com/trus
 
 <<< ./_snippets/automating-trusted-publishing.yaml [.github/workflows/publish.yml]
 
+::: tip Require approval before publishing
+You can also consider [creating an environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#creating-an-environment) with required reviewers to approve the publish job run. Set the environment name on the `publish` job [`environment`](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#creating-an-environment) property to require their approval before the publish job can continue. This is one way to ensure that only trusted maintainers can publish packages.
+:::
+
 ### Token-based Publishing
 
 ::: warning


### PR DESCRIPTION
Add a tip to setup `environments` for the approval process like we're doing.

Also, fixed the migration guide sidebar sorting.