### PR TITLE
Preserve bounds when updating dependency ranges

### DIFF
--- a/.changeset/calm-ranges-stay.md
+++ b/.changeset/calm-ranges-stay.md
@@ -1,0 +1,6 @@
+---
+"@changesets/apply-release-plan": patch
+"@changesets/cli": patch
+---
+
+Keep upper bounds when updating internal dependency ranges such as `>=1.0.0 <2.0.0`.

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -403,6 +403,120 @@ describe("apply release plan", () => {
       });
     });
 
+    test.each([
+      [">=1.0.0 <2.0.0", "1.0.0", "2.0.0", "major", ">=2.0.0 <3.0.0"],
+      // Preserve the original comparator order to minimize the manifest diff.
+      ["<2.0.0 >=1.0.0", "1.0.0", "2.0.0", "major", "<3.0.0 >=2.0.0"],
+      // The refreshed lower bound has to include the new version, so `>` becomes `>=`.
+      [">1.0.0 <2.0.0", "1.0.0", "2.0.0", "major", ">=2.0.0 <3.0.0"],
+      // There is no finite `<=` equivalent for a complete major range, so it becomes `<`.
+      [">=1.0.0 <=1.9.9", "1.0.0", "2.0.0", "major", ">=2.0.0 <3.0.0"],
+      [">=1.0.0 <3.0.0", "1.0.0", "2.0.0", "major", ">=2.0.0 <3.0.0"],
+      [">=1.2.0 <1.3.0", "1.2.0", "1.3.0", "minor", ">=1.3.0 <1.4.0"],
+      [">=1.2.3 <1.2.4", "1.2.3", "1.2.4", "patch", ">=1.2.4 <1.2.5"],
+    ] as const)(
+      "should update the bounded dependency range %s",
+      async (versionRange, oldVersion, newVersion, type, expected) => {
+        const releasePlan = new FakeReleasePlan(
+          [
+            {
+              id: "some-id",
+              releases: [{ name: "pkg-b", type }],
+              summary: "a very useful summary",
+            },
+          ],
+          [
+            {
+              changesets: ["some-id"],
+              name: "pkg-b",
+              newVersion,
+              oldVersion,
+              type,
+            },
+          ],
+        );
+        const { changedFiles } = await testSetup(
+          {
+            "package.json": JSON.stringify({
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "package-lock.json": "",
+            "packages/pkg-a/package.json": JSON.stringify({
+              name: "pkg-a",
+              version: "1.0.0",
+              dependencies: {
+                "pkg-b": versionRange,
+              },
+            }),
+            "packages/pkg-b/package.json": JSON.stringify({
+              name: "pkg-b",
+              version: oldVersion,
+            }),
+          },
+          releasePlan.getReleasePlan(),
+          releasePlan.config,
+        );
+        const pkgPath = changedFiles.find((file) =>
+          file.endsWith(`pkg-a${path.sep}package.json`),
+        );
+
+        if (!pkgPath) throw new Error(`could not find an updated package json`);
+        const pkgJSON = await readJson(pkgPath);
+
+        expect(pkgJSON).toMatchObject({
+          dependencies: { "pkg-b": expected },
+        });
+      },
+    );
+
+    it("should leave dependency ranges unchanged for none releases", async () => {
+      const releasePlan = new FakeReleasePlan(
+        [],
+        [
+          {
+            changesets: [],
+            name: "pkg-b",
+            newVersion: "1.0.0",
+            oldVersion: "1.0.0",
+            type: "none",
+          },
+        ],
+      );
+      const { changedFiles } = await testSetup(
+        {
+          "package.json": JSON.stringify({
+            private: true,
+            workspaces: ["packages/*"],
+          }),
+          "package-lock.json": "",
+          "packages/pkg-a/package.json": JSON.stringify({
+            name: "pkg-a",
+            version: "1.0.0",
+            dependencies: {
+              "pkg-b": ">=2.0.0 <3.0.0",
+            },
+          }),
+          "packages/pkg-b/package.json": JSON.stringify({
+            name: "pkg-b",
+            version: "1.0.0",
+          }),
+        },
+        releasePlan.getReleasePlan(),
+        releasePlan.config,
+      );
+      const pkgPath = changedFiles.find((file) =>
+        file.endsWith(`pkg-a${path.sep}package.json`),
+      );
+
+      if (!pkgPath) throw new Error(`could not find an updated package json`);
+      const pkgJSON = await readJson(pkgPath);
+
+      expect(pkgJSON).toMatchObject({
+        dependencies: { "pkg-b": ">=2.0.0 <3.0.0" },
+      });
+    });
+
     it("should not update workspace version aliases", async () => {
       const releasePlan = new FakeReleasePlan(
         [

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -1,6 +1,8 @@
 import type { ComprehensiveRelease, PackageJSON } from "@changesets/types";
 import Range from "semver/classes/range.js";
+import semverInc from "semver/functions/inc.js";
 import semverPrerelease from "semver/functions/prerelease.js";
+import semverSatisfies from "semver/functions/satisfies.js";
 import validRange from "semver/ranges/valid.js";
 import type { EditJsonOperation } from "./edit-json.ts";
 import { shouldUpdateDependencyBasedOnConfig } from "./utils.ts";
@@ -39,11 +41,11 @@ export function getDependencyVersionEdits(
     const deps = packageJson[depType];
     if (deps) {
       for (const release of versionsToUpdate) {
-        if (release.newVersion == null) {
+        const { name, newVersion, type } = release;
+        if (newVersion == null || type === "none") {
           continue;
         }
 
-        const { name, newVersion } = release;
         let depCurrentVersion = deps[name];
         if (
           !depCurrentVersion ||
@@ -101,7 +103,7 @@ export function getDependencyVersionEdits(
         ) {
           let newNewRange = snapshot
             ? newVersion
-            : `${getVersionRangeType(depCurrentVersion)}${newVersion}`;
+            : getNewDependencyRange(depCurrentVersion, newVersion, type);
           if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
           pkgJsonEdits.push({ keys: [depType, name], value: newNewRange });
         }
@@ -110,6 +112,43 @@ export function getDependencyVersionEdits(
   }
 
   return pkgJsonEdits;
+}
+
+function getNewDependencyRange(
+  versionRange: string,
+  newVersion: string,
+  releaseType: "major" | "minor" | "patch",
+) {
+  const comparatorSets = new Range(versionRange).set;
+  // A union has multiple comparator sets and cannot be rewritten as one bounded range.
+  const comparators = comparatorSets.length === 1 ? comparatorSets[0] : [];
+
+  if (
+    // A bounded range has exactly one lower and one upper comparator.
+    comparators.length === 2 &&
+    versionRange.includes(">") &&
+    versionRange.includes("<")
+  ) {
+    const lowerBound = comparators.find(({ operator }) =>
+      operator.startsWith(">"),
+    );
+    const upperBound = comparators.find(({ operator }) =>
+      operator.startsWith("<"),
+    );
+
+    if (lowerBound && upperBound) {
+      let newUpperBound = upperBound.value;
+      if (!semverSatisfies(newVersion, newUpperBound)) {
+        newUpperBound = `<${semverInc(newVersion, releaseType)}`;
+      }
+
+      return comparators[0] === lowerBound
+        ? `>=${newVersion} ${newUpperBound}`
+        : `${newUpperBound} >=${newVersion}`;
+    }
+  }
+
+  return `${getVersionRangeType(versionRange)}${newVersion}`;
 }
 
 function getVersionRangeType(


### PR DESCRIPTION
fixes https://github.com/changesets/changesets/issues/2271

I agree the other ranges are more idiomatic, but we should try to respect the authored ranges as much as we can to avoid surprising results