### PR TITLE
Report a package in multiple fixed or linked groups only once

### DIFF
--- a/.changeset/soft-books-invent.md
+++ b/.changeset/soft-books-invent.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Report a package that is defined in multiple `fixed` or `linked` groups only once, instead of once for every group that follows the duplicate.

--- a/packages/config/src/parse.test.ts
+++ b/packages/config/src/parse.test.ts
@@ -624,6 +624,44 @@ describe("validateConfig", () => {
 
   // any tests that don't fit nicely into the cases above
   describe("rules", () => {
+    describe("noDuplicateFixedPackages", () => {
+      it("should report a duplicated package once when more groups follow it", async () => {
+        const config = { fixed: [["pkg-a"], ["pkg-a"], ["pkg-b"]] };
+
+        const cwd = await testdir({
+          ".changeset/config.json": JSON.stringify(config),
+          "package.json": JSON.stringify(rootManifest),
+        });
+        const packages = withPackages(cwd, ["pkg-a", "pkg-b"]);
+
+        const result = validateConfig(config, packages);
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors![0]).toContain(
+          'fixed: Invalid group: The package or glob "pkg-a" is defined in multiple groups',
+        );
+      });
+    });
+
+    describe("noDuplicateLinkedPackages", () => {
+      it("should report a duplicated package once when more groups follow it", async () => {
+        const config = { linked: [["pkg-a"], ["pkg-a"], ["pkg-b"]] };
+
+        const cwd = await testdir({
+          ".changeset/config.json": JSON.stringify(config),
+          "package.json": JSON.stringify(rootManifest),
+        });
+        const packages = withPackages(cwd, ["pkg-a", "pkg-b"]);
+
+        const result = validateConfig(config, packages);
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors![0]).toContain(
+          'linked: Invalid group: The package or glob "pkg-a" is defined in multiple groups',
+        );
+      });
+    });
+
     describe("alsoSkipDependentsOfSkipped", () => {
       it("should error when a not-skipped package depends on a skipped package", async () => {
         const pkgA = {

--- a/packages/config/src/rules.ts
+++ b/packages/config/src/rules.ts
@@ -49,14 +49,15 @@ const noDuplicateFixedPackages: Rule = ({ config, errors }) => {
       }
       foundNames.add(name);
     }
-    errors.push(
-      ...Array.from(
-        duplicatedNames,
-        (pkgOrGlob) =>
-          `fixed: Invalid group: The package or glob "${pkgOrGlob}" is defined in multiple groups of fixed packages. Packages can only be belong to a single group. ${picomatchNote}`,
-      ),
-    );
   }
+
+  errors.push(
+    ...Array.from(
+      duplicatedNames,
+      (pkgOrGlob) =>
+        `fixed: Invalid group: The package or glob "${pkgOrGlob}" is defined in multiple groups of fixed packages. Packages can only be belong to a single group. ${picomatchNote}`,
+    ),
+  );
 };
 
 const linkedGroupsExist: Rule = ({
@@ -89,14 +90,15 @@ const noDuplicateLinkedPackages: Rule = ({ config, errors }) => {
       }
       foundNames.add(name);
     }
-    errors.push(
-      ...Array.from(
-        duplicatedNames,
-        (pkgOrGlob) =>
-          `linked: Invalid group: The package or glob "${pkgOrGlob}" is defined in multiple groups of linked packages. Packages can only be belong to a single group. ${picomatchNote}`,
-      ),
-    );
   }
+
+  errors.push(
+    ...Array.from(
+      duplicatedNames,
+      (pkgOrGlob) =>
+        `linked: Invalid group: The package or glob "${pkgOrGlob}" is defined in multiple groups of linked packages. Packages can only be belong to a single group. ${picomatchNote}`,
+    ),
+  );
 };
 
 const noFixedAndLinkedPackages: Rule = ({ config, errors }) => {


### PR DESCRIPTION
A project with three or more `fixed` or `linked` groups gets the "defined in multiple groups" config error printed once for every group that follows the duplicate. With `fixed: [["pkg-a"], ["pkg-a"], ["pkg-b"]]` the `pkg-a` message is printed twice, and adding a fourth group prints it three times.

The cause is in `packages/config/src/rules.ts`. `noDuplicateFixedPackages` (line 39) and `noDuplicateLinkedPackages` (line 79) collect duplicates into a `duplicatedNames` set, but the `errors.push(...Array.from(duplicatedNames, ...))` call sits inside the loop over the groups, at line 52 and line 92. Every iteration re-emits a message for every name already in the set, so a name first seen twice while processing group 2 of 4 gets pushed by groups 2, 3 and 4. The two existing cases in `packages/config/src/parse.test.ts` use two groups, `fixed: [["pkg-a"], ["pkg-a"]]` and `linked: [["pkg-a"], ["pkg-a"]]`, where the duplicate is in the last group and no later iteration exists to repeat it, and the table harness compares expected substrings positionally without checking how many errors came back, so neither case could catch this.

The fix moves both pushes out of the loop. Each duplicated package now produces exactly one error regardless of how many groups follow it. The set of names collected, the message text, and the early return when the group list is empty are all unchanged.

Two regression tests are added to the `rules` block of `packages/config/src/parse.test.ts`, one for `fixed` and one for `linked`, each asserting exactly one error for `[["pkg-a"], ["pkg-a"], ["pkg-b"]]`. Against unmodified `rules.ts` both fail with `AssertionError: expected [ …(2) ] to have a length of 1 but got 2`. With the fix, `pnpm vitest run packages/config` reports `Test Files 2 passed (2)` and `Tests 65 passed (65)`.

Verified on macOS with Node 22.23.2 and pnpm 11.13.1. `pnpm test run --maxWorkers=3` reports `Test Files 41 passed (41)` and `Tests 916 passed | 2 skipped | 2 todo (920)` in 130.94s, with no failures. `pnpm types:check`, `pnpm lint` and `pnpm format` each exit 0, with `oxfmt --check` reporting "All matched files use the correct format" across 298 files.

Changeset included, patch bump for `@changesets/config`.
