### PR TITLE
fix: remove two spaces

### DIFF
--- a/.changeset/cuddly-mugs-end.md
+++ b/.changeset/cuddly-mugs-end.md
@@ -1,0 +1,5 @@
+---
+"@changesets/write": patch
+---
+
+Remove two spaces from last line of generated changeset file.

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -54,7 +54,7 @@ ${releases.map((release) => `"${release.name}": ${release.type}`).join("\n")}
 ---
 
 ${summary}
-  `;
+`;
 
   await fs.mkdir(path.dirname(newChangesetPath), { recursive: true });
   await fs.writeFile(newChangesetPath, changesetContents);


### PR DESCRIPTION
#### Description

This PR removes two hard-coded spaces, which show up in the last line of all generated changeset files.
The files are technically correct by [POSIX definitions](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206) because the second-to-last line includes the trailing newline and the spaces will just be ignored, but most linters and git diffs are not happy with them.