### PR TITLE
Skip release PR in PR status workflow example

### DIFF
--- a/site/guide/_snippets/automating-non-blocking.yaml
+++ b/site/guide/_snippets/automating-non-blocking.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   pr-status:
     # recommended: skip the release pull request, as it never has changesets
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-slim
     permissions:
       contents: read # to check out repo (actions/checkout)

--- a/site/guide/_snippets/automating-non-blocking.yaml
+++ b/site/guide/_snippets/automating-non-blocking.yaml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   pr-status:
+    # recommended: skip the release pull request, as it never has changesets
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}
     runs-on: ubuntu-slim
     permissions:
       contents: read # to check out repo (actions/checkout)

--- a/site/guide/_snippets/automating-non-blocking.yaml
+++ b/site/guide/_snippets/automating-non-blocking.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   pr-status:
-    # recommended: skip the release pull request, as it never has changesets
+    # recommended: skip the release pull request as it never has changesets
     if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-slim
     permissions:

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -46,8 +46,6 @@ jobs:
 
 <<< ./_snippets/automating-non-blocking.yaml [.github/workflows/comment-changesets-pr-status.yml]
 
-The `if` condition on the `pr-status` job skips the release pull request opened by the Changesets GitHub Action, which never has changesets.
-
 Both approaches comment on PRs of whether changesets are present and gives you link to add your own changeset as a maintainer to smooth over merging pull requests without waiting for the contributor to add a changeset.
 
 ### Blocking

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -38,7 +38,7 @@ You can also use the `pull_request` event if you prefer to lock permissions down
 ```yaml
 jobs:
   pr-status:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'changeset-release/')
     # ...
 ```
 

--- a/site/guide/automating.md
+++ b/site/guide/automating.md
@@ -46,6 +46,8 @@ jobs:
 
 <<< ./_snippets/automating-non-blocking.yaml [.github/workflows/comment-changesets-pr-status.yml]
 
+The `if` condition on the `pr-status` job skips the release pull request opened by the Changesets GitHub Action, which never has changesets.
+
 Both approaches comment on PRs of whether changesets are present and gives you link to add your own changeset as a maintainer to smooth over merging pull requests without waiting for the contributor to add a changeset.
 
 ### Blocking


### PR DESCRIPTION
The example comments on every pull request, including the release PR where `changeset version` has consumed all changesets, so the comment always reports that none is present.

This adds an `if` condition to the `pr-status` job skipping `changeset-release/*`
branches, matching what the Changesets GitHub Bot does internally.