### PR TITLE
Infer the default branch during changeset init

### DIFF
--- a/.changeset/quiet-cats-remember.md
+++ b/.changeset/quiet-cats-remember.md
@@ -1,0 +1,6 @@
+---
+"@changesets/cli": minor
+"@changesets/git": minor
+---
+
+Use the branch referenced by `origin/HEAD` as the default base branch when initializing Changesets, while continuing to fall back to `main` when it cannot be resolved.

--- a/packages/cli/src/commands/init/__tests__/command.test.ts
+++ b/packages/cli/src/commands/init/__tests__/command.test.ts
@@ -2,13 +2,16 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { defaultWrittenConfig } from "@changesets/config";
+import * as git from "@changesets/git";
 import { silenceLogsInBlock, testdir } from "@changesets/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as cli from "../../../utils/cli-utilities.ts";
 import { init as initializeCommand } from "../index.ts";
 
 vi.mock("../../../utils/cli-utilities.ts");
+vi.mock("@changesets/git");
 const mockedUtils = vi.mocked(cli);
+const mockedGit = vi.mocked(git);
 
 const getPaths = (cwd: string) => ({
   readmePath: path.join(cwd, ".changeset/README.md"),
@@ -18,6 +21,7 @@ const getPaths = (cwd: string) => ({
 beforeEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
+  mockedGit.getDefaultBranchName.mockResolvedValue(undefined);
 
   mockedUtils.askList.mockImplementation(async (message) => {
     if (message.includes("published")) {
@@ -223,6 +227,7 @@ describe("init", () => {
   });
 
   it("should be written with public access, commit enabled, and custom branch when chosen", async () => {
+    mockedGit.getDefaultBranchName.mockResolvedValue("trunk");
     mockedUtils.askConfirm.mockResolvedValue(true);
     mockedUtils.askList.mockImplementation(async (message) => {
       if (message.includes("published")) {
@@ -275,6 +280,28 @@ describe("init", () => {
     const config = JSON.parse(await fs.readFile(configPath, "utf8"));
 
     expect(config.baseBranch).toBe("main");
+  });
+
+  it("should use origin's default branch when the base branch is left empty", async () => {
+    mockedGit.getDefaultBranchName.mockResolvedValue("trunk");
+
+    const cwd = await testdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+      }),
+    });
+
+    await initializeCommand({ cwd });
+
+    const { configPath } = getPaths(cwd);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+
+    expect(config.baseBranch).toBe("trunk");
+    expect(mockedUtils.askQuestion).toHaveBeenCalledWith(
+      "Which base branch should be used?",
+      { placeholder: "trunk" },
+    );
   });
 
   it("should be written with consistently ordered properties", async () => {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import c from "@changesets/color";
 import { defaultWrittenConfig } from "@changesets/config";
+import { getDefaultBranchName } from "@changesets/git";
 import type { AccessType } from "@changesets/types";
 import { log } from "@clack/prompts";
 import { getPackages } from "@manypkg/get-packages";
@@ -17,7 +18,7 @@ export interface InitOptions {
   cwd?: string;
 }
 
-async function getInteractiveConfig() {
+async function getInteractiveConfig(cwd: string) {
   const config = { ...defaultWrittenConfig };
 
   const useGithub = await cli.askConfirm(
@@ -49,12 +50,13 @@ async function getInteractiveConfig() {
     ],
   );
 
+  const defaultBaseBranch = (await getDefaultBranchName(cwd)) ?? "main";
   const baseBranchInput = await cli.askQuestion(
     "Which base branch should be used?",
-    { placeholder: "main" },
+    { placeholder: defaultBaseBranch },
   );
 
-  config.baseBranch = baseBranchInput || "main";
+  config.baseBranch = baseBranchInput || defaultBaseBranch;
 
   const priorityOrder = [
     "$schema",
@@ -110,7 +112,7 @@ Changeset commands can be run with no problems.
     await fs.mkdir(changesetBase, { recursive: true });
   }
 
-  const newConfigStr = await getInteractiveConfig();
+  const newConfigStr = await getInteractiveConfig(packages.rootDir);
 
   await fs.writeFile(path.resolve(changesetBase, "config.json"), newConfigStr);
 

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { gitdir, outputFile, shallowClone } from "@changesets/test-utils";
 import { writeChangeset } from "@changesets/write";
 import { exec } from "tinyexec";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   add,
   commit,
@@ -13,6 +13,7 @@ import {
   getChangedPackagesSinceRef,
   getCommitsThatAddFiles,
   getCurrentCommitId,
+  getDefaultBranchName,
   getDivergedCommit,
   tag,
   tagExists,
@@ -26,6 +27,82 @@ async function getCommitCount(cwd: string) {
 }
 
 describe("git", { tags: ["slow"] }, () => {
+  describe("getDefaultBranchName", () => {
+    it("returns the branch referenced by origin/HEAD", async () => {
+      const cwd = await gitdir({
+        "a.js": 'export default "a"',
+      });
+
+      await exec("git", ["update-ref", "refs/remotes/origin/trunk", "HEAD"], {
+        nodeOptions: { cwd },
+      });
+      await exec(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/trunk",
+        ],
+        { nodeOptions: { cwd } },
+      );
+
+      expect(await getDefaultBranchName(cwd)).toBe("trunk");
+    });
+
+    it("returns undefined when origin/HEAD cannot be resolved", async () => {
+      const cwd = await gitdir({
+        "a.js": 'export default "a"',
+      });
+
+      expect(await getDefaultBranchName(cwd)).toBeUndefined();
+    });
+
+    it("returns undefined when origin/HEAD references a non-origin branch", async () => {
+      const cwd = await gitdir({
+        "a.js": 'export default "a"',
+      });
+
+      await exec(
+        "git",
+        ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/main"],
+        { nodeOptions: { cwd } },
+      );
+
+      expect(await getDefaultBranchName(cwd)).toBeUndefined();
+    });
+
+    it("returns undefined when origin/HEAD references a missing branch", async () => {
+      const cwd = await gitdir({
+        "a.js": 'export default "a"',
+      });
+
+      await exec(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/missing",
+        ],
+        { nodeOptions: { cwd } },
+      );
+
+      expect(await getDefaultBranchName(cwd)).toBeUndefined();
+    });
+
+    it("returns undefined when git cannot be executed", async () => {
+      const cwd = await gitdir({
+        "a.js": 'export default "a"',
+      });
+
+      vi.stubEnv("PATH", "");
+      try {
+        expect(await getDefaultBranchName(cwd)).toBeUndefined();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
   describe("getDivergedCommit", () => {
     it("should return same commit when branches have not diverged", async () => {
       const cwd = await gitdir({

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -330,6 +330,42 @@ export async function getCurrentCommitId({
     .trim();
 }
 
+export async function getDefaultBranchName(
+  cwd: string,
+): Promise<string | undefined> {
+  try {
+    const symbolicRefCmd = await exec(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD"],
+      { nodeOptions: { cwd } },
+    );
+
+    if (symbolicRefCmd.exitCode !== 0) {
+      return undefined;
+    }
+
+    const remoteBranchRef = symbolicRefCmd.stdout.toString().trim();
+    const originPrefix = "refs/remotes/origin/";
+    if (!remoteBranchRef.startsWith(originPrefix)) {
+      return undefined;
+    }
+
+    const verifyRefCmd = await exec(
+      "git",
+      ["show-ref", "--verify", "--quiet", remoteBranchRef],
+      { nodeOptions: { cwd } },
+    );
+    if (verifyRefCmd.exitCode !== 0) {
+      return undefined;
+    }
+
+    const branchName = remoteBranchRef.slice(originPrefix.length);
+    return branchName || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function remoteTagExists(tagStr: string) {
   const gitCmd = await exec("git", [
     "ls-remote",


### PR DESCRIPTION
Closes #807.

When `changeset init` asks for a base branch, it now reads the symbolic `origin/HEAD` and verifies that its target ref exists. It continues using `main` if Git is unavailable or the ref cannot be resolved. A branch entered at the prompt still takes precedence.

Focused tests cover non-`main`, missing, dangling, non-origin, unavailable-Git, and explicit-input cases. The focused 49 tests, build, typecheck, lint, and format checks pass.

The full suite reports 915 passing tests and one unchanged `packages/write` formatter-fixture failure: `pnpm exec oxfmt` exits with status 1 inside its isolated temporary workspace.
