### PR TITLE
fix(cli): detect already-published errors outside `error.summary`

### DIFF
--- a/.changeset/smart-poems-hammer.md
+++ b/.changeset/smart-poems-hammer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Detect already-published npm errors when the message isn't in `error.summary`. `handlePublishError` now also matches `error.detail` and the process output, so an `E403` whose JSON payload omits `summary` is skipped as already-published instead of failing the release.

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -25,11 +25,10 @@ export const npmPublishQueue = createPromiseQueue(
 export function isAlreadyPublishedError(
   ...messages: (string | undefined)[]
 ): boolean {
-  return messages
-    .filter((message) => message != null)
-    .some((message) =>
-      message.includes("cannot publish over the previously published"),
-    );
+  return messages.some(
+    (message) =>
+      message?.includes("cannot publish over the previously published") ?? false,
+  );
 }
 
 export const isPublishSuccessful = (

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -17,10 +17,19 @@ export const npmPublishQueue = createPromiseQueue(
 
 /*
  * We check `npm info` before publishing but it can return stale data at times
- * so we need to gracefully handle this situation
+ * so we need to gracefully handle this situation.
+ *
+ * Which field carries the message varies by package manager and version, so
+ * callers pass every candidate and we match across all of them.
  */
-export function isAlreadyPublishedError(message: string) {
-  return message.includes("cannot publish over the previously published");
+export function isAlreadyPublishedError(
+  ...messages: (string | undefined)[]
+): boolean {
+  return messages
+    .filter((message) => message != null)
+    .some((message) =>
+      message.includes("cannot publish over the previously published"),
+    );
 }
 
 export const isPublishSuccessful = (

--- a/packages/cli/src/lib/npm.test.ts
+++ b/packages/cli/src/lib/npm.test.ts
@@ -113,6 +113,16 @@ describe("publishing", () => {
     },
   );
 
+  it("should handle an already-published error the JSON payload doesn't describe", () => {
+    const result = npm.handlePublishError(
+      { name: "@test/package", version: "1.0.0" },
+      { error: { code: "E403" } },
+      "npm error code E403\nnpm error 403 Forbidden - PUT https://registry.npmjs.org/@test%2fpackage - You cannot publish over the previously published versions: 1.0.0.",
+    );
+
+    expect(result.result).toEqual("failed:already-published");
+  });
+
   const need2faCases = Object.entries(need2faErrorSnapshot.npm);
 
   it.each(need2faCases)(

--- a/packages/cli/src/lib/npm.ts
+++ b/packages/cli/src/lib/npm.ts
@@ -277,6 +277,15 @@ export function handlePublishError(
 ): PublishResult {
   // if we get back an unknown error
   if (!isNpmPublishError(json)) {
+    // the JSON payload doesn't always carry a `summary` (trusted publishing is
+    // one case), but the process output still says the version is already up
+    if (isAlreadyPublishedError(processOutput)) {
+      return {
+        ...resultBase,
+        result: "failed:already-published",
+      };
+    }
+
     return {
       ...resultBase,
       result: "failed",
@@ -285,7 +294,13 @@ export function handlePublishError(
   }
 
   // npm v11 doesn't return a `code` on already-published errors
-  if (isAlreadyPublishedError(json.error.summary)) {
+  if (
+    isAlreadyPublishedError(
+      json.error.summary,
+      json.error.detail,
+      processOutput,
+    )
+  ) {
     // we don't need to log anything here, it just turned out the version was already published so we gracefully exit the publish process
     return {
       ...resultBase,


### PR DESCRIPTION
Follow-up to #2099. The publish-tool refactor fixed the crash, but the npm path still only matches the already-published message in `error.summary`, so an `E403` that puts it elsewhere fails the release instead of being skipped.

- `isAlreadyPublishedError` takes any number of candidate strings and ignores nullish ones.
- `handlePublishError` also matches `error.detail` and the process output.
- A payload that fails `isNpmPublishError` (no `summary`) is now classified from the process output rather than falling straight to `failed`.
- Existing snapshots are untouched; one test covers the unrecognised-payload branch.

Context on why that branch matters in practice: #2195.