### PR TITLE
test: use inline snapshots for publish plan tests

### DIFF
--- a/packages/cli/src/commands/publish-plan/__tests__/getPublishPlan.test.ts
+++ b/packages/cli/src/commands/publish-plan/__tests__/getPublishPlan.test.ts
@@ -61,22 +61,24 @@ describe("getPublishPlan", () => {
     const config = await readConfig(cwd);
     const result = await getPublishPlan(cwd, config.config!);
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-        {
-          kind: "tag-only",
-          name: "pkg-b",
-          version: "1.0.0",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+          {
+            "kind": "tag-only",
+            "name": "pkg-b",
+            "version": "1.0.0",
+          },
+        ],
+      ]
+    `);
   });
 
   it("skips ignored public packages", async () => {
@@ -144,33 +146,35 @@ describe("getPublishPlan", () => {
     const config = await readConfig(cwd);
     const result = await getPublishPlan(cwd, config.config!);
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-b",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-      [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-      [
-        {
-          kind: "tag-only",
-          name: "pkg-c",
-          version: "1.0.0",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-b",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+        ],
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+        ],
+        [
+          {
+            "kind": "tag-only",
+            "name": "pkg-c",
+            "version": "1.0.0",
+          },
+        ],
+      ]
+    `);
   });
 
   it("keeps cyclic dependencies in one chunk", async () => {
@@ -204,24 +208,26 @@ describe("getPublishPlan", () => {
     const config = await readConfig(cwd);
     const result = await getPublishPlan(cwd, config.config!);
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-        {
-          kind: "publish",
-          name: "pkg-b",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-b",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+        ],
+      ]
+    `);
   });
 
   it("uses latest tag when all published versions are prereleases for the current pre tag", async () => {
@@ -256,17 +262,19 @@ describe("getPublishPlan", () => {
     const config = await readConfig(cwd);
     const result = await getPublishPlan(cwd, config.config!);
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0-next.3",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0-next.3",
+          },
+        ],
+      ]
+    `);
   });
 
   it("includes a package when it is published but the local version is not", async () => {
@@ -295,16 +303,18 @@ describe("getPublishPlan", () => {
     const config = await readConfig(cwd);
     const result = await getPublishPlan(cwd, config.config!);
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.1.0",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.1.0",
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/packages/cli/src/commands/publish-plan/__tests__/index.test.ts
+++ b/packages/cli/src/commands/publish-plan/__tests__/index.test.ts
@@ -61,22 +61,24 @@ describe("publish-plan", () => {
 
     const result = await publishPlan({ cwd });
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-        {
-          kind: "tag-only",
-          name: "pkg-b",
-          version: "1.0.0",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+          {
+            "kind": "tag-only",
+            "name": "pkg-b",
+            "version": "1.0.0",
+          },
+        ],
+      ]
+    `);
   });
 
   it("returns empty arrays when there is nothing to publish or tag", async () => {
@@ -130,17 +132,19 @@ describe("publish-plan", () => {
     const output = "publish-plan.json";
     const result = await publishPlan({ cwd, output });
 
-    expect(result).toEqual([
+    expect(result).toMatchInlineSnapshot(`
       [
-        {
-          kind: "publish",
-          name: "pkg-a",
-          version: "1.0.0",
-          access: "restricted",
-          tag: "latest",
-        },
-      ],
-    ]);
+        [
+          {
+            "access": "restricted",
+            "kind": "publish",
+            "name": "pkg-a",
+            "tag": "latest",
+            "version": "1.0.0",
+          },
+        ],
+      ]
+    `);
     await expect(fs.readFile(path.join(cwd, output), "utf8")).resolves.toEqual(
       `${JSON.stringify({ version: 1, plan: result }, undefined, 2)}`,
     );


### PR DESCRIPTION
This is just to improve DX as it means any time these change, we can
just have vitest automatically update the value rather than us having to
figure it out.

Also what Adam mentioned here: https://github.com/changesets/changesets/pull/2183/changes#r3680782268
