### PR TITLE
fix: report versionless workspace name collisions

### DIFF
--- a/.changeset/tidy-pandas-report.md
+++ b/.changeset/tidy-pandas-report.md
@@ -1,0 +1,6 @@
+---
+"@changesets/get-dependents-graph": patch
+"@changesets/cli": patch
+---
+
+Report an actionable dependency graph error when a dependency name collides with a versionless workspace package instead of crashing while formatting its missing version.

--- a/packages/get-dependents-graph/src/get-dependency-graph.test.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.test.ts
@@ -178,6 +178,43 @@ describe("getting the dependency graph", function () {
   );
 
   it(
+    "should report dependencies that collide with a versionless workspace package",
+    temporarilySilenceLogs(() => {
+      const rootPackage: Package = {
+        dir: path.resolve(),
+        packageJson: { name: "root", version: "1.0.0" },
+      };
+      const { valid } = getDependencyGraph(
+        {
+          tool: { type: "pnpm" },
+          rootDir: rootPackage.dir,
+          rootPackage,
+          packages: [
+            {
+              dir: "packages/stripe",
+              packageJson: {
+                name: "stripe",
+                private: true,
+                dependencies: {
+                  stripe: "^18.0.0",
+                },
+              } as unknown as Package["packageJson"],
+            },
+          ],
+        },
+        rootPackage,
+      );
+
+      expect(valid).toBe(false);
+      expect(
+        stripVTControlCharacters((console.error as any).mock.calls[0][0]),
+      ).toBe(
+        "Package stripe depends on stripe@^18.0.0, but stripe is also the name of a workspace package without a version. Add a version to stripe or rename the workspace package.",
+      );
+    }),
+  );
+
+  it(
     "should skip dependencies not specified using workspace protocol when bumpVersionsWithWorkspaceProtocolOnly is true",
     temporarilySilenceLogs(() => {
       const rootPackage: Package = {

--- a/packages/get-dependents-graph/src/get-dependency-graph.ts
+++ b/packages/get-dependents-graph/src/get-dependency-graph.ts
@@ -118,16 +118,25 @@ export function getDependencyGraph(
           dependencies.push(depName);
           continue;
         }
-
-        if (!getValidRange(depRange)) {
-          valid = false;
-          // TODO: replace with returning errors/warnings
-          console.error(
-            `Package ${c.blue(name)} must depend on the current version of ${c.blue(depName)}: ${c.green(expected)} vs ${c.red(rawDepRange)}`,
-          );
-          continue;
-        }
       } else if (bumpVersionsWithWorkspaceProtocolOnly) {
+        continue;
+      }
+
+      if (typeof expected !== "string") {
+        valid = false;
+        // TODO: replace with returning errors/warnings
+        console.error(
+          `Package ${c.blue(name)} depends on ${c.blue(depName)}@${c.red(rawDepRange)}, but ${c.blue(depName)} is also the name of a workspace package without a version. Add a version to ${c.blue(depName)} or rename the workspace package.`,
+        );
+        continue;
+      }
+
+      if (usesWorkspaceRange && !getValidRange(depRange)) {
+        valid = false;
+        // TODO: replace with returning errors/warnings
+        console.error(
+          `Package ${c.blue(name)} must depend on the current version of ${c.blue(depName)}: ${c.green(expected)} vs ${c.red(rawDepRange)}`,
+        );
         continue;
       }
 


### PR DESCRIPTION
## Motivation

Changesets v3 crashes while validating the dependency graph when a versionless workspace package shares a name with a registry dependency. This masks the actual workspace-name collision.

Fixes wevm/mppx#833.

## Summary

- Detect versionless workspace matches before semver validation and color formatting
- Report the dependent package, colliding workspace name, and requested range
- Add regression coverage and patch changesets for the graph package and CLI

## Key design considerations

- Preserve valid workspace aliases and workspace path dependencies
- Keep bumpVersionsWithWorkspaceProtocolOnly behavior unchanged for registry ranges