### PR TITLE
fix: resolve internal dep updates recursively

### DIFF
--- a/.changeset/fuzzy-pandas-resolve.md
+++ b/.changeset/fuzzy-pandas-resolve.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+Resolve transitive internal dependencies recursively to fix missing commit traces in release notes.

--- a/.changeset/moody-bats-smile.md
+++ b/.changeset/moody-bats-smile.md
@@ -2,4 +2,4 @@
 "@changesets/apply-release-plan": patch
 ---
 
-List in-range internal dependencies when `updateInternalDependents` is `"always"`.
+List in-range internal dependencies when `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents` is `"always"`.

--- a/.changeset/moody-bats-smile.md
+++ b/.changeset/moody-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+List in-range internal dependencies when `updateInternalDependents` is `"always"`.

--- a/packages/apply-release-plan/src/get-changelog-entry.test.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.test.ts
@@ -39,6 +39,10 @@ async function getDependencyChangesets(
   target: string,
   releases: ModCompWithPackage[],
   changesets: NewChangesetWithCommit[],
+  config: {
+    updateInternalDependents?: "always" | "out-of-range";
+    updateInternalDependencies?: "patch" | "minor";
+  } = {},
 ): Promise<NewChangesetWithCommit[]> {
   let recorded: NewChangesetWithCommit[] = [];
   const funcs: ChangelogFunctions = {
@@ -56,7 +60,9 @@ async function getDependencyChangesets(
     funcs,
     null,
     {
-      updateInternalDependencies: "patch",
+      updateInternalDependencies: config.updateInternalDependencies ?? "patch",
+      updateInternalDependents:
+        config.updateInternalDependents ?? "out-of-range",
       onlyUpdatePeerDependentsWhenOutOfRange: false,
     },
   );
@@ -195,6 +201,53 @@ describe("getChangelogEntry", () => {
     ).then((cs) => cs.map((cs) => cs.id));
 
     expect(changesetIds).toEqual(["changeset-d"]);
+  });
+
+  it("lists an in-range dependency when updateInternalDependents is always", async () => {
+    // a -> b. b is a patch bump within a's range, and a only bumps internal
+    // deps of at least "minor" type, so under "out-of-range" b is not listed.
+    // "always" mirrors assemble-release-plan, which bumps a for every internal
+    // dependency update, so b's commit should still surface.
+    const releases = [
+      makeRelease("a", { b: "^1.0.0" }, []),
+      makeRelease("b", {}, ["changeset-b"]),
+    ];
+    const changesets = [makeChangeset("changeset-b", "b")];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+      {
+        updateInternalDependents: "always",
+        updateInternalDependencies: "minor",
+      },
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual(["changeset-b"]);
+  });
+
+  it("does not list an in-range dependency when updateInternalDependents is out-of-range", async () => {
+    // a -> b. b is a patch bump within a's range, and a only bumps internal
+    // deps of at least "minor" type, so under the default "out-of-range"
+    // behavior b is not listed and its commit does not surface.
+    const releases = [
+      makeRelease("a", { b: "^1.0.0" }, []),
+      makeRelease("b", {}, ["changeset-b"]),
+    ];
+    const changesets = [makeChangeset("changeset-b", "b")];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+      {
+        updateInternalDependents: "out-of-range",
+        updateInternalDependencies: "minor",
+      },
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual([]);
   });
 
   it("handles dependency cycles without infinite recursion", async () => {

--- a/packages/apply-release-plan/src/get-changelog-entry.test.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.test.ts
@@ -1,5 +1,67 @@
+import type {
+  ChangelogFunctions,
+  ModCompWithPackage,
+  NewChangesetWithCommit,
+} from "@changesets/types";
 import { describe, expect, it } from "vitest";
-import { generateMarkdownForVersionType } from "./get-changelog-entry.ts";
+import {
+  generateMarkdownForVersionType,
+  getChangelogEntry,
+} from "./get-changelog-entry.ts";
+
+function makeChangeset(id: string, release: string): NewChangesetWithCommit {
+  return {
+    id,
+    summary: `change ${id}`,
+    releases: [{ name: release, type: "patch" }],
+    commit: `${id}-commit`,
+  };
+}
+
+function makeRelease(
+  name: string,
+  dependencies: Record<string, string>,
+  changesets: string[],
+): ModCompWithPackage {
+  return {
+    name,
+    type: "patch",
+    oldVersion: "1.0.0",
+    newVersion: "1.0.1",
+    changesets,
+    dir: `/repo/${name}`,
+    packageJson: { name, version: "1.0.0", dependencies },
+  };
+}
+
+// Returns the changesets a package's "Updated dependencies" line would render.
+async function getDependencyChangesets(
+  target: string,
+  releases: ModCompWithPackage[],
+  changesets: NewChangesetWithCommit[],
+): Promise<NewChangesetWithCommit[]> {
+  let recorded: NewChangesetWithCommit[] = [];
+  const funcs: ChangelogFunctions = {
+    getReleaseLine: async () => "",
+    getDependencyReleaseLine: async (cs) => {
+      recorded = cs;
+      return "";
+    },
+  };
+  await getChangelogEntry(
+    "/repo",
+    releases.find((r) => r.name === target)!,
+    releases,
+    changesets,
+    funcs,
+    null,
+    {
+      updateInternalDependencies: "patch",
+      onlyUpdatePeerDependentsWhenOutOfRange: false,
+    },
+  );
+  return recorded;
+}
 
 describe("generateMarkdownForVersionType", () => {
   it("returns undefined when there are empty lines", () => {
@@ -70,5 +132,84 @@ describe("generateMarkdownForVersionType", () => {
 
       mixed three"
     `);
+  });
+});
+
+describe("getChangelogEntry", () => {
+  it("traces a transitive dependency update back to the origin changeset", async () => {
+    // a -> b -> c, where only c carries a changeset. a's "Updated dependencies"
+    // line should still resolve to c's commit instead of an empty ref.
+    const releases = [
+      makeRelease("a", { b: "^1.0.0" }, []),
+      makeRelease("b", { c: "^1.0.0" }, []),
+      makeRelease("c", {}, ["changeset-c"]),
+    ];
+    const changesets = [makeChangeset("changeset-c", "c")];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual(["changeset-c"]);
+  });
+
+  it("does not over-resolve a dependency that has its own changesets", async () => {
+    // a -> b -> c, where b changed directly. a's update of b is attributed to
+    // b's changeset; the deeper c update is b's concern, not a's.
+    const releases = [
+      makeRelease("a", { b: "^1.0.0" }, []),
+      makeRelease("b", { c: "^1.0.0" }, ["changeset-b"]),
+      makeRelease("c", {}, ["changeset-c"]),
+    ];
+    const changesets = [
+      makeChangeset("changeset-b", "b"),
+      makeChangeset("changeset-c", "c"),
+    ];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual(["changeset-b"]);
+  });
+
+  it("deduplicates shared origin changesets across siblings", async () => {
+    // a depends on b and c, both released purely because of d. Only one commit
+    // ref should surface.
+    const releases = [
+      makeRelease("a", { b: "^1.0.0", c: "^1.0.0" }, []),
+      makeRelease("b", { d: "^1.0.0" }, []),
+      makeRelease("c", { d: "^1.0.0" }, []),
+      makeRelease("d", {}, ["changeset-d"]),
+    ];
+    const changesets = [makeChangeset("changeset-d", "d")];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual(["changeset-d"]);
+  });
+
+  it("handles dependency cycles without infinite recursion", async () => {
+    const releases = [
+      makeRelease("a", { b: "^1.0.0" }, []),
+      makeRelease("b", { a: "^1.0.0" }, []),
+    ];
+    const changesets: NewChangesetWithCommit[] = [];
+
+    const changesetIds = await getDependencyChangesets(
+      "a",
+      releases,
+      changesets,
+    ).then((cs) => cs.map((cs) => cs.id));
+
+    expect(changesetIds).toEqual([]);
   });
 });

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -1,5 +1,7 @@
 import type {
   ChangelogFunctions,
+  Config,
+  ExperimentalOptions,
   ModCompWithPackage,
   NewChangesetWithCommit,
 } from "@changesets/types";
@@ -12,10 +14,8 @@ type ChangelogLines = {
   patch: Array<Promise<string>>;
 };
 
-type DependencyUpdateConfig = {
-  updateInternalDependencies: "patch" | "minor";
-  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-};
+type DependencyUpdateConfig = Pick<Config, "updateInternalDependencies"> &
+  Required<ExperimentalOptions>;
 
 function getDependentReleases(
   cwd: string,
@@ -27,6 +27,13 @@ function getDependentReleases(
     const dependencyVersionRange = release.packageJson.dependencies?.[rel.name];
     const peerDependencyVersionRange =
       release.packageJson.peerDependencies?.[rel.name];
+
+    if (
+      dependencyVersionRange &&
+      config.updateInternalDependents === "always"
+    ) {
+      return true;
+    }
 
     const versionRange = dependencyVersionRange || peerDependencyVersionRange;
     const usesWorkspaceRange = versionRange?.startsWith("workspace:");
@@ -88,9 +95,11 @@ export async function getChangelogEntry(
   changelogOpts: null | Record<string, unknown>,
   {
     updateInternalDependencies,
+    updateInternalDependents,
     onlyUpdatePeerDependentsWhenOutOfRange,
   }: {
     updateInternalDependencies: "patch" | "minor";
+    updateInternalDependents: "always" | "out-of-range";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   },
 ) {
@@ -118,6 +127,7 @@ export async function getChangelogEntry(
   });
   const dependencyUpdateConfig: DependencyUpdateConfig = {
     updateInternalDependencies,
+    updateInternalDependents,
     onlyUpdatePeerDependentsWhenOutOfRange,
   };
 

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -12,6 +12,72 @@ type ChangelogLines = {
   patch: Array<Promise<string>>;
 };
 
+type DependencyUpdateConfig = {
+  updateInternalDependencies: "patch" | "minor";
+  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+};
+
+function getDependentReleases(
+  cwd: string,
+  release: ModCompWithPackage,
+  releases: ModCompWithPackage[],
+  config: DependencyUpdateConfig,
+): ModCompWithPackage[] {
+  return releases.filter((rel) => {
+    const dependencyVersionRange = release.packageJson.dependencies?.[rel.name];
+    const peerDependencyVersionRange =
+      release.packageJson.peerDependencies?.[rel.name];
+
+    const versionRange = dependencyVersionRange || peerDependencyVersionRange;
+    const usesWorkspaceRange = versionRange?.startsWith("workspace:");
+    return (
+      versionRange &&
+      (usesWorkspaceRange || validRange(versionRange) != null) &&
+      shouldUpdateDependencyBasedOnConfig(
+        cwd,
+        rel,
+        {
+          depVersionRange: versionRange,
+          depType: dependencyVersionRange ? "dependencies" : "peerDependencies",
+        },
+        {
+          minReleaseType: config.updateInternalDependencies,
+          onlyUpdatePeerDependentsWhenOutOfRange:
+            config.onlyUpdatePeerDependentsWhenOutOfRange,
+        },
+      )
+    );
+  });
+}
+
+function collectOriginChangesets(
+  cwd: string,
+  release: ModCompWithPackage,
+  releases: ModCompWithPackage[],
+  config: DependencyUpdateConfig,
+  visited: Set<string>,
+): string[] {
+  if (visited.has(release.name)) return [];
+  visited.add(release.name);
+
+  if (release.changesets.length > 0) {
+    return [...release.changesets];
+  }
+
+  const origin: string[] = [];
+  for (const dependency of getDependentReleases(
+    cwd,
+    release,
+    releases,
+    config,
+  )) {
+    origin.push(
+      ...collectOriginChangesets(cwd, dependency, releases, config, visited),
+    );
+  }
+  return origin;
+}
+
 // release is the package and version we are releasing
 export async function getChangelogEntry(
   cwd: string,
@@ -50,37 +116,32 @@ export async function getChangelogEntry(
       );
     }
   });
-  const dependentReleases = releases.filter((rel) => {
-    const dependencyVersionRange = release.packageJson.dependencies?.[rel.name];
-    const peerDependencyVersionRange =
-      release.packageJson.peerDependencies?.[rel.name];
+  const dependencyUpdateConfig: DependencyUpdateConfig = {
+    updateInternalDependencies,
+    onlyUpdatePeerDependentsWhenOutOfRange,
+  };
 
-    const versionRange = dependencyVersionRange || peerDependencyVersionRange;
-    const usesWorkspaceRange = versionRange?.startsWith("workspace:");
-    return (
-      versionRange &&
-      (usesWorkspaceRange || validRange(versionRange) != null) &&
-      shouldUpdateDependencyBasedOnConfig(
-        cwd,
-        rel,
-        {
-          depVersionRange: versionRange,
-          depType: dependencyVersionRange ? "dependencies" : "peerDependencies",
-        },
-        {
-          minReleaseType: updateInternalDependencies,
-          onlyUpdatePeerDependentsWhenOutOfRange,
-        },
-      )
-    );
-  });
+  const dependentReleases = getDependentReleases(
+    cwd,
+    release,
+    releases,
+    dependencyUpdateConfig,
+  );
 
   const relevantChangesetIds: Set<string> = new Set();
 
   dependentReleases.forEach((rel) => {
-    rel.changesets.forEach((cs) => {
-      relevantChangesetIds.add(cs);
-    });
+    for (const id of collectOriginChangesets(
+      cwd,
+      rel,
+      releases,
+      dependencyUpdateConfig,
+      new Set(),
+    )) {
+      if (changesets.some((cs) => cs.id === id)) {
+        relevantChangesetIds.add(id);
+      }
+    }
   });
 
   const relevantChangesets = changesets.filter((cs) =>

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -304,6 +304,9 @@ async function getNewChangelogEntry(
         changelogOpts,
         {
           updateInternalDependencies: config.updateInternalDependencies,
+          updateInternalDependents:
+            config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+              .updateInternalDependents,
           onlyUpdatePeerDependentsWhenOutOfRange:
             config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange,

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -2456,6 +2456,8 @@ describe("updateInternalDependents: always", () => {
       ### Patch Changes
 
       - g1th4sh: This is some fix
+      - Updated dependencies [g1th4sh]
+        - pkg-a@1.1.0
       "
     `);
   });


### PR DESCRIPTION
#### Description

This PR implements recursive internal dependency resolution in the `apply-release-plan` package to be able to list commit references in case the chain looks like e.g. `a -> b -> c`.

I added some tests with small functions to generate the dependency graph.

- Closes #918