### PR TITLE
Insert new version below CHANGELOG intro

### DIFF
--- a/.changeset/real-comics-punch.md
+++ b/.changeset/real-comics-punch.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": minor
+---
+
+New version information will now be added to `CHANGELOG.md` above the first version header (if any) allowing intro content in `CHANGELOG.md` to be maintained at the top.

--- a/.changeset/real-comics-punch.md
+++ b/.changeset/real-comics-punch.md
@@ -1,5 +1,5 @@
 ---
-"@changesets/apply-release-plan": minor
+"@changesets/apply-release-plan": patch
 ---
 
 New version information will now be added to `CHANGELOG.md` above the first version header (if any) allowing intro content in `CHANGELOG.md` to be maintained at the top.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -2154,6 +2154,57 @@ describe("apply release plan", () => {
       `);
     });
 
+    it("should update a changelog and maintain non-version CHANGELOG intro for one package", async () => {
+      const releasePlan = new FakeReleasePlan();
+      const { changedFiles } = await testSetup(
+        {
+          "package.json": JSON.stringify({
+            private: true,
+            workspaces: ["packages/*"],
+          }),
+          "package-lock.json": "",
+          "packages/pkg-a/package.json": JSON.stringify({
+            name: "pkg-a",
+            version: "1.0.0",
+          }),
+          "packages/pkg-a/CHANGELOG.md":
+            "# Changelog for pkg-a\n\n## Overview\n\nThis file contains a history\nof changes made to pkg-a. We\nhope you enjoy them.\n\n## 1.0.0\n\n- Fixed some bug",
+        },
+        releasePlan.getReleasePlan(),
+        {
+          ...releasePlan.config,
+          changelog: [changesetsCliChangelogPath, null],
+        },
+      );
+
+      const readmePath = changedFiles.find((a) =>
+        a.endsWith(`pkg-a${path.sep}CHANGELOG.md`),
+      );
+
+      if (!readmePath) throw new Error(`could not find an updated changelog`);
+      const readme = await fs.readFile(readmePath, "utf-8");
+
+      expect(readme.trim()).toMatchInlineSnapshot(`
+        "# Changelog for pkg-a
+
+        ## Overview
+
+        This file contains a history
+        of changes made to pkg-a. We
+        hope you enjoy them.
+
+        ## 1.1.0
+
+        ### Minor Changes
+
+        - Hey, let's have fun with testing!
+
+        ## 1.0.0
+
+        - Fixed some bug"
+      `);
+    });
+
     it("should insert new entry before existing version heading when no package title is present", async () => {
       const releasePlan = new FakeReleasePlan();
       const { changedFiles } = await testSetup(
@@ -2190,6 +2241,7 @@ describe("apply release plan", () => {
         ### Minor Changes
 
         - Hey, let's have fun with testing!
+
         ## 1.0.0
 
         ### Minor Changes

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -358,8 +358,8 @@ async function updateChangelog(
 
   let newChangelog: string;
   if (firstVersionHeaderIndex >= 0) {
-    const prefix = fileData.substring(0, firstVersionHeaderIndex);
-    const suffix = fileData.substring(firstVersionHeaderIndex);
+    const prefix = fileData.slice(0, firstVersionHeaderIndex);
+    const suffix = fileData.slice(firstVersionHeaderIndex);
     newChangelog = prefix + templateString.trimStart() + "\n" + suffix;
   } else {
     const index = fileData.indexOf("\n");

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -354,11 +354,13 @@ async function updateChangelog(
   // Require just 2 version numbers here, assuming `## 1.1` is a valid version heading.
   // Our version headings start with ##, we are more permissive here though.
   // Note: we also need to handle prerelease versions here but that's already covered by the regex.
-  const isVersionHeading = /^#{1,6}\s+\d+\.\d+/.test(fileData);
+  const firstVersionHeaderIndex = fileData.search(/^#{1,6}\s+\d+\.\d+/m);
 
   let newChangelog: string;
-  if (isVersionHeading) {
-    newChangelog = templateString.trimStart() + fileData;
+  if (firstVersionHeaderIndex >= 0) {
+    const prefix = fileData.substring(0, firstVersionHeaderIndex);
+    const suffix = fileData.substring(firstVersionHeaderIndex);
+    newChangelog = prefix + templateString.trimStart() + "\n" + suffix;
   } else {
     const index = fileData.indexOf("\n");
     newChangelog =


### PR DESCRIPTION
Currently when you version, content is added directly below the file header (or at the very top of the file if the first line is a version header). This change instead adds the content directly above the first version header if one exists (otherwise previous position is maintained) allowing the CHANGELOG.md file to contain introductory content.