### PR TITLE
Don't report that a changeset was committed when git commit fails

### DIFF
--- a/.changeset/missed-hooks-commit.md
+++ b/.changeset/missed-hooks-commit.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Don't report that a changeset was added and committed when `git commit` fails.

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -257,6 +257,50 @@ describe("Add command", () => {
     );
   });
 
+  it("should not report the changeset as committed when git commit fails", async () => {
+    const cwd = await gitdir({
+      "package.json": JSON.stringify({
+        name: "single-package",
+        version: "1.0.0",
+      }),
+      ".changeset/config.json": JSON.stringify({
+        ...defaultConfig,
+        commit: [
+          path.resolve(
+            import.meta.dirname,
+            "..",
+            "..",
+            "..",
+            "commit",
+            "index.ts",
+          ),
+          null,
+        ],
+      }),
+    });
+
+    const loggerErrorSpy = vi.spyOn(clack.log, "error");
+    const loggerSuccessSpy = vi.spyOn(clack.log, "success");
+    const commitSpy = vi.spyOn(git, "commit").mockResolvedValue(false);
+
+    await addChangeset({ cwd, empty: true });
+
+    expect(commitSpy).toHaveBeenCalled();
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "Changesets ran into trouble committing your files",
+    );
+    const successOutput = stripVTControlCharacters(
+      loggerSuccessSpy.mock.calls[0][0],
+    );
+    expect(successOutput).toContain(
+      "Empty Changeset added - you can now commit it!",
+    );
+    expect(successOutput).not.toContain("added and committed");
+
+    const changesets = await getChangesets(cwd);
+    expect(changesets).toHaveLength(1);
+  });
+
   it("should create empty changeset when empty flag is passed in", async () => {
     const cwd = await testdir({
       "package.json": JSON.stringify({

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -119,15 +119,24 @@ ${(error as Error).toString()}
       path.resolve(changesetBase, `${changesetID}.md`),
       packages.rootDir,
     );
-    await git.commit(
+    const commit = await git.commit(
       await getAddMessage(newChangeset, commitOpts),
       packages.rootDir,
     );
-    finalLogMessageLines.push(
-      c.green(
-        `${options?.empty ? "Empty " : ""}Changeset added and committed!`,
-      ),
-    );
+    if (!commit) {
+      log.error("Changesets ran into trouble committing your files");
+      finalLogMessageLines.push(
+        c.green(
+          `${options?.empty ? "Empty " : ""}Changeset added - you can now commit it!`,
+        ),
+      );
+    } else {
+      finalLogMessageLines.push(
+        c.green(
+          `${options?.empty ? "Empty " : ""}Changeset added and committed!`,
+        ),
+      );
+    }
   } else {
     finalLogMessageLines.push(
       c.green(


### PR DESCRIPTION
## Summary

With `commit` enabled, `changeset add` no longer prints a green "Changeset added and committed" when `git commit` fails (for example a pre-commit hook that spell-checks the new changeset file). The command logs `Changesets ran into trouble committing your files` and falls back to "Changeset added - you can now commit it!". The changeset file is still written.

`@changesets/git` already returns `false` when `git commit` exits non-zero. `changeset version` already checks that boolean and logs the same error. The issue description is still accurate on current `main`; only the line number moved.

Fixes #1326.

## Decision

Check `git.commit`'s boolean and log the same error `changeset version` already uses. Do not throw; `changeset add` still exits 0, matching `version`. Alternative: throw `ExitError` so the CLI exits 1 when the commit fails. Can switch to a non-zero exit (and to do the same in `version`) if both commands should fail the process.

## Test plan

- [x] `changeset add` with `commit` enabled still creates a commit on the success path (existing "should commit when the commit flag is passed in" case)
- [x] When `git commit` fails, the CLI logs the trouble-committing error, does not say "added and committed", and still writes the changeset file
- [ ] Optional: with `commit: true` and a pre-commit hook that exits 1, run `changeset add --empty` and confirm there is no green "committed" line and HEAD does not move
