### PR TITLE
feat(cli): add `changeset check` command to validate changesets before release

### DIFF
--- a/.changeset/quick-owls-check.md
+++ b/.changeset/quick-owls-check.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Added a `changeset check` command that validates every changeset in `.changeset/` is well-formed and only references packages that still exist in the workspace. Useful in CI to catch malformed or stale changesets (e.g. from AI-generated content or deleted packages) before they break `changeset version` during a release.

--- a/docs/checking-for-changesets.md
+++ b/docs/checking-for-changesets.md
@@ -12,3 +12,24 @@ alert users of missing changesets.
 
 If you want to cause a failure in CI on missing changesets (not recommended), you can run `changeset status --since=main`,
 which will exit with a status code of 1 if there are changed packages but no new changesets. It will not fail if there are no changed packages.
+
+## Validating changesets
+
+If changesets are created or edited by hand (or by an AI tool), they may end up
+malformed or reference packages that no longer exist in the workspace. This
+typically surfaces as an error during `changeset version` on the release branch.
+
+To catch these issues earlier, run:
+
+```
+changeset check
+```
+
+This validates that every changeset in `.changeset/`:
+
+- is well-formed (valid frontmatter with package names and version types), and
+- only references packages that still exist in the workspace.
+
+It exits with code `1` on the first invalid changeset, printing the offending
+file and the reason. Use it in CI on your main branch (or on pull requests)
+before `changeset version` runs to prevent broken releases.

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -10,6 +10,7 @@ The command line for changesets is the main way of interacting with it. There ar
 - version [--ignore, --snapshot]
 - publish [--otp=code, --tag]
 - status [--since=master --verbose --output=JSON_FILE.json]
+- check
 - pre [exit|enter {tag}]
 - git-tag
 
@@ -142,6 +143,16 @@ The status command provides information about the changesets that currently exis
 - `--since` - to only display information about changesets since a specific branch or git tag (such as `main`, or the git hash of latest). While this can be used to add a CI check for changesets, we recommend not doing this. We instead recommend using the [changeset bot](https://github.com/apps/changeset-bot) to detect pull requests missing changesets, as not all pull requests need one if you are on GitHub.
 
 > NOTE: `status` will fail if you are in the middle of running `version` or `publish`. If you want to get changeset status at the time of a version increase and publish, you need to run it immediately before running `version`.
+
+## check
+
+```
+changeset check
+```
+
+The check command validates that every changeset in `.changeset/` is well-formed (valid frontmatter with package names and version types) and only references packages that still exist in the workspace. It exits with status code `1` on the first invalid changeset, printing the offending file and the reason.
+
+This is useful in CI on your main branch (or on pull requests) to catch changesets that were created or edited by hand or by an AI tool and would otherwise break `changeset version` during a release. Unlike `status`, `check` does not require changesets to exist for changed packages — it only validates the changesets that are already present.
 
 ## pre
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { cli } from "./cli.ts";
 import { add } from "./commands/add/index.ts";
+import { check } from "./commands/check/index.ts";
 import { gitTag } from "./commands/git-tag/index.ts";
 import { init } from "./commands/init/index.ts";
 import { pack } from "./commands/pack/index.ts";
@@ -17,6 +18,7 @@ vi.mock("./commands/publish/index.ts");
 vi.mock("./commands/publish-plan/index.ts");
 vi.mock("./commands/pack/index.ts");
 vi.mock("./commands/status/index.ts");
+vi.mock("./commands/check/index.ts");
 vi.mock("./commands/git-tag/index.ts");
 vi.mock("./commands/pre/index.ts");
 
@@ -260,6 +262,16 @@ const tests: CommandTest[] = [
           verbose: true,
           output: "status.json",
         },
+      },
+    ],
+  },
+  {
+    command: "check",
+    fn: check,
+    cases: [
+      {
+        args: [],
+        options: {},
       },
     ],
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -172,6 +172,18 @@ cli
   });
 
 cli
+  .command(
+    "check",
+    "Validate that all changesets are well-formed and in sync with the workspace",
+  )
+  .example("  $ changeset check")
+  .action(async (options) => {
+    normalizeOptions(options);
+    const { check } = await import("./commands/check/index.ts");
+    await check(options);
+  });
+
+cli
   .command("git-tag", "Create git tags for the current version of all packages")
   .alias("tag")
   .action(async (options) => {

--- a/packages/cli/src/commands/check/__tests__/check.test.ts
+++ b/packages/cli/src/commands/check/__tests__/check.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gitdir, silenceLogsInBlock } from "@changesets/test-utils";
+import { writeChangeset } from "@changesets/write";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { check } from "../index.ts";
+
+describe("check", { tags: ["slow"] }, () => {
+  silenceLogsInBlock();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function setup(cwd: string) {
+    return {
+      writeChangesetFile: async (
+        name: string,
+        contents: string,
+      ): Promise<void> => {
+        await fs.writeFile(
+          path.join(cwd, ".changeset", `${name}.md`),
+          contents,
+        );
+      },
+    };
+  }
+
+  it("passes when all changesets are valid and reference existing packages", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    await writeChangeset(
+      {
+        summary: "This is a summary",
+        releases: [{ name: "pkg-a", type: "minor" }],
+      },
+      cwd,
+    );
+
+    await expect(check({ cwd })).resolves.toBeUndefined();
+  });
+
+  it("passes when there are no changesets", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    await expect(check({ cwd })).resolves.toBeUndefined();
+  });
+
+  it("passes for an empty changeset (created with --empty)", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    const { writeChangesetFile } = await setup(cwd);
+    await writeChangesetFile("empty", "---\n---\n");
+
+    await expect(check({ cwd })).resolves.toBeUndefined();
+  });
+
+  it("fails when a changeset references a package that does not exist in the workspace", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    await writeChangeset(
+      {
+        summary: "This is a summary",
+        releases: [{ name: "deleted-pkg", type: "minor" }],
+      },
+      cwd,
+    );
+
+    await expect(check({ cwd })).rejects.toThrow();
+  });
+
+  it("fails when a changeset has malformed frontmatter", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    const { writeChangesetFile } = await setup(cwd);
+    await writeChangesetFile(
+      "malformed",
+      "This is not a valid changeset - no frontmatter",
+    );
+
+    await expect(check({ cwd })).rejects.toThrow();
+  });
+
+  it("fails when a changeset has an invalid version type", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    const { writeChangesetFile } = await setup(cwd);
+    await writeChangesetFile(
+      "bad-version",
+      '---\n"pkg-a": not-a-version-type\n---\n\nSummary\n',
+    );
+
+    await expect(check({ cwd })).rejects.toThrow();
+  });
+
+  it("does not require changed packages to have changesets (unlike status)", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        private: true,
+        name: "root-pkg",
+        workspaces: ["packages/*"],
+      }),
+      "package-lock.json": "",
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+      "packages/pkg-a/a.js": 'export default "a"',
+      ".changeset/config.json": JSON.stringify({}),
+    });
+
+    // No changeset exists, but there's a package with a source file.
+    // `status` would fail here; `check` should pass (it only validates
+    // existing changesets, not whether changesets exist for changes).
+    await expect(check({ cwd })).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/check/index.ts
+++ b/packages/cli/src/commands/check/index.ts
@@ -1,0 +1,45 @@
+import { assembleReleasePlan } from "@changesets/assemble-release-plan";
+import c from "@changesets/color";
+import { ExitError } from "@changesets/errors";
+import { readPreState } from "@changesets/pre";
+import { readChangesets } from "@changesets/read";
+import { log } from "@clack/prompts";
+import { getPackages } from "@manypkg/get-packages";
+import { readConfig } from "../../utils/read-config.ts";
+import { ensureChangesetFolder } from "../shared.ts";
+
+export interface CheckOptions {
+  cwd?: string;
+}
+
+export async function check(options?: CheckOptions): Promise<void> {
+  const cwd = options?.cwd ?? process.cwd();
+
+  const packages = await getPackages(cwd);
+  await ensureChangesetFolder(packages.rootDir);
+  const config = await readConfig(packages);
+  const preState = await readPreState(packages.rootDir);
+
+  let changesets;
+  try {
+    changesets = await readChangesets(packages.rootDir);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      `Failed to parse changesets:\n${error.message}\n\nFix or remove the invalid file before running ${c.cyan("changeset version")}.`,
+    );
+    throw new ExitError(1, { cause: error });
+  }
+
+  try {
+    assembleReleasePlan(changesets, packages, config, preState);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      `Invalid changesets detected:\n${error.message}\n\nFix or remove the invalid file before running ${c.cyan("changeset version")}.`,
+    );
+    throw new ExitError(1, { cause: error });
+  }
+
+  log.info(`All ${changesets.length} changeset(s) are valid.`);
+}


### PR DESCRIPTION
## Summary

Adds a new `changeset check` command that validates every changeset in `.changeset/` is well-formed and only references packages that still exist in the workspace. Designed to run in CI on `main` (or on PRs) to catch malformed or stale changesets **before** they break `changeset version` during a release.

## Problem

When changesets are created or edited by hand (or by an AI tool), they can end up:

- **malformed** — missing/invalid frontmatter, bad YAML, invalid version types, etc.
- **stale** — referencing packages that were since deleted from the workspace

These errors currently surface during `changeset version` on the release branch, blocking the release. `changeset status` catches them too, but it also runs git (diffing against `baseBranch`/`--since`) and exits 1 when there are changed packages without changesets — which makes it unsuitable as a pure validation check on `main`.

## Solution

`changeset check` reuses the existing `readChangesets` + `assembleReleasePlan` pipeline:

- `readChangesets` parses each `.changeset/*.md` file → throws on malformed format (missing frontmatter, invalid YAML, bad version type, etc.)
- `assembleReleasePlan` validates that every referenced package exists in the workspace → throws `Found changeset X for package Y which is not in the workspace`

It reads only the working tree (no `--since`, no git diff), so it works in shallow CI clones and merge-commit checkouts without depending on git history.

```yaml
# .github/workflows/release.yml
- run: changeset check
- run: changeset version
```

## What it does NOT do

- Does **not** use git (unlike `status`, which calls `git diff` against `baseBranch`/`--since`)
- Does **not** fail when there are changed packages without changesets (that is `status`'s job, and intentionally not recommended for CI)
- Does **not** check only changesets added in the current PR — it validates **all** changesets present on disk in the current checkout
- Stops at the **first** invalid changeset (error message names the file + reason — good enough; a collect-all-errors mode can be added later if needed)

## Files

- `packages/cli/src/commands/check/index.ts` — the command (~45 lines, reuses `readChangesets` + `assembleReleasePlan`)
- `packages/cli/src/cli.ts` — registers the `check` command
- `packages/cli/src/commands/check/__tests__/check.test.ts` — 7 tests (valid, empty `--empty` changeset, no changesets, stale package ref, malformed frontmatter, invalid version type, no-fail-when-changed-packages-have-no-changeset)
- `packages/cli/src/cli.test.ts` — CLI wiring test
- `docs/command-line-options.md` + `docs/checking-for-changesets.md` — docs

## Test plan

- [x] `pnpm types:check`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test run packages/cli/src/cli.test.ts` (30 passed)
- [x] `pnpm test run packages/cli/src/commands/check` (7 passed)
- [x] Manual: `node packages/cli/bin.js check` on this repo → `All 2 changeset(s) are valid.`
- [x] Manual: malformed changeset → exits 1 with file + reason
- [x] Manual: stale package reference → exits 1 with `Found changeset X for package Y which is not in the workspace`