### PR TITLE
docs: mention `github-token` in migration

### DIFF
--- a/site/guide/migration.md
+++ b/site/guide/migration.md
@@ -278,8 +278,7 @@ If you passed any inputs, make sure to update them accordingly:
 # ...
 ```
 
-In case you had set a `GITHUB_TOKEN` environment variable, pass it via the `github-token` parameter now.
-If you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
+In case you had set a custom `GITHUB_TOKEN` environment variable, pass it via the `github-token` input now. If you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
 
 For the full list of breaking changes, check out the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0) in the [action repository](https://github.com/changesets/action).
 

--- a/site/guide/migration.md
+++ b/site/guide/migration.md
@@ -278,6 +278,7 @@ If you passed any inputs, make sure to update them accordingly:
 # ...
 ```
 
+In case you had set a `GITHUB_TOKEN` environment variable, pass it via the `github-token` parameter now.
 If you rely on the local Git state for subsequent steps, make sure to set `push-with-git-cli: true` as well.
 
 For the full list of breaking changes, check out the [v2.0.0 release notes](https://github.com/changesets/action/releases/tag/v2.0.0) in the [action repository](https://github.com/changesets/action).


### PR DESCRIPTION
[As discussed in Discord](https://discord.com/channels/1499011163705573470/1499011165144092837/1541469066542325860), this PR informs people that the `GITHUB_TOKEN` environment variable should be passed via the `github-token` now.

<img width="1546" height="516" alt="image" src="https://github.com/user-attachments/assets/c288ac6d-2341-428b-85a8-a424f46c4330" />
