### PR TITLE
Add script to run unit and e2e tests separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "lint": "eslint",
     "test": "vitest",
     "test:fast": "vitest --tags-filter=!slow",
+    "test:unit": "vitest --tags-filter=!e2e",
+    "test:e2e": "vitest --tags-filter=e2e",
     "types:check": "tsc",
     "check-all": "pnpm build && pnpm test run && pnpm types:check && pnpm lint && pnpm format",
     "site:dev": "pnpm --filter=./site dev",

--- a/packages/cli/src/commands/pack/__tests__/e2e.test.ts
+++ b/packages/cli/src/commands/pack/__tests__/e2e.test.ts
@@ -31,7 +31,7 @@ function sanitizePackLog(message: unknown) {
 }
 
 // to avoid depending on pnpr here we only test the pack command with precomputed publish plans
-describe("Pack command e2e", { tags: ["slow"] }, () => {
+describe("Pack command e2e", { tags: ["slow", "e2e"] }, () => {
   describe.each(pmCases)("$name", (pm) => {
     it("packs from a publish plan", async ({ signal }) => {
       await using stack = new AbortableAsyncDisposableStack(signal);

--- a/packages/cli/src/commands/publish/__tests__/e2e.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/e2e.test.ts
@@ -948,7 +948,7 @@ function createPmContext(
   };
 }
 
-describe("Publish command e2e", { tags: ["slow"] }, () => {
+describe("Publish command e2e", { tags: ["slow", "e2e"] }, () => {
   describe.each(pmCases)("$name", (pm) => {
     it("publishes a new version of a package", async ({ signal }) => {
       await using stack = new AbortableAsyncDisposableStack(signal);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
           "Slow tests, like ones that require lots of git operations",
         timeout: process.platform === "win32" ? 30_000 : 10_000,
       },
+      {
+        name: "e2e",
+        description: "End-to-end tests that runs very slow",
+        timeout: process.platform === "win32" ? 30_000 : 10_000,
+      },
     ],
   },
 });


### PR DESCRIPTION
Sometimes I want to run the slow tests, but not the e2e tests as they run very very slow for me. So in this PR, I added some additional commands to run the unit and e2e tests separately, so I can call `pnpm test:unit` to also run the slows tests without e2e.