### PR TITLE
fix(git): wrong changeset file commit

### DIFF
--- a/.changeset/honest-coats-kick.md
+++ b/.changeset/honest-coats-kick.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": patch
+---
+
+Fix commit mismatch on similar changeset files.

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -430,7 +430,10 @@ describe("git", { tags: ["slow"] }, () => {
         await outputFile(path.join(cwd, "a.js"), 'export default "Andarist"');
         const originalCommit = await addFileAndCommit("a.js", cwd);
 
-        await outputFile(path.join(cwd, "a.js"), 'export default "Andarist tweaked"');
+        await outputFile(
+          path.join(cwd, "a.js"),
+          'export default "Andarist tweaked"',
+        );
         await add("a.js", cwd);
         await commit("tweak a.js", cwd);
 
@@ -438,7 +441,9 @@ describe("git", { tags: ["slow"] }, () => {
         await renameFileAndCommit("a.js", "pre/a.js", cwd);
 
         const clone = await shallowClone(cwd, 1);
-        const commits = await getCommitsThatAddFiles(["pre/a.js"], { cwd: clone });
+        const commits = await getCommitsThatAddFiles(["pre/a.js"], {
+          cwd: clone,
+        });
         expect(commits).toEqual([originalCommit]);
       });
 
@@ -450,12 +455,17 @@ describe("git", { tags: ["slow"] }, () => {
         await fs.mkdir(path.join(cwd, "pre"));
         await renameFileAndCommit("a.js", "pre/a.js", cwd);
 
-        await outputFile(path.join(cwd, "pre/a.js"), 'export default "bluwy tweaked"');
+        await outputFile(
+          path.join(cwd, "pre/a.js"),
+          'export default "bluwy tweaked"',
+        );
         await add("pre/a.js", cwd);
         await commit("tweak pre/a.js", cwd);
 
         const clone = await shallowClone(cwd, 1);
-        const commits = await getCommitsThatAddFiles(["pre/a.js"], { cwd: clone });
+        const commits = await getCommitsThatAddFiles(["pre/a.js"], {
+          cwd: clone,
+        });
         expect(commits).toEqual([originalCommit]);
       });
 
@@ -474,11 +484,13 @@ describe("git", { tags: ["slow"] }, () => {
 
       it("reads the SHA of a file-add even if it is highly similar to a previously added file", async () => {
         const cwd = await gitdir({});
-        const contentA = "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: foo\n";
+        const contentA =
+          "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: foo\n";
         await outputFile(path.join(cwd, "a.md"), contentA);
         await addFileAndCommit("a.md", cwd);
 
-        const contentB = "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: bar\n";
+        const contentB =
+          "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: bar\n";
         await outputFile(path.join(cwd, "b.md"), contentB);
         const secondCommit = await addFileAndCommit("b.md", cwd);
 

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -424,6 +424,68 @@ describe("git", { tags: ["slow"] }, () => {
         const commits = await getCommitsThatAddFiles(["b.js"], { cwd: clone });
         expect(commits).toEqual([originalCommit]);
       });
+
+      it("reads the SHA of a file-add when tweaked then moved to pre", async () => {
+        const cwd = await gitdir({});
+        await outputFile(path.join(cwd, "a.js"), 'export default "Andarist"');
+        const originalCommit = await addFileAndCommit("a.js", cwd);
+
+        await outputFile(path.join(cwd, "a.js"), 'export default "Andarist tweaked"');
+        await add("a.js", cwd);
+        await commit("tweak a.js", cwd);
+
+        await fs.mkdir(path.join(cwd, "pre"));
+        await renameFileAndCommit("a.js", "pre/a.js", cwd);
+
+        const clone = await shallowClone(cwd, 1);
+        const commits = await getCommitsThatAddFiles(["pre/a.js"], { cwd: clone });
+        expect(commits).toEqual([originalCommit]);
+      });
+
+      it("reads the SHA of a file-add when moved to pre then tweaked", async () => {
+        const cwd = await gitdir({});
+        await outputFile(path.join(cwd, "a.js"), 'export default "bluwy"');
+        const originalCommit = await addFileAndCommit("a.js", cwd);
+
+        await fs.mkdir(path.join(cwd, "pre"));
+        await renameFileAndCommit("a.js", "pre/a.js", cwd);
+
+        await outputFile(path.join(cwd, "pre/a.js"), 'export default "bluwy tweaked"');
+        await add("pre/a.js", cwd);
+        await commit("tweak pre/a.js", cwd);
+
+        const clone = await shallowClone(cwd, 1);
+        const commits = await getCommitsThatAddFiles(["pre/a.js"], { cwd: clone });
+        expect(commits).toEqual([originalCommit]);
+      });
+
+      it("reads the SHA of a file-add even if it is an exact copy of a previously added file", async () => {
+        const cwd = await gitdir({});
+        await outputFile(path.join(cwd, "a.js"), 'export default "foo"');
+        await addFileAndCommit("a.js", cwd);
+
+        await outputFile(path.join(cwd, "b.js"), 'export default "foo"');
+        const secondCommit = await addFileAndCommit("b.js", cwd);
+
+        const clone = await shallowClone(cwd, 2);
+        const commits = await getCommitsThatAddFiles(["b.js"], { cwd: clone });
+        expect(commits).toEqual([secondCommit]);
+      });
+
+      it("reads the SHA of a file-add even if it is highly similar to a previously added file", async () => {
+        const cwd = await gitdir({});
+        const contentA = "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: foo\n";
+        await outputFile(path.join(cwd, "a.md"), contentA);
+        await addFileAndCommit("a.md", cwd);
+
+        const contentB = "---\n'pkg': patch\n---\n\nThis is a rather long and completely identical summary sentence to ensure Git detects similarity. Adds a brand new function export: bar\n";
+        await outputFile(path.join(cwd, "b.md"), contentB);
+        const secondCommit = await addFileAndCommit("b.md", cwd);
+
+        const clone = await shallowClone(cwd, 2);
+        const commits = await getCommitsThatAddFiles(["b.md"], { cwd: clone });
+        expect(commits).toEqual([secondCommit]);
+      });
     });
   });
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -84,7 +84,7 @@ export async function getCommitsThatAddFiles(
             "git",
             [
               "log",
-              "--diff-filter=A",
+              "--diff-filter=AC",
               "--follow",
               "--max-count=1",
               short ? "--pretty=format:%h:%p" : "--pretty=format:%H:%p",

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -93,7 +93,6 @@ export async function getCommitsThatAddFiles(
               "--follow",
               "--max-count=1",
               short ? "--pretty=format:%h:%p" : "--pretty=format:%H:%p",
-              "--",
               gitPath,
             ],
             { nodeOptions: { cwd } },

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -88,6 +88,7 @@ export async function getCommitsThatAddFiles(
               "--follow",
               "--max-count=1",
               short ? "--pretty=format:%h:%p" : "--pretty=format:%H:%p",
+              "--",
               gitPath,
             ],
             { nodeOptions: { cwd } },

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -84,7 +84,12 @@ export async function getCommitsThatAddFiles(
             "git",
             [
               "log",
+              // We want to stop following commits when the file is flagged with either
+              // A = added (new file) or C = copied (new file with similar content).
+              // https://git-scm.com/docs/git-log#Documentation/git-log.txt---diff-filterACDMRTUXB
               "--diff-filter=AC",
+              // We want to allow file renames and small word tweaks.
+              // https://git-scm.com/docs/git-log#Documentation/git-log.txt---follow
               "--follow",
               "--max-count=1",
               short ? "--pretty=format:%h:%p" : "--pretty=format:%H:%p",


### PR DESCRIPTION
#### Description

This PR fixes a regression added [here](https://github.com/changesets/changesets/pull/2190#discussion_r3654687068), where similar changeset files can lead to wrong commit SHA lookups if the file content is very similar.

The fix adds the `C` (copy) git type to the [`--diff-filter` option](https://git-scm.com/docs/git-log#Documentation/git-log.txt---diff-filterACDMRTUXB), which means that two changeset files will not be mixed up by git just because they have similar content.

- Fixes #2272