### PR TITLE
Set cacheKeyFn for github dataloader

### DIFF
--- a/.changeset/busy-carrots-carry.md
+++ b/.changeset/busy-carrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-github-info": patch
+---
+
+Use consistent cache key when fetching the same commit or PR data

--- a/packages/get-github-info/src/dataloader.ts
+++ b/packages/get-github-info/src/dataloader.ts
@@ -58,8 +58,15 @@ interface PullOutput {
   } | null;
 }
 
-// Set maxBatchSize to 50 to prevent potentially sending a massive query and hitting rate limits
-const GHDataLoader = new DataLoader(batchLoad, { maxBatchSize: 50 });
+const GHDataLoader = new DataLoader(batchLoad, {
+  // Set maxBatchSize to 50 to prevent potentially sending a massive query and hitting rate limits
+  maxBatchSize: 50,
+  cacheKeyFn(request) {
+    return request.kind === "commit"
+      ? `commit:${request.repo}:${request.commit}`
+      : `pull:${request.repo}:${request.pull}`;
+  },
+});
 
 export async function loadCommitData(options: Omit<CommitInput, "kind">) {
   const result = await GHDataLoader.load({ ...options, kind: "commit" });

--- a/packages/get-github-info/src/dataloader.ts
+++ b/packages/get-github-info/src/dataloader.ts
@@ -78,6 +78,11 @@ export async function loadPullData(options: Omit<PullInput, "kind">) {
   return result as PullOutput | null;
 }
 
+// Used by tests only
+export function clearCache() {
+  GHDataLoader.clearAll();
+}
+
 interface GraphqlFetchData {
   errors?: unknown;
   data?: Record<string, unknown>;

--- a/packages/get-github-info/src/get-commit-info.test.ts
+++ b/packages/get-github-info/src/get-commit-info.test.ts
@@ -1,5 +1,6 @@
 import nock from "nock";
 import { expect, test, beforeEach, afterEach, vi } from "vitest";
+import { clearCache } from "./dataloader.ts";
 import { getCommitInfo } from "./get-commit-info.ts";
 
 const apiPath = `/graphql`;
@@ -10,6 +11,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearCache();
   vi.unstubAllEnvs();
   nock.cleanAll();
   nock.enableNetConnect();

--- a/packages/get-github-info/src/get-pull-request-info.test.ts
+++ b/packages/get-github-info/src/get-pull-request-info.test.ts
@@ -1,5 +1,6 @@
 import nock from "nock";
 import { expect, test, beforeEach, afterEach, vi } from "vitest";
+import { clearCache } from "./dataloader.ts";
 import { getPullRequestInfo } from "./get-pull-request-info.ts";
 
 const apiPath = `/graphql`;
@@ -10,6 +11,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearCache();
   vi.unstubAllEnvs();
   nock.cleanAll();
   nock.enableNetConnect();


### PR DESCRIPTION
ref: https://github.com/changesets/changesets/pull/1925#issuecomment-5068570217

closes #1925

original pr description:

> ### Fixed DataLoader cache deduplication (`@changesets/get-github-info`)
> * Adds a `cacheKeyFn` to the DataLoader so its result cache actually works
> * Previously, cache keys were compared by object reference (JavaScript `Map` semantics), so identical requests for the same commit/PR were never deduplicated
> * This was causing a 6-7x inflation in the number of GitHub API lookups (e.g. 654 changesets → 4261 requests)