### PR TITLE
feat(parse): add non-throwing safeParseChangesetFile

### DIFF
--- a/.changeset/safe-parse-changeset-file.md
+++ b/.changeset/safe-parse-changeset-file.md
@@ -1,0 +1,5 @@
+---
+"@changesets/parse": minor
+---
+
+Add `safeParseChangesetFile`, a non-throwing twin of `parseChangesetFile` that returns `{ ok: true, changeset }` for valid contents and `{ ok: false, error }` (with the exact message the throwing form produces) for invalid ones.

--- a/packages/parse/src/index.test.ts
+++ b/packages/parse/src/index.test.ts
@@ -1,6 +1,9 @@
 import { outdent } from "outdent";
 import { describe, expect, it } from "vitest";
-import { parseChangesetFile as parse } from "./index.ts";
+import {
+  parseChangesetFile as parse,
+  safeParseChangesetFile as safeParse,
+} from "./index.ts";
 
 describe("parsing a changeset", () => {
   it("should parse a changeset", () => {
@@ -360,5 +363,136 @@ describe("parsing a changeset", () => {
 
       Nice simple summary]
     `);
+  });
+});
+
+describe("safeParseChangesetFile", () => {
+  const validChangeset = outdent`---
+  "cool-package": minor
+  ---
+
+  Nice simple summary
+  `;
+
+  const invalidPackageName = outdent`---
+  "": minor
+  ---
+
+  Nice simple summary
+  `;
+
+  const invalidReleaseType = outdent`---
+  "cool-package": invalid-type
+  ---
+
+  Nice simple summary
+  `;
+
+  const noFrontmatter = "Just some content without frontmatter";
+
+  it("returns { ok: true, changeset } for a normal changeset", () => {
+    const result = safeParse(validChangeset);
+    expect(result).toEqual({
+      ok: true,
+      changeset: {
+        releases: [{ name: "cool-package", type: "minor" }],
+        summary: "Nice simple summary",
+      },
+    });
+  });
+
+  it("returns { ok: false, error } for an invalid package name", () => {
+    const result = safeParse(invalidPackageName);
+    expect(result.ok).toBe(false);
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining(
+        "could not parse changeset - invalid package name in frontmatter.",
+      ),
+    });
+  });
+
+  it("returns { ok: false, error } for an invalid release type", () => {
+    const result = safeParse(invalidReleaseType);
+    expect(result.ok).toBe(false);
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining(
+        'could not parse changeset - invalid version type "invalid-type" for package "cool-package".',
+      ),
+    });
+  });
+
+  it("returns { ok: false, error } for contents with no parsable frontmatter", () => {
+    const result = safeParse(noFrontmatter);
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining(
+        "could not parse changeset - missing or invalid frontmatter.",
+      ),
+    });
+  });
+
+  it("never throws for any input string", () => {
+    const inputs = [
+      "",
+      "   ",
+      "\n\n",
+      validChangeset,
+      invalidPackageName,
+      invalidReleaseType,
+      noFrontmatter,
+      "---\n: minor\n---",
+      "---\n---",
+      "random ---\n garbage : : :",
+    ];
+    for (const input of inputs) {
+      expect(() => safeParse(input)).not.toThrow();
+    }
+  });
+
+  it("error message equals the message thrown by parseChangesetFile for the same input (R-1.2)", () => {
+    const failingInputs = [
+      "",
+      invalidPackageName,
+      invalidReleaseType,
+      noFrontmatter,
+      "---\n: minor\n---",
+    ];
+    for (const input of failingInputs) {
+      let thrownMessage: string | undefined;
+      try {
+        parse(input);
+      } catch (e) {
+        thrownMessage = e instanceof Error ? e.message : String(e);
+      }
+      expect(thrownMessage).toBeDefined();
+      const result = safeParse(input);
+      expect(result).toEqual({ ok: false, error: thrownMessage });
+    }
+  });
+
+  it("deep-equals parseChangesetFile's output for valid inputs", () => {
+    const validInputs = [
+      validChangeset,
+      outdent`---
+      "cool-package": minor
+      "best-package": patch
+      ---
+
+      Multi package summary
+      `,
+      outdent`---
+      "@cool/package": major
+      ---
+
+      Scoped
+      `,
+      "---\n---",
+    ];
+    for (const input of validInputs) {
+      const result = safeParse(input);
+      expect(result).toEqual({ ok: true, changeset: parse(input) });
+    }
   });
 });

--- a/packages/parse/src/index.ts
+++ b/packages/parse/src/index.ts
@@ -108,6 +108,31 @@ export function parseChangesetFile(contents: string): {
   return { releases, summary };
 }
 
+export type Changeset = {
+  summary: string;
+  releases: Release[];
+};
+
+export type SafeParseSuccess = {
+  ok: true;
+  changeset: Changeset;
+};
+
+export type SafeParseFailure = {
+  ok: false;
+  error: string;
+};
+
+export type SafeParseResult = SafeParseSuccess | SafeParseFailure;
+
+export function safeParseChangesetFile(contents: string): SafeParseResult {
+  try {
+    return { ok: true, changeset: parseChangesetFile(contents) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 /** @deprecated Use named export `parseChangesetFile` instead */
 const parseChangesetFileDefault = parseChangesetFile;
 export default parseChangesetFileDefault;


### PR DESCRIPTION
Adds `safeParseChangesetFile` to `@changesets/parse`: a non-throwing twin of `parseChangesetFile` for callers that want to report problems rather than crash (editors, linters, bulk scanners) — the same result-shape convention this repo already consumes from valibot in `@changesets/config`, offered for the changeset format itself.

- For any contents `parseChangesetFile` accepts: `{ ok: true, changeset }`, deep-equal to the throwing form's return.
- For any contents that make it throw: `{ ok: false, error }`, where `error` is exactly the message the throwing form produces for that input — covered by an equality test against the thrown message.
- Never throws; the result is a discriminated union on `ok` so callers narrow without casts.
- One shared code path — `parseChangesetFile` (and the deprecated default export) keep byte-identical behavior; nothing forked that could drift.

Tests follow the existing `index.test.ts` style (vitest + outdent); a minor changeset for `@changesets/parse` is included. Build, tsc, eslint, and the vitest suite pass.

Full disclosure: this change was implemented end-to-end by [Detent](https://github.com/AmineYagoub/detent), an autonomous-engineering tool I'm building — every step gated by this repo's own toolchain and independently reviewed before commit. Happy to adjust API shape or naming to fit the project's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
