### PR TITLE
docs: improve migration section about action

### DIFF
--- a/site/guide/migration.md
+++ b/site/guide/migration.md
@@ -245,12 +245,39 @@ Update to `changesets/action@v2` in your GitHub Actions workflows to support Cha
 <!-- prettier-ignore -->
 ```yaml [.github/workflows/publish.yml]
 # ...
-        uses: changesets/action/publish@v1 # [!code --]
-        uses: changesets/action/publish@v2 # [!code ++]
+        uses: changesets/action@v1 # [!code --]
+        uses: changesets/action@v2 # [!code ++]
 # ...
 ```
 
-The v2 action contains some breaking changes that you should review in the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0).
+If you are using [npm trusted publishing (provenance)](https://docs.npmjs.com/trusted-publishers), it is recommended to use the new individual sub-actions instead of the combined action to tighten permissions. See the [Trusted Publishing guide](/guide/automating#trusted-publishing) for more details.
+
+### Update parameters
+
+If you passed any parameters or a GitHub token, make sure to update them accordingly:
+
+<!-- prettier-ignore -->
+```yaml [.github/workflows/publish.yml]
+# ...
+        uses: changesets/action@v1 # [!code --]
+        with: # [!code --]
+          version: pnpm run version # [!code --]
+          commit: "ci: release" # [!code --]
+          title: "ci: release" # [!code --]
+        env: # [!code --]
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # [!code --]
+        uses: changesets/action@v2 # [!code ++]
+        with: # [!code ++]
+          version-script: pnpm run version # [!code ++]
+          commit-message: "ci: release" # [!code ++]
+          pr-title: "ci: release" # [!code ++]
+          github-token: ${{ secrets.GITHUB_TOKEN }} # [!code ++]
+# ...
+```
+
+Note that `commit-mesage` had a typo, which was fixed in `v2.1.1`. Moreover, if you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
+
+For the full list of breaking changes and available parameters, check out the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0) in the [action repository](https://github.com/changesets/action).
 
 ### Review your workflow setup
 

--- a/site/guide/migration.md
+++ b/site/guide/migration.md
@@ -250,7 +250,11 @@ Update to `changesets/action@v2` in your GitHub Actions workflows to support Cha
 # ...
 ```
 
-If you are using [npm trusted publishing (provenance)](https://docs.npmjs.com/trusted-publishers), it is recommended to use the new individual sub-actions instead of the combined action to tighten permissions. See the [Trusted Publishing guide](/guide/automating#trusted-publishing) for more details.
+### Review your workflow setup
+
+While the existing action should work as before, the v2 action exposes more sub-actions that allow you to better customize, compose, and secure your GitHub Actions workflows.
+
+For instance, if you are using [npm trusted publishing (provenance)](https://docs.npmjs.com/trusted-publishers), it is recommended to migrate to these sub-actions to tighten publish permissions. Check the new [Automating Changesets guide](./automating.md) for the new setup recommendations.
 
 ### Update parameters
 
@@ -278,9 +282,3 @@ If you passed any parameters or a GitHub token, make sure to update them accordi
 Note that `commit-mesage` had a typo, which was fixed in `v2.1.1`. Moreover, if you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
 
 For the full list of breaking changes and available parameters, check out the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0) in the [action repository](https://github.com/changesets/action).
-
-### Review your workflow setup
-
-While the existing action should work as before, the v2 action exposes more sub-actions that allow you to better customize, compose, and secure your GitHub Actions workflows.
-
-Check the new [Automating Changesets](./automating.md) guide and consider adopting the new setup recommendations.

--- a/site/guide/migration.md
+++ b/site/guide/migration.md
@@ -282,3 +282,7 @@ If you passed any parameters or a GitHub token, make sure to update them accordi
 Note that `commit-mesage` had a typo, which was fixed in `v2.1.1`. Moreover, if you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
 
 For the full list of breaking changes and available parameters, check out the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0) in the [action repository](https://github.com/changesets/action).
+
+## You're all set!
+
+That covers all the major updates. Good luck with your migration to v3, and happy releasing!


### PR DESCRIPTION
This PR adds more documentation to the migration guide regarding the changes of the `changesets/action`. I chose to keep it simple and not mention any sub-actions in the code blocks, but just link to the docs for [Trusted Publishing](https://changesets.dev/guide/automating#trusted-publishing) as then it is recommended to split up the action.

Moreover, I added a section for updating parameters with "common gotcha" notes below and then linked to the release and the repo for full available parameters and breaking changes.

Preview link: https://deploy-preview-2258--changesets.netlify.app/guide/migration#github-actions-changes

Any suggestions are welcome!